### PR TITLE
Expanded agent test suite to 38 total tests

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -2,57 +2,90 @@ package agent
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
 )
 
-// mockProvider is a test LLM provider that returns canned responses.
-type mockProvider struct {
-	response string
+// ---------------------------------------------------------------------------
+// Mock LLM provider
+// ---------------------------------------------------------------------------
+
+type MockProvider struct {
+	chatResponse string
 }
 
-func (m *mockProvider) Chat(_ context.Context, msgs []core.Message, _ ...core.ChatOption) (*core.Response, error) {
-	return &core.Response{Content: m.response, Model: "mock"}, nil
+func (m *MockProvider) Chat(_ context.Context, msgs []core.Message, _ ...core.ChatOption) (*core.Response, error) {
+	content := m.chatResponse
+	if content == "" {
+		content = "CHAT"
+	}
+	return &core.Response{
+		Content:          content,
+		Model:            "mock-model",
+		PromptTokens:     10,
+		CompletionTokens: 5,
+	}, nil
 }
 
-func (m *mockProvider) Stream(_ context.Context, msgs []core.Message, _ ...core.ChatOption) (<-chan core.StreamChunk, error) {
+func (m *MockProvider) Stream(_ context.Context, msgs []core.Message, _ ...core.ChatOption) (<-chan core.StreamChunk, error) {
 	ch := make(chan core.StreamChunk, 1)
-	ch <- core.StreamChunk{Content: m.response, Done: true}
+	content := m.chatResponse
+	if content == "" {
+		content = "mock stream chunk"
+	}
+	ch <- core.StreamChunk{Content: content, Done: true}
 	close(ch)
 	return ch, nil
 }
 
-func (m *mockProvider) Name() string                           { return "mock" }
-func (m *mockProvider) ModelName() string                      { return "mock-model" }
-func (m *mockProvider) Available(_ context.Context) bool       { return true }
+func (m *MockProvider) Name() string                     { return "mock" }
+func (m *MockProvider) ModelName() string                { return "mock-model" }
+func (m *MockProvider) Available(_ context.Context) bool { return true }
 
-// mockBrain provides minimal brain interface for tests.
+// ---------------------------------------------------------------------------
+// Mock Brain
+// ---------------------------------------------------------------------------
+
 type mockBrain struct{}
 
-func (b *mockBrain) Memory() core.Memory             { return nil }
-func (b *mockBrain) GetPersonality() *core.Personality {
-	return &core.Personality{Name: "TestKrill", Greeting: "Hello!"}
-}
-func (b *mockBrain) GetSoul() *core.Soul {
-	return &core.Soul{SystemPrompt: "You are a test krill."}
-}
-func (b *mockBrain) SystemPrompt() string { return "You are a test krill." }
+func (b *mockBrain) Memory() core.Memory               { return nil }
+func (b *mockBrain) GetPersonality() *core.Personality  { return &core.Personality{Name: "TestKrill"} }
+func (b *mockBrain) GetSoul() *core.Soul                { return &core.Soul{SystemPrompt: "You are a test krill.", Identity: "test"} }
+func (b *mockBrain) SystemPrompt() string               { return "You are a test krill." }
+func (b *mockBrain) RandomFact() string                 { return "Krill are tiny." }
 func (b *mockBrain) EnrichMessages(msgs []core.Message) []core.Message {
-	return append([]core.Message{{Role: "system", Content: "You are a test krill."}}, msgs...)
+	sysMsg := core.Message{Role: "system", Content: "You are a test krill."}
+	if len(msgs) > 0 && msgs[0].Role == "system" {
+		enriched := make([]core.Message, len(msgs))
+		copy(enriched, msgs)
+		enriched[0] = sysMsg
+		return enriched
+	}
+	enriched := make([]core.Message, 0, len(msgs)+1)
+	enriched = append(enriched, sysMsg)
+	enriched = append(enriched, msgs...)
+	return enriched
 }
-func (b *mockBrain) RandomFact() string { return "Krill are cool." }
 
-// mockSkillReg provides minimal skill registry for tests.
-type mockSkillReg struct{}
+// ---------------------------------------------------------------------------
+// Mock Skill Registry
+// ---------------------------------------------------------------------------
 
-func (r *mockSkillReg) Register(_ core.Skill) error      { return nil }
-func (r *mockSkillReg) Unregister(_ string) error         { return nil }
-func (r *mockSkillReg) Get(_ string) (core.Skill, bool)   { return nil, false }
-func (r *mockSkillReg) List() []core.SkillInfo             { return nil }
+type mockSkillRegistry struct{}
 
-// mockMCPReg provides minimal MCP registry for tests.
+func (r *mockSkillRegistry) Register(_ core.Skill) error      { return nil }
+func (r *mockSkillRegistry) Unregister(_ string) error         { return nil }
+func (r *mockSkillRegistry) Get(_ string) (core.Skill, bool)   { return nil, false }
+func (r *mockSkillRegistry) List() []core.SkillInfo             { return nil }
+
+// ---------------------------------------------------------------------------
+// Mock MCP Registry
+// ---------------------------------------------------------------------------
+
 type mockMCPReg struct{}
 
 func (r *mockMCPReg) Register(_ string, _ core.MCPServer) error { return nil }
@@ -61,15 +94,23 @@ func (r *mockMCPReg) List() []core.MCPServerInfo                 { return nil }
 func (r *mockMCPReg) AllTools() []core.MCPTool                   { return nil }
 func (r *mockMCPReg) Close() error                               { return nil }
 
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
 func newTestAgent(response string) *KrillAgent {
 	return New(
-		config.AgentConfig{Name: "test-krill", MaxSubKrills: 2, PlanApproval: true},
-		&mockProvider{response: response},
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: true},
+		&MockProvider{chatResponse: response},
 		&mockBrain{},
-		&mockSkillReg{},
+		&mockSkillRegistry{},
 		&mockMCPReg{},
 	)
 }
+
+// ---------------------------------------------------------------------------
+// Agent tests
+// ---------------------------------------------------------------------------
 
 func TestNewAgent(t *testing.T) {
 	a := newTestAgent("hello")
@@ -79,34 +120,76 @@ func TestNewAgent(t *testing.T) {
 }
 
 func TestAgentChat(t *testing.T) {
-	// The mock LLM returns "CHAT" for classification, then "hello world" for response
-	a := newTestAgent("CHAT")
-	// Override to make it respond differently after classification
-	a.llm = &mockProvider{response: "Hello, I am Mini Krill!"}
+	// The mock always returns "Hello from the deep!" which doesn't contain TASK,
+	// so classifyIntent defaults to CHAT, and the chat response is also this string.
+	a := newTestAgent("Hello from the deep!")
 
-	resp, err := a.Chat(context.Background(), "hey there")
+	resp, err := a.Chat(context.Background(), "hi there")
 	if err != nil {
-		t.Fatalf("chat: %v", err)
+		t.Fatalf("Chat() error: %v", err)
 	}
 	if resp == "" {
-		t.Error("chat returned empty response")
+		t.Error("Chat() returned empty response")
+	}
+}
+
+func TestAgentChatMultipleMessages(t *testing.T) {
+	a := newTestAgent("response from krill")
+
+	for i := 0; i < 5; i++ {
+		resp, err := a.Chat(context.Background(), "message")
+		if err != nil {
+			t.Fatalf("Chat() iteration %d error: %v", i, err)
+		}
+		if resp == "" {
+			t.Errorf("Chat() iteration %d returned empty response", i)
+		}
 	}
 }
 
 func TestAgentPlanApproval(t *testing.T) {
-	// Mock that always returns "TASK" for classification and a plan for planning
-	a := newTestAgent("TASK")
+	// The mock LLM returns "CHAT" for classification (since "Just chatting"
+	// doesn't contain "TASK"), so this tests the chat path.
+	a := newTestAgent("Just chatting")
 
 	resp, err := a.Chat(context.Background(), "build me a website")
 	if err != nil {
-		t.Fatalf("chat: %v", err)
+		t.Fatalf("Chat() error: %v", err)
 	}
 	if resp == "" {
-		t.Error("expected plan response, got empty")
+		t.Error("Chat() returned empty response for task-like message")
 	}
-	// Agent should now have a pending plan
-	if a.pendingPlan == nil {
-		t.Log("Note: plan may not be pending if mock response didn't parse as plan")
+}
+
+func TestAgentPlanApprovalWithTaskClassification(t *testing.T) {
+	// Use a provider that returns "TASK" for classification, then a plan response
+	callCount := 0
+	provider := &sequentialMockProvider{
+		responses: []string{
+			"TASK",
+			"SUMMARY: Build a website\nSTEP 1: Set up\nSTEP 2: Code",
+		},
+		callCount: &callCount,
+	}
+
+	agent := New(
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: true},
+		provider,
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	resp, err := agent.Chat(context.Background(), "build me a website")
+	if err != nil {
+		t.Fatalf("Chat() error: %v", err)
+	}
+
+	if !strings.Contains(resp, "DIVE PLAN") {
+		t.Errorf("expected plan output containing 'DIVE PLAN', got: %s", resp)
+	}
+	if !strings.Contains(resp, "Approve this plan") {
+		t.Errorf("expected plan to ask for approval, got: %s", resp)
 	}
 }
 
@@ -135,23 +218,231 @@ func TestAgentApproveReject(t *testing.T) {
 	}
 }
 
-func TestSubKrillManager(t *testing.T) {
-	cfg := config.AgentConfig{MaxSubKrills: 2}
-	mgr := NewSubKrillManager(cfg, &mockProvider{response: "subtask done"})
+func TestAgentApproveAndExecute(t *testing.T) {
+	a := newTestAgent("executed result")
 
-	sk, err := mgr.Spawn(context.Background(), "test subtask")
+	// Manually set a pending plan
+	a.pendingPlan = &core.Plan{
+		Task:    "test task",
+		Summary: "test summary",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "step one", Status: "pending"},
+		},
+	}
+
+	// Approve it
+	resp, err := a.Chat(context.Background(), "yes")
 	if err != nil {
-		t.Fatalf("spawn: %v", err)
+		t.Fatalf("approve: %v", err)
 	}
-	if sk == nil {
-		t.Fatal("spawn returned nil")
+	if resp == "" {
+		t.Error("expected execution response after approval")
 	}
-	if sk.ID == "" {
-		t.Error("sub-krill has no ID")
-	}
-
-	list := mgr.List()
-	if len(list) == 0 {
-		t.Error("expected at least one active sub-krill")
+	if a.pendingPlan != nil {
+		t.Error("pending plan should be nil after approval and execution")
 	}
 }
+
+// sequentialMockProvider returns different responses for sequential calls
+type sequentialMockProvider struct {
+	responses []string
+	callCount *int
+}
+
+func (m *sequentialMockProvider) Chat(_ context.Context, _ []core.Message, _ ...core.ChatOption) (*core.Response, error) {
+	idx := *m.callCount
+	*m.callCount++
+	content := "fallback"
+	if idx < len(m.responses) {
+		content = m.responses[idx]
+	}
+	return &core.Response{Content: content, Model: "mock"}, nil
+}
+
+func (m *sequentialMockProvider) Stream(_ context.Context, _ []core.Message, _ ...core.ChatOption) (<-chan core.StreamChunk, error) {
+	ch := make(chan core.StreamChunk, 1)
+	ch <- core.StreamChunk{Content: "stream", Done: true}
+	close(ch)
+	return ch, nil
+}
+
+func (m *sequentialMockProvider) Name() string                     { return "sequential-mock" }
+func (m *sequentialMockProvider) ModelName() string                { return "sequential-mock" }
+func (m *sequentialMockProvider) Available(_ context.Context) bool { return true }
+
+// ---------------------------------------------------------------------------
+// SubKrillManager tests
+// ---------------------------------------------------------------------------
+
+func TestSubKrillManagerSpawnAndWait(t *testing.T) {
+	provider := &MockProvider{chatResponse: "sub-krill result"}
+	cfg := config.AgentConfig{
+		Name:         "test-krill",
+		MaxSubKrills: 3,
+	}
+
+	mgr := NewSubKrillManager(cfg, provider)
+
+	sub, err := mgr.Spawn(context.Background(), "analyze this data")
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+	if sub == nil {
+		t.Fatal("Spawn() returned nil")
+	}
+	if sub.ID == "" {
+		t.Error("Spawn() returned SubKrill with empty ID")
+	}
+	if sub.Task != "analyze this data" {
+		t.Errorf("SubKrill.Task = %q, want %q", sub.Task, "analyze this data")
+	}
+
+	// Wait for completion
+	result, err := mgr.Wait(sub.ID, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Wait() error: %v", err)
+	}
+	if result.Status != "done" {
+		t.Errorf("SubKrill.Status = %q, want %q", result.Status, "done")
+	}
+	if result.Output == "" {
+		t.Error("SubKrill.Output is empty after completion")
+	}
+}
+
+func TestSubKrillManagerConcurrencyLimit(t *testing.T) {
+	provider := &slowMockProvider{delay: 100 * time.Millisecond, response: "done"}
+	cfg := config.AgentConfig{
+		Name:         "test-krill",
+		MaxSubKrills: 2,
+	}
+
+	mgr := NewSubKrillManager(cfg, provider)
+	ctx := context.Background()
+
+	// Spawn up to the limit
+	sub1, err := mgr.Spawn(ctx, "task 1")
+	if err != nil {
+		t.Fatalf("Spawn(1) error: %v", err)
+	}
+	sub2, err := mgr.Spawn(ctx, "task 2")
+	if err != nil {
+		t.Fatalf("Spawn(2) error: %v", err)
+	}
+
+	// Third spawn should fail because we are at capacity
+	_, err = mgr.Spawn(ctx, "task 3")
+	if err == nil {
+		t.Error("Spawn(3) should fail when at capacity, got nil error")
+	}
+	if err != nil && !strings.Contains(err.Error(), "capacity") {
+		t.Errorf("error = %q, want to contain 'capacity'", err.Error())
+	}
+
+	// Wait for sub-krills to finish, then we should be able to spawn again
+	_, _ = mgr.Wait(sub1.ID, 5*time.Second)
+	_, _ = mgr.Wait(sub2.ID, 5*time.Second)
+
+	// Cleanup completed sub-krills
+	mgr.Cleanup()
+
+	sub3, err := mgr.Spawn(ctx, "task 3 retry")
+	if err != nil {
+		t.Fatalf("Spawn(3 retry) after cleanup error: %v", err)
+	}
+	if sub3 == nil {
+		t.Error("Spawn(3 retry) returned nil after cleanup")
+	}
+}
+
+func TestSubKrillManagerList(t *testing.T) {
+	provider := &MockProvider{chatResponse: "result"}
+	cfg := config.AgentConfig{
+		Name:         "test-krill",
+		MaxSubKrills: 5,
+	}
+
+	mgr := NewSubKrillManager(cfg, provider)
+	ctx := context.Background()
+
+	_, _ = mgr.Spawn(ctx, "task a")
+	_, _ = mgr.Spawn(ctx, "task b")
+
+	// Wait briefly for goroutines to register
+	time.Sleep(50 * time.Millisecond)
+
+	list := mgr.List()
+	if len(list) != 2 {
+		t.Errorf("List() returned %d sub-krills, want 2", len(list))
+	}
+}
+
+func TestSubKrillManagerWaitNotFound(t *testing.T) {
+	provider := &MockProvider{chatResponse: "result"}
+	cfg := config.AgentConfig{
+		Name:         "test-krill",
+		MaxSubKrills: 3,
+	}
+
+	mgr := NewSubKrillManager(cfg, provider)
+
+	_, err := mgr.Wait("nonexistent-id", 1*time.Second)
+	if err == nil {
+		t.Error("Wait(nonexistent) should return error")
+	}
+}
+
+func TestSubKrillManagerCleanup(t *testing.T) {
+	provider := &MockProvider{chatResponse: "done"}
+	cfg := config.AgentConfig{
+		Name:         "test-krill",
+		MaxSubKrills: 5,
+	}
+
+	mgr := NewSubKrillManager(cfg, provider)
+	ctx := context.Background()
+
+	sub, err := mgr.Spawn(ctx, "cleanup task")
+	if err != nil {
+		t.Fatalf("Spawn() error: %v", err)
+	}
+
+	// Wait for it to finish
+	_, err = mgr.Wait(sub.ID, 5*time.Second)
+	if err != nil {
+		t.Fatalf("Wait() error: %v", err)
+	}
+
+	// Before cleanup, list should still have it
+	if len(mgr.List()) != 1 {
+		t.Errorf("List() before cleanup = %d, want 1", len(mgr.List()))
+	}
+
+	mgr.Cleanup()
+
+	if len(mgr.List()) != 0 {
+		t.Errorf("List() after cleanup = %d, want 0", len(mgr.List()))
+	}
+}
+
+// slowMockProvider simulates a slow LLM for concurrency testing
+type slowMockProvider struct {
+	delay    time.Duration
+	response string
+}
+
+func (m *slowMockProvider) Chat(_ context.Context, _ []core.Message, _ ...core.ChatOption) (*core.Response, error) {
+	time.Sleep(m.delay)
+	return &core.Response{Content: m.response, Model: "slow-mock"}, nil
+}
+
+func (m *slowMockProvider) Stream(_ context.Context, _ []core.Message, _ ...core.ChatOption) (<-chan core.StreamChunk, error) {
+	ch := make(chan core.StreamChunk, 1)
+	ch <- core.StreamChunk{Content: m.response, Done: true}
+	close(ch)
+	return ch, nil
+}
+
+func (m *slowMockProvider) Name() string                     { return "slow-mock" }
+func (m *slowMockProvider) ModelName() string                { return "slow-mock" }
+func (m *slowMockProvider) Available(_ context.Context) bool { return true }


### PR DESCRIPTION
## Summary
- Expanded agent_test.go from 5 to 12 tests with sequential mock provider
- Added TASK classification flow, plan approval/execution, sub-krill lifecycle tests
- Total test count: 38 across 5 packages, all passing

## Test plan
- [x] `go test ./... -count=1` passes (38/38)
- [x] No external dependencies in tests