### PR TITLE
Added web search skill and Telegram reactions

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -188,9 +188,33 @@ func (a *KrillAgent) handleTask(ctx context.Context, input string) (string, erro
 }
 
 // handleChat generates a conversational response using the LLM with brain enrichment.
+// If the user's question looks like it needs current information, the krill
+// automatically searches the web first and includes results in context.
 func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
-	// Enrich messages with personality, soul, and memory context
+	// Check if the latest user message needs web search
+	lastMsg := ""
+	if len(a.history) > 0 {
+		lastMsg = a.history[len(a.history)-1].Content
+	}
+
 	enriched := a.brain.EnrichMessages(a.history)
+
+	// If the question likely needs current info, search the web first
+	if a.shouldSearch(lastMsg) {
+		if searchSkill, ok := a.skills.Get("search"); ok {
+			log.Info("auto-searching web for context", "query", lastMsg)
+			searchResults, err := searchSkill.Execute(ctx, lastMsg, nil) // raw results, no LLM summary
+			if err == nil && searchResults != "" {
+				// Inject search results as context before the user message
+				searchCtx := core.Message{
+					Role:    "system",
+					Content: "Here are recent web search results relevant to the user's question. Use them to provide an informed answer:\n\n" + searchResults,
+				}
+				// Insert before the last user message
+				enriched = append(enriched[:len(enriched)-1], searchCtx, enriched[len(enriched)-1])
+			}
+		}
+	}
 
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
@@ -206,6 +230,24 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 	)
 
 	return resp.Content, nil
+}
+
+// shouldSearch detects if a message likely needs current web information.
+// Krill have photoreceptors that detect light changes - this detects info needs.
+func (a *KrillAgent) shouldSearch(msg string) bool {
+	lower := strings.ToLower(msg)
+	searchTriggers := []string{
+		"search for", "look up", "find out", "what is the latest",
+		"current news", "recent", "today", "who is", "what happened",
+		"search the web", "google", "search online", "look online",
+		"what's new", "latest on", "news about", "find me",
+	}
+	for _, trigger := range searchTriggers {
+		if strings.Contains(lower, trigger) {
+			return true
+		}
+	}
+	return false
 }
 
 // classifyIntent sends the user input to the LLM for TASK vs CHAT classification.

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -134,7 +134,10 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 		return
 	}
 
-	// Regular message - send typing indicator, then process.
+	// Acknowledge with a reaction emoji so user knows we received it
+	t.react(chatID, msg.MessageID, "eyes")
+
+	// Send typing indicator while processing
 	typing := tgbotapi.NewChatAction(chatID, tgbotapi.ChatTyping)
 	if _, err := t.bot.Send(typing); err != nil {
 		log.Debug("failed to send typing action", "error", err)
@@ -155,6 +158,13 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 	}
 	if strings.TrimSpace(resp) == "" {
 		resp = "..."
+	}
+
+	// Swap reaction from eyes to checkmark on success, or warning on error
+	if err != nil {
+		t.react(chatID, msg.MessageID, "thumbs_down")
+	} else {
+		t.react(chatID, msg.MessageID, "thumbs_up")
 	}
 
 	t.sendLong(chatID, resp)
@@ -218,6 +228,40 @@ func (t *TelegramBot) isAllowed(userID int64) bool {
 		}
 	}
 	return false
+}
+
+// react sets an emoji reaction on a message via the Telegram Bot API.
+// Uses the setMessageReaction endpoint (Bot API 7.2+).
+func (t *TelegramBot) react(chatID int64, messageID int, emoji string) {
+	params := tgbotapi.Params{}
+	params.AddNonZero64("chat_id", chatID)
+	params.AddNonZero("message_id", messageID)
+	// Build the reaction JSON inline - the library doesn't have native support yet
+	reactionJSON := fmt.Sprintf(`[{"type":"emoji","emoji":"%s"}]`, emojiChar(emoji))
+	params["reaction"] = reactionJSON
+	if _, err := t.bot.MakeRequest("setMessageReaction", params); err != nil {
+		log.Debug("failed to set reaction", "emoji", emoji, "error", err)
+	}
+}
+
+// emojiChar maps short names to actual unicode emoji for reactions.
+func emojiChar(name string) string {
+	switch name {
+	case "eyes":
+		return "\U0001F440" // eyes
+	case "thumbs_up":
+		return "\U0001F44D" // thumbs up
+	case "thumbs_down":
+		return "\U0001F44E" // thumbs down
+	case "fire":
+		return "\U0001F525" // fire
+	case "check":
+		return "\u2705" // green check
+	case "thinking":
+		return "\U0001F914" // thinking face
+	default:
+		return "\U0001F44D" // default to thumbs up
+	}
 }
 
 // sendMessage sends a single text message to the given chat.

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -9,6 +9,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -23,6 +25,13 @@ import (
 
 	"gopkg.in/yaml.v3"
 )
+
+// Type aliases for stdlib HTTP - keeps the search skill self-contained
+// without polluting the package with direct http usage everywhere.
+type httpClient = http.Client
+
+var httpNewRequestWithContext = http.NewRequestWithContext
+var readAll = io.ReadAll
 
 // ---------------------------------------------------------------------------
 // Skill Registry - the swarm coordinator for all agent capabilities
@@ -262,6 +271,7 @@ func (r *SkillRegistryImpl) RegisterBuiltins() {
 		&recallSkill{},
 		&sysinfoSkill{},
 		&timeSkill{},
+		&webSearchSkill{},
 	}
 
 	for _, s := range builtins {
@@ -357,6 +367,234 @@ func (s *timeSkill) Execute(_ context.Context, _ string, _ core.LLMProvider) (st
 		now.Location().String(),
 		now.Unix(),
 	), nil
+}
+
+// --- web search skill ---
+// Searches the web via DuckDuckGo - no API key needed.
+// Like krill using echolocation in the dark ocean, this skill lets
+// the agent sense information beyond its training data.
+
+type webSearchSkill struct{}
+
+func (s *webSearchSkill) Name() string        { return "search" }
+func (s *webSearchSkill) Description() string { return "Search the web via DuckDuckGo (no API key needed)" }
+
+// Execute searches the web and returns formatted results. If an LLM is
+// provided, it summarizes the results. Otherwise returns raw search data.
+func (s *webSearchSkill) Execute(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		return "No search query provided. What should I look up?", nil
+	}
+
+	results, err := duckduckgoSearch(ctx, input)
+	if err != nil {
+		return fmt.Sprintf("Search failed: %v", err), nil
+	}
+
+	if len(results) == 0 {
+		return fmt.Sprintf("No results found for: %s", input), nil
+	}
+
+	// Format results
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Web search results for: %s\n\n", input))
+	for i, r := range results {
+		if i >= 5 {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, r.title))
+		if r.url != "" {
+			sb.WriteString(fmt.Sprintf("   %s\n", r.url))
+		}
+		if r.snippet != "" {
+			sb.WriteString(fmt.Sprintf("   %s\n", r.snippet))
+		}
+		sb.WriteString("\n")
+	}
+
+	raw := sb.String()
+
+	// If LLM is available, ask it to summarize the results
+	if llm != nil {
+		summary, err := llm.Chat(ctx, []core.Message{
+			{Role: "system", Content: "You are a helpful assistant. Summarize these web search results concisely. Include key facts and cite sources."},
+			{Role: "user", Content: raw},
+		})
+		if err == nil && summary.Content != "" {
+			return summary.Content, nil
+		}
+		// Fall back to raw results if summarization fails
+	}
+
+	return raw, nil
+}
+
+type searchResult struct {
+	title   string
+	url     string
+	snippet string
+}
+
+// duckduckgoSearch queries DuckDuckGo's HTML lite page and parses results.
+// No API key needed - this is the krill's sonar for the open web.
+func duckduckgoSearch(ctx context.Context, query string) ([]searchResult, error) {
+	searchURL := "https://html.duckduckgo.com/html/?q=" + urlEncode(query)
+
+	req, err := httpNewRequestWithContext(ctx, "GET", searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "MiniKrill/1.0 (search skill)")
+
+	client := &httpClient{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := readAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	return parseSearchResults(string(body)), nil
+}
+
+// parseSearchResults extracts titles, URLs, and snippets from DuckDuckGo HTML.
+func parseSearchResults(html string) []searchResult {
+	var results []searchResult
+
+	// DuckDuckGo HTML results have class="result__a" for links
+	// and class="result__snippet" for snippets
+	chunks := strings.Split(html, "class=\"result__a\"")
+	if len(chunks) <= 1 {
+		// Try alternate format
+		chunks = strings.Split(html, "class='result__a'")
+	}
+
+	for i := 1; i < len(chunks) && len(results) < 8; i++ {
+		chunk := chunks[i]
+		r := searchResult{}
+
+		// Extract URL from href
+		if hrefIdx := strings.Index(chunk, "href=\""); hrefIdx != -1 {
+			start := hrefIdx + 6
+			if endIdx := strings.Index(chunk[start:], "\""); endIdx != -1 {
+				rawURL := chunk[start : start+endIdx]
+				// DuckDuckGo wraps URLs in a redirect, extract the actual URL
+				if uddgIdx := strings.Index(rawURL, "uddg="); uddgIdx != -1 {
+					rawURL = rawURL[uddgIdx+5:]
+					if ampIdx := strings.Index(rawURL, "&"); ampIdx != -1 {
+						rawURL = rawURL[:ampIdx]
+					}
+					rawURL = urlDecode(rawURL)
+				}
+				r.url = rawURL
+			}
+		}
+
+		// Extract title (text between > and </a>)
+		if gtIdx := strings.Index(chunk, ">"); gtIdx != -1 {
+			after := chunk[gtIdx+1:]
+			if endIdx := strings.Index(after, "</a>"); endIdx != -1 {
+				r.title = stripHTML(after[:endIdx])
+			}
+		}
+
+		// Extract snippet
+		if snipIdx := strings.Index(chunk, "result__snippet"); snipIdx != -1 {
+			after := chunk[snipIdx:]
+			if gtIdx := strings.Index(after, ">"); gtIdx != -1 {
+				after = after[gtIdx+1:]
+				if endIdx := strings.Index(after, "</"); endIdx != -1 {
+					r.snippet = stripHTML(after[:endIdx])
+				}
+			}
+		}
+
+		if r.title != "" {
+			results = append(results, r)
+		}
+	}
+
+	return results
+}
+
+// stripHTML removes HTML tags from a string.
+func stripHTML(s string) string {
+	var out strings.Builder
+	inTag := false
+	for _, c := range s {
+		switch {
+		case c == '<':
+			inTag = true
+		case c == '>':
+			inTag = false
+		case !inTag:
+			out.WriteRune(c)
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// urlEncode does basic percent-encoding for a search query.
+func urlEncode(s string) string {
+	var buf strings.Builder
+	for _, c := range s {
+		switch {
+		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'):
+			buf.WriteRune(c)
+		case c == ' ':
+			buf.WriteByte('+')
+		case c == '-' || c == '_' || c == '.' || c == '~':
+			buf.WriteRune(c)
+		default:
+			buf.WriteString(fmt.Sprintf("%%%02X", c))
+		}
+	}
+	return buf.String()
+}
+
+// urlDecode does basic percent-decoding.
+func urlDecode(s string) string {
+	var buf strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' && i+2 < len(s) {
+			if val, err := parseHexByte(s[i+1], s[i+2]); err == nil {
+				buf.WriteByte(val)
+				i += 2
+				continue
+			}
+		} else if s[i] == '+' {
+			buf.WriteByte(' ')
+			continue
+		}
+		buf.WriteByte(s[i])
+	}
+	return buf.String()
+}
+
+func parseHexByte(h1, h2 byte) (byte, error) {
+	n1 := hexVal(h1)
+	n2 := hexVal(h2)
+	if n1 < 0 || n2 < 0 {
+		return 0, fmt.Errorf("invalid hex")
+	}
+	return byte(n1<<4 | n2), nil
+}
+
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	default:
+		return -1
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -140,15 +140,16 @@ func TestSkillRegistryBuiltins(t *testing.T) {
 	reg.RegisterBuiltins()
 
 	infos := reg.List()
-	if len(infos) != 3 {
-		t.Fatalf("RegisterBuiltins() resulted in %d skills, want 3", len(infos))
+	if len(infos) < 3 {
+		t.Fatalf("RegisterBuiltins() resulted in %d skills, want at least 3", len(infos))
 	}
 
-	// Verify the three expected built-in skills exist
+	// Verify the expected built-in skills exist
 	expected := map[string]bool{
 		"recall":  false,
 		"sysinfo": false,
 		"time":    false,
+		"search":  false,
 	}
 
 	for _, info := range infos {


### PR DESCRIPTION
## Summary
- Built-in DuckDuckGo web search skill (no API key needed)
- Agent auto-detects when questions need current web info and searches
- Telegram bot now reacts with eyes on receive, thumbs up/down on complete
- Search results fed to LLM as context for informed answers

## Test plan
- [x] go test ./... passes
- [x] minikrill skill list shows 'search' skill
- [x] Binary compiles clean