### PR TITLE
Refactor architecture for clarity and efficiency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,9 @@ vendor/
 
 # Mini Krill runtime data (never commit)
 .mini-krill/
-brain/
-memories/
-logs/
+/brain/
+/memories/
+/logs/
 *.pid
 
 # Secrets

--- a/cmd/minikrill/cmd_brain.go
+++ b/cmd/minikrill/cmd_brain.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/srvsngh99/mini-krill/internal/brain"
+)
+
+var brainCmd = &cobra.Command{
+	Use:   "brain",
+	Short: "Inspect and manage the krill's brain",
+}
+
+var brainStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show brain status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfigWithLog()
+		if err != nil {
+			return err
+		}
+		krillBrain, err := brain.New(cfg.Brain, nil)
+		if err != nil {
+			return fmt.Errorf("init brain: %w", err)
+		}
+		p := krillBrain.GetPersonality()
+		fmt.Println()
+		fmt.Printf(cDim+"  Personality: "+cReset+cBCyan+"%s\n"+cReset, p.Name)
+		fmt.Printf(cDim+"  Traits:      "+cReset+"%s\n", strings.Join(p.Traits, ", "))
+		fmt.Printf(cDim+"  Style:       "+cReset+"%s\n", p.Style)
+		fmt.Printf(cDim+"  Memories:    "+cReset+"%d\n", krillBrain.Memory().Count())
+		fmt.Printf(cDim+"  Data dir:    "+cReset+"%s\n", cfg.Brain.DataDir)
+		fmt.Println()
+		return nil
+	},
+}
+
+var brainRecallCmd = &cobra.Command{
+	Use:   "recall [key]",
+	Short: "Recall a memory by key",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfigWithLog()
+		if err != nil {
+			return err
+		}
+		krillBrain, err := brain.New(cfg.Brain, nil)
+		if err != nil {
+			return err
+		}
+		entry, err := krillBrain.Memory().Recall(context.Background(), args[0])
+		if err != nil {
+			return fmt.Errorf("memory not found: %s", args[0])
+		}
+		if entry == nil {
+			return fmt.Errorf("memory not found: %s", args[0])
+		}
+		fmt.Printf(cDim+"Key:     "+cReset+cCyan+"%s\n"+cReset, entry.Key)
+		fmt.Printf(cDim+"Value:   "+cReset+"%s\n", entry.Value)
+		fmt.Printf(cDim+"Tags:    "+cReset+"%s\n", strings.Join(entry.Tags, ", "))
+		fmt.Printf(cDim+"Created: "+cReset+"%s\n", entry.CreatedAt.Format("2006-01-02 15:04:05"))
+		return nil
+	},
+}
+
+var brainForgetCmd = &cobra.Command{
+	Use:   "forget [key]",
+	Short: "Forget a memory",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfigWithLog()
+		if err != nil {
+			return err
+		}
+		krillBrain, err := brain.New(cfg.Brain, nil)
+		if err != nil {
+			return err
+		}
+		if err := krillBrain.Memory().Forget(context.Background(), args[0]); err != nil {
+			return err
+		}
+		fmt.Printf(cDim+"Forgot: "+cReset+"%s\n", args[0])
+		return nil
+	},
+}
+
+var brainSearchCmd = &cobra.Command{
+	Use:   "search [query]",
+	Short: "Search memories",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := loadConfigWithLog()
+		if err != nil {
+			return err
+		}
+		krillBrain, err := brain.New(cfg.Brain, nil)
+		if err != nil {
+			return err
+		}
+		entries, err := krillBrain.Memory().Search(context.Background(), args[0], 10)
+		if err != nil {
+			return err
+		}
+		if len(entries) == 0 {
+			fmt.Println("No memories found.")
+			return nil
+		}
+		for _, e := range entries {
+			fmt.Printf("  "+cCyan+"[%s]"+cReset+" %s\n", e.Key, truncateStr(e.Value, 80))
+		}
+		return nil
+	},
+}

--- a/cmd/minikrill/cmd_ollama.go
+++ b/cmd/minikrill/cmd_ollama.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var ollamaCmd = &cobra.Command{
+	Use:   "ollama",
+	Short: "Manage local Ollama installation",
+}
+
+var ollamaInstallCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Install Ollama",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, _ := newOllamaManager()
+		if mgr.IsInstalled() {
+			fmt.Println(cGreen + "Ollama is already installed!" + cReset)
+			return nil
+		}
+		fmt.Println(cDim + "Installing Ollama..." + cReset)
+		if err := mgr.Install(context.Background()); err != nil {
+			return fmt.Errorf("install failed: %w\nInstall manually: https://ollama.com", err)
+		}
+		fmt.Println(cGreen + "Ollama installed!" + cReset)
+		return nil
+	},
+}
+
+var ollamaStartCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start Ollama server",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, _ := newOllamaManager()
+		fmt.Println(cDim + "Starting Ollama..." + cReset)
+		if err := mgr.Start(context.Background()); err != nil {
+			return err
+		}
+		fmt.Println(cGreen + "Ollama is running!" + cReset)
+		return nil
+	},
+}
+
+var ollamaStopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stop Ollama server",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, _ := newOllamaManager()
+		if err := mgr.Stop(); err != nil {
+			return err
+		}
+		fmt.Println(cCyan + "Ollama stopped." + cReset)
+		return nil
+	},
+}
+
+var ollamaPullCmd = &cobra.Command{
+	Use:   "pull [model]",
+	Short: "Pull an Ollama model",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, _ := newOllamaManager()
+		model := args[0]
+		fmt.Printf(cDim+"Pulling %s..."+cReset+"\n", model)
+		if err := mgr.Pull(context.Background(), model); err != nil {
+			return err
+		}
+		fmt.Printf(cGreen+"Model %s is ready!"+cReset+"\n", model)
+		return nil
+	},
+}
+
+var ollamaListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List local Ollama models",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, _ := newOllamaManager()
+		models, err := mgr.ListModels(context.Background())
+		if err != nil {
+			return fmt.Errorf("could not list models: %w", err)
+		}
+		if len(models) == 0 {
+			fmt.Println("No models found.")
+			fmt.Println(cDim + "Pull one with: " + cReset + "minikrill ollama pull llama3.2")
+			return nil
+		}
+		fmt.Println(cBold + "Local models:" + cReset)
+		for _, m := range models {
+			fmt.Printf("  "+cCyan+"%-25s"+cReset+cDim+" %.1f GB\n"+cReset, m.Name, float64(m.Size)/(1024*1024*1024))
+		}
+		return nil
+	},
+}
+
+var ollamaStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check Ollama status",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, _ := newOllamaManager()
+		status := mgr.Status(context.Background())
+		switch status {
+		case "running":
+			fmt.Println(cGreen + "Ollama: running" + cReset)
+		case "stopped":
+			fmt.Println(cYellow + "Ollama: stopped" + cReset)
+			fmt.Println(cDim + "Start with: " + cReset + "minikrill ollama start")
+		default:
+			fmt.Println(cRed + "Ollama: " + status + cReset)
+		}
+		return nil
+	},
+}

--- a/cmd/minikrill/cmd_personality.go
+++ b/cmd/minikrill/cmd_personality.go
@@ -63,7 +63,7 @@ var personalityCreateCmd = &cobra.Command{
 
 		displayName := ask(scanner, cCyan+"  Display name: "+cReset)
 		if displayName == "" {
-			displayName = strings.Title(name)
+			displayName = strings.ToUpper(name[:1]) + name[1:]
 		}
 
 		style := ask(scanner, cCyan+"  Style (e.g. 'formal and precise', 'casual and fun'): "+cReset)

--- a/cmd/minikrill/cmd_personality.go
+++ b/cmd/minikrill/cmd_personality.go
@@ -1,0 +1,196 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/srvsngh99/mini-krill/internal/brain"
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+	klog "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+var personalityCmd = &cobra.Command{
+	Use:   "personality",
+	Short: "Manage krill personalities",
+}
+
+var personalityListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available personalities",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, _ := config.Load()
+		active := "krill"
+		if cfg != nil && cfg.Agent.Personality != "" {
+			active = cfg.Agent.Personality
+		}
+		names := brain.ListPersonalities(config.DataDir())
+		fmt.Println(cBold + "Personalities:" + cReset)
+		for _, n := range names {
+			marker := "  "
+			if n == active {
+				marker = cBGreen + "> " + cReset
+			}
+			fmt.Printf("  %s"+cCyan+"%s"+cReset+"\n", marker, n)
+		}
+		fmt.Println()
+		fmt.Println(cDim + "Create new: " + cReset + "minikrill personality create")
+		fmt.Println(cDim + "Switch:     " + cReset + "minikrill personality switch <name>")
+		return nil
+	},
+}
+
+var personalityCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a new personality (interactive)",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		scanner := bufio.NewScanner(os.Stdin)
+
+		fmt.Println()
+		fmt.Println(cBCyan + "  Create a new Mini Krill personality" + cReset)
+		fmt.Println(cDim + "  Give your krill a unique identity." + cReset)
+		fmt.Println()
+
+		name := ask(scanner, cCyan+"  Name (lowercase, no spaces): "+cReset)
+		if name == "" {
+			return fmt.Errorf("name is required")
+		}
+		name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+
+		displayName := ask(scanner, cCyan+"  Display name: "+cReset)
+		if displayName == "" {
+			displayName = strings.Title(name)
+		}
+
+		style := ask(scanner, cCyan+"  Style (e.g. 'formal and precise', 'casual and fun'): "+cReset)
+		if style == "" {
+			style = "Friendly and helpful"
+		}
+
+		traitsStr := ask(scanner, cCyan+"  Traits (comma-separated, e.g. 'witty, bold, creative'): "+cReset)
+		var traits []string
+		for _, t := range strings.Split(traitsStr, ",") {
+			t = strings.TrimSpace(t)
+			if t != "" {
+				traits = append(traits, t)
+			}
+		}
+		if len(traits) == 0 {
+			traits = []string{"helpful", "friendly"}
+		}
+
+		greeting := ask(scanner, cCyan+"  Greeting message: "+cReset)
+		if greeting == "" {
+			greeting = fmt.Sprintf("Hey! %s here, ready to help.", displayName)
+		}
+
+		identity := ask(scanner, cCyan+"  Identity (one line about who this personality is): "+cReset)
+		if identity == "" {
+			identity = fmt.Sprintf("%s - a custom Mini Krill personality", displayName)
+		}
+
+		systemPrompt := ask(scanner, cCyan+"  Custom system prompt "+cDim+"(press Enter for default): "+cReset)
+
+		p := &core.Personality{
+			Name:       displayName,
+			Traits:     traits,
+			Style:      style,
+			Quirks:     []string{},
+			KrillFacts: core.KrillFacts,
+			Greeting:   greeting,
+		}
+
+		soul := &core.Soul{
+			SystemPrompt: systemPrompt,
+			Identity:     identity,
+			Values:       []string{"Be helpful", "Be honest", "Plan before acting"},
+			Boundaries:   []string{"Never execute without showing a plan"},
+		}
+
+		if err := brain.SavePersonality(name, config.DataDir(), soul, p); err != nil {
+			return err
+		}
+
+		fmt.Println()
+		fmt.Printf(cBGreen+"  Personality '%s' created!"+cReset+"\n", name)
+		fmt.Printf(cDim+"  Switch to it: "+cReset+"minikrill personality switch %s\n", name)
+		fmt.Println()
+		return nil
+	},
+}
+
+var personalitySwitchCmd = &cobra.Command{
+	Use:   "switch [name]",
+	Short: "Switch active personality",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := strings.ToLower(args[0])
+		names := brain.ListPersonalities(config.DataDir())
+		found := false
+		for _, n := range names {
+			if n == name {
+				found = true
+				break
+			}
+		}
+		if !found {
+			fmt.Printf(cRed+"Personality '%s' not found."+cReset+"\n", name)
+			fmt.Println(cDim + "Available:" + cReset)
+			for _, n := range names {
+				fmt.Printf("  %s\n", n)
+			}
+			return nil
+		}
+
+		cfg, err := config.Load()
+		if err != nil {
+			return err
+		}
+		cfg.Agent.Personality = name
+		if err := config.Save(cfg); err != nil {
+			return err
+		}
+
+		fmt.Printf(cBGreen+"Switched to personality: %s"+cReset+"\n", name)
+		fmt.Println(cDim + "Restart chat/dive for it to take effect." + cReset)
+		return nil
+	},
+}
+
+var personalityShowCmd = &cobra.Command{
+	Use:   "show [name]",
+	Short: "Show personality details",
+	Args:  cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, _ := config.Load()
+		name := "krill"
+		if cfg != nil && cfg.Agent.Personality != "" {
+			name = cfg.Agent.Personality
+		}
+		if len(args) > 0 {
+			name = args[0]
+		}
+
+		_ = klog.InitQuiet(config.LogConfig{})
+		soul, p, err := brain.LoadPersonalityByName(name, config.DataDir(), "")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println()
+		fmt.Printf(cDim+"  Name:     "+cReset+cBCyan+"%s"+cReset+"\n", p.Name)
+		fmt.Printf(cDim+"  Traits:   "+cReset+"%s\n", strings.Join(p.Traits, ", "))
+		fmt.Printf(cDim+"  Style:    "+cReset+"%s\n", p.Style)
+		fmt.Printf(cDim+"  Identity: "+cReset+"%s\n", soul.Identity)
+		fmt.Printf(cDim+"  Greeting: "+cReset+"%s\n", p.Greeting)
+		if len(p.Quirks) > 0 {
+			fmt.Printf(cDim+"  Quirks:   "+cReset+"%s\n", strings.Join(p.Quirks, "; "))
+		}
+		fmt.Println()
+		return nil
+	},
+}

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -374,7 +374,7 @@ var tuiCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		_ = stack.hb.Start(ctx)
-		defer stack.hb.Stop()
+		defer func() { _ = stack.hb.Stop() }()
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, core.Version, stack.cfg.Log.File)
 		return app.Run()

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -1,0 +1,514 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/srvsngh99/mini-krill/internal/chat"
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+	"github.com/srvsngh99/mini-krill/internal/doctor"
+	"github.com/srvsngh99/mini-krill/internal/llm"
+	klog "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/ollama"
+	"github.com/srvsngh99/mini-krill/internal/plugin"
+	"github.com/srvsngh99/mini-krill/internal/tui"
+)
+
+// ---------------------------------------------------------------------------
+// init command
+// ---------------------------------------------------------------------------
+
+var initCmd = &cobra.Command{
+	Use:   "init",
+	Short: "Setup wizard - configure Mini Krill",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		printBanner()
+		fmt.Println(cBold + "  Welcome to Mini Krill setup!" + cReset)
+		fmt.Println(cDim + "  Let's get you swimming in under a minute." + cReset)
+		fmt.Println()
+
+		cfg := config.DefaultConfig()
+		scanner := bufio.NewScanner(os.Stdin)
+
+		fmt.Println(cBCyan + "  Choose your LLM provider:" + cReset)
+		fmt.Println()
+		fmt.Println("    " + cBGreen + "[1]" + cReset + " Ollama        " + cDim + "local, free, private" + cReset)
+		fmt.Println("    " + cBBlue + "[2]" + cReset + " OpenAI        " + cDim + "$20/mo plan" + cReset)
+		fmt.Println("    " + cBBlue + "[3]" + cReset + " Anthropic     " + cDim + "$20/mo plan" + cReset)
+		fmt.Println("    " + cBBlue + "[4]" + cReset + " Google Gemini " + cDim + "free tier available" + cReset)
+		fmt.Println()
+		choice := ask(scanner, cCyan+"  > "+cReset)
+
+		switch choice {
+		case "2", "openai":
+			cfg.LLM.Provider = "openai"
+			cfg.LLM.Model = "gpt-4o-mini"
+			fmt.Println()
+			cfg.LLM.APIKey = ask(scanner, cCyan+"  API key: "+cReset)
+			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.LLM.Model)
+			scanner.Scan()
+			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
+				cfg.LLM.Model = m
+			}
+		case "3", "anthropic":
+			cfg.LLM.Provider = "anthropic"
+			cfg.LLM.Model = "claude-sonnet-4-20250514"
+			fmt.Println()
+			cfg.LLM.APIKey = ask(scanner, cCyan+"  API key: "+cReset)
+			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.LLM.Model)
+			scanner.Scan()
+			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
+				cfg.LLM.Model = m
+			}
+		case "4", "google":
+			cfg.LLM.Provider = "google"
+			cfg.LLM.Model = "gemini-2.0-flash"
+			fmt.Println()
+			cfg.LLM.APIKey = ask(scanner, cCyan+"  API key: "+cReset)
+			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.LLM.Model)
+			scanner.Scan()
+			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
+				cfg.LLM.Model = m
+			}
+		default:
+			cfg.LLM.Provider = "ollama"
+			fmt.Println()
+			mgr := ollama.NewManager(cfg.Ollama)
+			if !mgr.IsInstalled() {
+				ans := ask(scanner, cYellow+"  Ollama not found."+cReset+" Install now? "+cDim+"[Y/n]"+cReset+" ")
+				if ans == "" || strings.HasPrefix(strings.ToLower(ans), "y") {
+					fmt.Println(cDim + "  Installing Ollama..." + cReset)
+					if err := mgr.Install(context.Background()); err != nil {
+						fmt.Printf(cRed+"  Install failed: %v\n"+cReset, err)
+						fmt.Println(cDim + "  Install manually: https://ollama.com" + cReset)
+					} else {
+						fmt.Println(cGreen + "  Ollama installed!" + cReset)
+					}
+				}
+			} else {
+				fmt.Println(cGreen + "  Ollama: found!" + cReset)
+			}
+			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.Ollama.DefaultModel)
+			scanner.Scan()
+			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
+				cfg.LLM.Model = m
+				cfg.Ollama.DefaultModel = m
+			}
+		}
+
+		fmt.Println()
+		if ans := ask(scanner, cCyan+"  Enable Telegram bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
+			cfg.Telegram.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
+			cfg.Telegram.Enabled = cfg.Telegram.Token != ""
+		}
+		if ans := ask(scanner, cCyan+"  Enable Discord bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
+			cfg.Discord.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
+			cfg.Discord.Enabled = cfg.Discord.Token != ""
+		}
+
+		if err := config.EnsureDataDir(); err != nil {
+			return fmt.Errorf("create data dir: %w", err)
+		}
+		if err := config.Save(cfg); err != nil {
+			return fmt.Errorf("save config: %w", err)
+		}
+
+		fmt.Println()
+		fmt.Println(cBGreen + "  Mini Krill is ready to dive!" + cReset)
+		fmt.Printf(cDim+"  Config: %s\n"+cReset, filepath.Join(config.DataDir(), "config.yaml"))
+		fmt.Println()
+		fmt.Printf(cDimCyan+"  Fun fact: %s\n"+cReset, randomFact())
+		fmt.Println()
+		fmt.Println(cBold + "  Next steps:" + cReset)
+		fmt.Println("    " + cCyan + "minikrill chat" + cReset + "     Start chatting")
+		fmt.Println("    " + cCyan + "minikrill tui" + cReset + "      Terminal dashboard")
+		fmt.Println("    " + cCyan + "minikrill doctor" + cReset + "   Health check")
+		fmt.Println()
+		return nil
+	},
+}
+
+// ---------------------------------------------------------------------------
+// dive command
+// ---------------------------------------------------------------------------
+
+var diveCmd = &cobra.Command{
+	Use:   "dive",
+	Short: "Start Mini Krill - dive into the deep",
+	Long:  "Starts the agent with all configured services (Telegram, Discord).",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stack, err := initStack(false)
+		if err != nil {
+			return err
+		}
+
+		printBanner()
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		if err := stack.hb.Start(ctx); err != nil {
+			klog.Warn("heartbeat start failed", "error", err)
+		}
+
+		fmt.Printf("  "+cDim+"Provider:"+cReset+" %s "+cDim+"|"+cReset+" %s\n", stack.cfg.LLM.Provider, stack.cfg.LLM.Model)
+		fmt.Printf("  "+cDim+"Brain:"+cReset+"    %d memories\n", stack.brain.Memory().Count())
+		fmt.Printf("  "+cDim+"Skills:"+cReset+"   %d registered\n", len(stack.skills.List()))
+
+		if stack.cfg.Telegram.Enabled {
+			tgBot, err := chat.NewTelegramBot(stack.cfg.Telegram, stack.handler)
+			if err != nil {
+				fmt.Printf("  "+cRed+"Telegram: %s\n"+cReset, friendlyError(err))
+			} else {
+				tgBot.SetLearnFunc(func(ctx context.Context, key, value string) error {
+					return stack.brain.Memory().Store(ctx, core.MemoryEntry{
+						Key:        key,
+						Value:      value,
+						Tags:       []string{"group-learned", "telegram"},
+						CreatedAt:  time.Now(),
+						AccessedAt: time.Now(),
+					})
+				})
+				go func() {
+					if err := tgBot.Start(ctx); err != nil {
+						klog.Error("telegram error", "error", err)
+					}
+				}()
+				fmt.Println("  " + cGreen + "Telegram: swimming" + cReset)
+			}
+		}
+		if stack.cfg.Discord.Enabled {
+			dcBot, err := chat.NewDiscordBot(stack.cfg.Discord, stack.handler)
+			if err != nil {
+				fmt.Printf("  "+cRed+"Discord: %s\n"+cReset, friendlyError(err))
+			} else {
+				go func() {
+					if err := dcBot.Start(ctx); err != nil {
+						klog.Error("discord error", "error", err)
+					}
+				}()
+				fmt.Println("  " + cGreen + "Discord:  swimming" + cReset)
+			}
+		}
+
+		pidFile := filepath.Join(config.DataDir(), "krill.pid")
+		_ = os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0644)
+		defer os.Remove(pidFile)
+
+		fmt.Println()
+		fmt.Printf(cBGreen+"  Mini Krill is swimming!"+cReset+" "+cDim+"(PID: %d)\n"+cReset, os.Getpid())
+		fmt.Println(cDim + "  Press Ctrl+C to surface..." + cReset)
+		fmt.Println()
+		fmt.Println(cDimCyan + "  " + randomFact() + cReset)
+
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		<-sigCh
+
+		fmt.Println()
+		fmt.Println(cCyan + "  Mini Krill is surfacing..." + cReset)
+		cancel()
+		_ = stack.hb.Stop()
+		_ = stack.mcp.Close()
+		return nil
+	},
+}
+
+// ---------------------------------------------------------------------------
+// surface command
+// ---------------------------------------------------------------------------
+
+var surfaceCmd = &cobra.Command{
+	Use:   "surface",
+	Short: "Stop a running Mini Krill instance",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		pidFile := filepath.Join(config.DataDir(), "krill.pid")
+		data, err := os.ReadFile(pidFile)
+		if err != nil {
+			return fmt.Errorf("Mini Krill is not diving (no PID file)")
+		}
+		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+		if err != nil {
+			return fmt.Errorf("corrupt PID file")
+		}
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			return fmt.Errorf("process %d not found", pid)
+		}
+		if err := proc.Signal(syscall.SIGTERM); err != nil {
+			_ = proc.Kill()
+		}
+		_ = os.Remove(pidFile)
+		fmt.Println(cCyan + "Mini Krill is surfacing..." + cReset)
+		return nil
+	},
+}
+
+// ---------------------------------------------------------------------------
+// chat command
+// ---------------------------------------------------------------------------
+
+var chatCmd = &cobra.Command{
+	Use:   "chat",
+	Short: "Interactive chat with Mini Krill",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stack, err := initStack(true)
+		if err != nil {
+			return err
+		}
+
+		printBanner()
+		fmt.Printf(cDim+"  Provider: %s/%s"+cReset, stack.cfg.LLM.Provider, stack.cfg.LLM.Model)
+		fmt.Printf(cDim+" | Brain: %d memories"+cReset, stack.brain.Memory().Count())
+		fmt.Printf(cDim+" | Skills: %d"+cReset+"\n", len(stack.skills.List()))
+		fmt.Println()
+
+		greeting := stack.brain.GetPersonality().Greeting
+		if greeting == "" {
+			greeting = "Hey there! I'm Mini Krill, your crustaceous AI buddy."
+		}
+		fmt.Println(cBCyan + "  >=\\'>" + cReset + " " + greeting)
+		fmt.Println()
+		fmt.Println(cDim + "  Type " + cReset + "help" + cDim + " for commands, " + cReset + "exit" + cDim + " to leave" + cReset)
+		fmt.Println(cDim + "  Give me a task and I'll plan before doing anything" + cReset)
+		fmt.Println()
+
+		scanner := bufio.NewScanner(os.Stdin)
+		scanner.Buffer(make([]byte, 0), 1024*1024)
+		ctx := context.Background()
+
+		for {
+			fmt.Print(cBGreen + "you > " + cReset)
+			if !scanner.Scan() {
+				break
+			}
+			input := strings.TrimSpace(scanner.Text())
+			if input == "" {
+				continue
+			}
+			switch strings.ToLower(input) {
+			case "exit", "quit":
+				fmt.Println()
+				fmt.Println(cCyan + "  See you in the deep!" + cReset)
+				fmt.Println()
+				return nil
+			case "help":
+				printChatHelp()
+				continue
+			case "fact":
+				fmt.Println()
+				fmt.Printf(cBCyan+"krill > "+cReset+cDimCyan+"%s\n"+cReset, randomFact())
+				fmt.Println()
+				continue
+			case "status":
+				s := stack.hb.Status()
+				fmt.Println()
+				fmt.Print(cBCyan + "krill > " + cReset)
+				fmt.Printf(cDim+"Uptime: "+cReset+"%s", s.Uptime.Truncate(time.Second))
+				fmt.Printf(cDim+" | Memory: "+cReset+"%d KB", s.MemoryUsed/1024)
+				fmt.Printf(cDim+" | LLM: "+cReset+"%s", s.LLMStatus)
+				fmt.Println()
+				fmt.Println()
+				continue
+			}
+
+			done := make(chan struct{})
+			go spinner(done)
+
+			resp, err := stack.agent.Chat(ctx, input)
+			close(done)
+
+			fmt.Println()
+			if err != nil {
+				fmt.Printf(cBCyan+"krill > "+cReset+cYellow+"Bubbles! %s\n"+cReset, friendlyError(err))
+				fmt.Println(cDim + "         Try rephrasing, or check 'minikrill doctor' for issues." + cReset)
+			} else if resp == "" {
+				fmt.Println(cBCyan + "krill > " + cReset + cDimCyan + randomFact() + cReset)
+			} else {
+				fmt.Println(cBCyan + "krill > " + cReset + renderMarkdown(resp))
+			}
+			fmt.Println()
+		}
+		return nil
+	},
+}
+
+func printChatHelp() {
+	fmt.Println()
+	fmt.Println(cBCyan + "  Commands:" + cReset)
+	fmt.Println("    " + cCyan + "help" + cReset + "      Show this help")
+	fmt.Println("    " + cCyan + "fact" + cReset + "      Random krill fact")
+	fmt.Println("    " + cCyan + "status" + cReset + "    System status")
+	fmt.Println("    " + cCyan + "exit" + cReset + "      Leave the chat")
+	fmt.Println()
+	fmt.Println(cBCyan + "  Tips:" + cReset)
+	fmt.Println(cDim + "    Ask anything" + cReset + " - I'll chat naturally")
+	fmt.Println(cDim + "    Give me a task" + cReset + " - I'll show a dive plan for your approval")
+	fmt.Println(cDim + "    Say" + cReset + " 'yes'" + cDim + " to approve," + cReset + " 'no'" + cDim + " to reject a plan" + cReset)
+	fmt.Println()
+}
+
+// ---------------------------------------------------------------------------
+// tui command
+// ---------------------------------------------------------------------------
+
+var tuiCmd = &cobra.Command{
+	Use:   "tui",
+	Short: "Launch the terminal dashboard",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stack, err := initStack(true)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		_ = stack.hb.Start(ctx)
+		defer stack.hb.Stop()
+
+		app := tui.NewApp(stack.agent, stack.brain, stack.hb, core.Version, stack.cfg.Log.File)
+		return app.Run()
+	},
+}
+
+// ---------------------------------------------------------------------------
+// doctor command
+// ---------------------------------------------------------------------------
+
+var doctorCmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Run health diagnostics",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Printf(cBRed+"[FAIL]"+cReset+" config - %v\n", err)
+			return nil
+		}
+		_ = klog.InitQuiet(cfg.Log)
+
+		llmProvider, _ := llm.NewProvider(cfg.LLM, cfg.Ollama)
+		doc := doctor.NewDoctor(cfg.Ollama.Host, llmProvider, cfg.Brain.DataDir)
+
+		printBanner()
+		fmt.Println(cDim + "  Running diagnostics..." + cReset)
+		fmt.Println()
+		results := doc.RunAll(context.Background())
+		fmt.Println(doctor.FormatResults(results))
+
+		ok, warn, fail := 0, 0, 0
+		for _, r := range results {
+			switch r.Status {
+			case "ok":
+				ok++
+			case "warn":
+				warn++
+			case "fail":
+				fail++
+			}
+		}
+		fmt.Println()
+		fmt.Printf("  %s%d passed%s, %s%d warnings%s, %s%d failed%s\n",
+			cGreen, ok, cReset, cYellow, warn, cReset, cRed, fail, cReset)
+		if fail > 0 {
+			fmt.Println(cDim + "  Run " + cReset + "minikrill init" + cDim + " to reconfigure." + cReset)
+		}
+		fmt.Println()
+		return nil
+	},
+}
+
+// ---------------------------------------------------------------------------
+// sonar command
+// ---------------------------------------------------------------------------
+
+var sonarCmd = &cobra.Command{
+	Use:   "sonar",
+	Short: "Quick health ping",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, err := config.Load()
+		if err != nil {
+			fmt.Println(cRed + "FAIL" + cReset + " - config not loadable")
+			return nil
+		}
+		_ = klog.InitQuiet(cfg.Log)
+		llmProvider, err := llm.NewProvider(cfg.LLM, cfg.Ollama)
+		if err != nil {
+			fmt.Printf(cRed+"FAIL"+cReset+" - LLM: %s\n", friendlyError(err))
+			return nil
+		}
+		if llmProvider.Available(context.Background()) {
+			fmt.Printf(cBGreen+"PONG"+cReset+" - Mini Krill is alive! "+cDim+"(%s/%s)\n"+cReset, cfg.LLM.Provider, cfg.LLM.Model)
+		} else {
+			fmt.Printf(cBRed+"FAIL"+cReset+" - LLM not reachable "+cDim+"(%s/%s)\n"+cReset, cfg.LLM.Provider, cfg.LLM.Model)
+		}
+		return nil
+	},
+}
+
+// ---------------------------------------------------------------------------
+// version command
+// ---------------------------------------------------------------------------
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Show version information",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf(cBold+"Mini Krill"+cReset+" v%s\n", core.Version)
+		fmt.Printf(cDim+"Go:      "+cReset+"%s\n", runtime.Version())
+		fmt.Printf(cDim+"OS/Arch: "+cReset+"%s/%s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Println()
+		fmt.Println(cDimCyan + randomFact() + cReset)
+	},
+}
+
+// ---------------------------------------------------------------------------
+// skill subcommands
+// ---------------------------------------------------------------------------
+
+var skillCmd = &cobra.Command{
+	Use:   "skill",
+	Short: "Manage skills",
+}
+
+var skillListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available skills",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cfg, _ := config.Load()
+		if cfg != nil {
+			_ = klog.InitQuiet(cfg.Log)
+		}
+		reg := plugin.NewRegistry()
+		reg.RegisterBuiltins()
+		if cfg != nil && cfg.Plugins.Dir != "" {
+			_ = reg.LoadSkillsFromDir(cfg.Plugins.Dir)
+		}
+		skills := reg.List()
+		if len(skills) == 0 {
+			fmt.Println("No skills registered.")
+			return nil
+		}
+		fmt.Println(cBold + "Available skills:" + cReset)
+		for _, s := range skills {
+			status := cGreen + "on" + cReset
+			if !s.Enabled {
+				status = cDim + "off" + cReset
+			}
+			fmt.Printf("  [%s] "+cCyan+"%-15s"+cReset+" %s\n", status, s.Name, s.Description)
+		}
+		fmt.Println()
+		fmt.Println(cDim + "Add custom skills as YAML files in: " + cReset + config.DataDir() + "/skills/")
+		return nil
+	},
+}
+

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -1,20 +1,12 @@
 // Mini Krill - Your crustaceous AI buddy
-// A lightweight, open-source AI agent inspired by DeepKrill.
-// Krill fact: krill have survived for 130 million years - this binary aims for the same uptime.
 package main
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"math/rand"
 	"os"
-	"os/signal"
-	"path/filepath"
-	"runtime"
-	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -24,33 +16,28 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/chat"
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
-	"github.com/srvsngh99/mini-krill/internal/doctor"
 	"github.com/srvsngh99/mini-krill/internal/llm"
 	klog "github.com/srvsngh99/mini-krill/internal/log"
 	"github.com/srvsngh99/mini-krill/internal/ollama"
 	"github.com/srvsngh99/mini-krill/internal/plugin"
-	"github.com/srvsngh99/mini-krill/internal/tui"
 )
 
-// ---------------------------------------------------------------------------
 // ANSI color codes - ocean palette
-// ---------------------------------------------------------------------------
-
 const (
-	cReset  = "\033[0m"
-	cBold   = "\033[1m"
-	cDim    = "\033[2m"
-	cCyan   = "\033[36m"
-	cGreen  = "\033[32m"
-	cYellow = "\033[33m"
-	cRed    = "\033[31m"
-	cBlue   = "\033[34m"
+	cReset   = "\033[0m"
+	cBold    = "\033[1m"
+	cDim     = "\033[2m"
+	cCyan    = "\033[36m"
+	cGreen   = "\033[32m"
+	cYellow  = "\033[33m"
+	cRed     = "\033[31m"
+	cBlue    = "\033[34m"
 	cMagenta = "\033[35m"
-	cBCyan  = "\033[1;36m" // bold cyan
-	cBGreen = "\033[1;32m" // bold green
+	cBCyan   = "\033[1;36m"
+	cBGreen  = "\033[1;32m"
 	cBYellow = "\033[1;33m"
-	cBRed   = "\033[1;31m"
-	cBBlue  = "\033[1;34m"
+	cBRed    = "\033[1;31m"
+	cBBlue   = "\033[1;34m"
 	cDimCyan = "\033[2;36m"
 )
 
@@ -61,10 +48,6 @@ func main() {
 		os.Exit(1)
 	}
 }
-
-// ---------------------------------------------------------------------------
-// Root command
-// ---------------------------------------------------------------------------
 
 var rootCmd = &cobra.Command{
 	Use:   "minikrill",
@@ -99,92 +82,22 @@ func init() {
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Shared helpers
 // ---------------------------------------------------------------------------
 
-func printBanner() {
-	fmt.Println()
-	fmt.Println(cBCyan + "   ~~~~" + cReset)
-	fmt.Printf(cBCyan+"  >=\\'>"+cReset+"    "+cBold+"Mini Krill"+cReset+" v%s\n", core.Version)
-	fmt.Println(cBCyan + "   ~~~~" + cReset + "    " + cDim + "Your crustaceous AI buddy" + cReset)
-	fmt.Println()
-}
-
-func printChatHelp() {
-	fmt.Println()
-	fmt.Println(cBCyan + "  Commands:" + cReset)
-	fmt.Println("    " + cCyan + "help" + cReset + "      Show this help")
-	fmt.Println("    " + cCyan + "fact" + cReset + "      Random krill fact")
-	fmt.Println("    " + cCyan + "status" + cReset + "    System status")
-	fmt.Println("    " + cCyan + "exit" + cReset + "      Leave the chat")
-	fmt.Println()
-	fmt.Println(cBCyan + "  Tips:" + cReset)
-	fmt.Println(cDim + "    Ask anything" + cReset + " - I'll chat naturally")
-	fmt.Println(cDim + "    Give me a task" + cReset + " - I'll show a dive plan for your approval")
-	fmt.Println(cDim + "    Say" + cReset + " 'yes'" + cDim + " to approve," + cReset + " 'no'" + cDim + " to reject a plan" + cReset)
-	fmt.Println()
-}
-
-func ask(scanner *bufio.Scanner, question string) string {
-	fmt.Print(question)
-	scanner.Scan()
-	return strings.TrimSpace(scanner.Text())
-}
-
-// isConfirmation returns true if the input is just confirming the default.
-// This prevents "yes" from being used as a model name etc.
-func isConfirmation(s string) bool {
-	s = strings.ToLower(s)
-	return s == "yes" || s == "y" || s == "ok" || s == "sure" || s == "yep"
-}
-
-func colored(color, text string) string {
-	return color + text + cReset
-}
-
-// friendlyError strips raw API error dumps into a short, helpful message.
-func friendlyError(err error) string {
-	msg := err.Error()
-	// Strip long JSON bodies
-	if idx := strings.Index(msg, `{"error"`); idx > 0 {
-		msg = msg[:idx]
-	}
-	if idx := strings.Index(msg, `{"message"`); idx > 0 {
-		msg = msg[:idx]
-	}
-	// Trim trailing whitespace/punctuation
-	msg = strings.TrimRight(msg, " \n\t:,")
-	// Keep it short
-	if len(msg) > 120 {
-		msg = msg[:117] + "..."
-	}
-	if msg == "" {
-		msg = "Something went wrong in the deep"
-	}
-	return msg
-}
-
-// spinner shows a simple dots animation while waiting.
-func spinner(done <-chan struct{}) {
-	frames := []string{".", "..", "..."}
-	i := 0
-	ticker := time.NewTicker(400 * time.Millisecond)
-	defer ticker.Stop()
-	fmt.Print(cDimCyan + "  thinking" + cReset)
-	for {
-		select {
-		case <-done:
-			fmt.Print("\r\033[K") // clear line
-			return
-		case <-ticker.C:
-			fmt.Print("\r" + cDimCyan + "  thinking" + frames[i%3] + cReset + "   ")
-			i++
-		}
-	}
+// krillStack holds all initialized subsystems.
+type krillStack struct {
+	cfg     *config.Config
+	llm     core.LLMProvider
+	brain   *brain.KrillBrain
+	hb      core.Heartbeat
+	skills  *plugin.SkillRegistryImpl
+	mcp     *plugin.MCPRegistryImpl
+	agent   *agent.KrillAgent
+	handler *chat.ChatHandlerImpl
 }
 
 // initStack boots every subsystem needed for chat/dive/tui.
-// quiet=true suppresses stderr logging (for interactive modes).
 func initStack(quiet bool) (*krillStack, error) {
 	cfg, err := config.Load()
 	if err != nil {
@@ -192,7 +105,7 @@ func initStack(quiet bool) (*krillStack, error) {
 	}
 	if verbose {
 		cfg.Log.Level = "debug"
-		quiet = false // verbose overrides quiet
+		quiet = false
 	}
 	if err := config.EnsureDataDir(); err != nil {
 		return nil, fmt.Errorf("create data dir: %w", err)
@@ -203,10 +116,6 @@ func initStack(quiet bool) (*krillStack, error) {
 		_ = klog.Init(cfg.Log)
 	}
 
-	// Seed built-in personality profiles on first run
-	brain.SeedDefaultPersonalities(config.DataDir())
-
-	// Sync personality from agent config to brain config
 	if cfg.Agent.Personality != "" {
 		cfg.Brain.Personality = cfg.Agent.Personality
 	}
@@ -232,7 +141,6 @@ func initStack(quiet bool) (*krillStack, error) {
 		_ = mcpReg.LoadFromConfig(cfg.MCP.Servers)
 	}
 
-	// Self-awareness: give the krill eyes and hands on its own internals
 	skillReg.RegisterSelfSkills(plugin.SelfContext{
 		Brain:     krillBrain,
 		Config:    cfg,
@@ -257,1065 +165,88 @@ func initStack(quiet bool) (*krillStack, error) {
 	}, nil
 }
 
-type krillStack struct {
-	cfg     *config.Config
-	llm     core.LLMProvider
-	brain   *brain.KrillBrain
-	hb      core.Heartbeat
-	skills  *plugin.SkillRegistryImpl
-	mcp     *plugin.MCPRegistryImpl
-	agent   *agent.KrillAgent
-	handler *chat.ChatHandlerImpl
-}
-
-// ---------------------------------------------------------------------------
-// init command - setup wizard
-// ---------------------------------------------------------------------------
-
-var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Setup wizard - configure Mini Krill",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		printBanner()
-		fmt.Println(cBold + "  Welcome to Mini Krill setup!" + cReset)
-		fmt.Println(cDim + "  Let's get you swimming in under a minute." + cReset)
-		fmt.Println()
-
-		cfg := config.DefaultConfig()
-		scanner := bufio.NewScanner(os.Stdin)
-
-		// LLM provider selection
-		fmt.Println(cBCyan + "  Choose your LLM provider:" + cReset)
-		fmt.Println()
-		fmt.Println("    " + cBGreen + "[1]" + cReset + " Ollama        " + cDim + "local, free, private" + cReset)
-		fmt.Println("    " + cBBlue + "[2]" + cReset + " OpenAI        " + cDim + "$20/mo plan" + cReset)
-		fmt.Println("    " + cBBlue + "[3]" + cReset + " Anthropic     " + cDim + "$20/mo plan" + cReset)
-		fmt.Println("    " + cBBlue + "[4]" + cReset + " Google Gemini " + cDim + "free tier available" + cReset)
-		fmt.Println()
-		choice := ask(scanner, cCyan+"  > "+cReset)
-
-		switch choice {
-		case "2", "openai":
-			cfg.LLM.Provider = "openai"
-			cfg.LLM.Model = "gpt-4o-mini"
-			fmt.Println()
-			cfg.LLM.APIKey = ask(scanner, cCyan+"  API key: "+cReset)
-			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.LLM.Model)
-			scanner.Scan()
-			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
-				cfg.LLM.Model = m
-			}
-		case "3", "anthropic":
-			cfg.LLM.Provider = "anthropic"
-			cfg.LLM.Model = "claude-sonnet-4-20250514"
-			fmt.Println()
-			cfg.LLM.APIKey = ask(scanner, cCyan+"  API key: "+cReset)
-			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.LLM.Model)
-			scanner.Scan()
-			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
-				cfg.LLM.Model = m
-			}
-		case "4", "google":
-			cfg.LLM.Provider = "google"
-			cfg.LLM.Model = "gemini-2.0-flash"
-			fmt.Println()
-			cfg.LLM.APIKey = ask(scanner, cCyan+"  API key: "+cReset)
-			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.LLM.Model)
-			scanner.Scan()
-			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
-				cfg.LLM.Model = m
-			}
-		default: // 1, ollama, or empty
-			cfg.LLM.Provider = "ollama"
-			fmt.Println()
-			mgr := ollama.NewManager(cfg.Ollama)
-			if !mgr.IsInstalled() {
-				ans := ask(scanner, cYellow+"  Ollama not found."+cReset+" Install now? "+cDim+"[Y/n]"+cReset+" ")
-				if ans == "" || strings.HasPrefix(strings.ToLower(ans), "y") {
-					fmt.Println(cDim + "  Installing Ollama..." + cReset)
-					if err := mgr.Install(context.Background()); err != nil {
-						fmt.Printf(cRed+"  Install failed: %v\n"+cReset, err)
-						fmt.Println(cDim + "  Install manually: https://ollama.com" + cReset)
-					} else {
-						fmt.Println(cGreen + "  Ollama installed!" + cReset)
-					}
-				}
-			} else {
-				fmt.Println(cGreen + "  Ollama: found!" + cReset)
-			}
-			fmt.Printf(cDim+"  Model [%s]: "+cReset, cfg.Ollama.DefaultModel)
-			scanner.Scan()
-			if m := strings.TrimSpace(scanner.Text()); m != "" && !isConfirmation(m) {
-				cfg.LLM.Model = m
-				cfg.Ollama.DefaultModel = m
-			}
-		}
-
-		// Telegram
-		fmt.Println()
-		if ans := ask(scanner, cCyan+"  Enable Telegram bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
-			cfg.Telegram.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
-			cfg.Telegram.Enabled = cfg.Telegram.Token != ""
-		}
-
-		// Discord
-		if ans := ask(scanner, cCyan+"  Enable Discord bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
-			cfg.Discord.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
-			cfg.Discord.Enabled = cfg.Discord.Token != ""
-		}
-
-		// Save
-		if err := config.EnsureDataDir(); err != nil {
-			return fmt.Errorf("create data dir: %w", err)
-		}
-		if err := config.Save(cfg); err != nil {
-			return fmt.Errorf("save config: %w", err)
-		}
-
-		fmt.Println()
-		fmt.Println(cBGreen + "  Mini Krill is ready to dive!" + cReset)
-		fmt.Printf(cDim+"  Config: %s\n"+cReset, filepath.Join(config.DataDir(), "config.yaml"))
-		fmt.Println()
-		fmt.Printf(cDimCyan+"  Fun fact: %s\n"+cReset, core.KrillFacts[rand.Intn(len(core.KrillFacts))])
-		fmt.Println()
-		fmt.Println(cBold + "  Next steps:" + cReset)
-		fmt.Println("    " + cCyan + "minikrill chat" + cReset + "     Start chatting")
-		fmt.Println("    " + cCyan + "minikrill tui" + cReset + "      Terminal dashboard")
-		fmt.Println("    " + cCyan + "minikrill doctor" + cReset + "   Health check")
-		fmt.Println()
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// dive command - start all services
-// ---------------------------------------------------------------------------
-
-var diveCmd = &cobra.Command{
-	Use:   "dive",
-	Short: "Start Mini Krill - dive into the deep",
-	Long:  "Starts the agent with all configured services (Telegram, Discord).",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		stack, err := initStack(false)
-		if err != nil {
-			return err
-		}
-
-		printBanner()
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		if err := stack.hb.Start(ctx); err != nil {
-			klog.Warn("heartbeat start failed", "error", err)
-		}
-
-		fmt.Printf("  "+cDim+"Provider:"+cReset+" %s "+cDim+"|"+cReset+" %s\n", stack.cfg.LLM.Provider, stack.cfg.LLM.Model)
-		fmt.Printf("  "+cDim+"Brain:"+cReset+"    %d memories\n", stack.brain.Memory().Count())
-		fmt.Printf("  "+cDim+"Skills:"+cReset+"   %d registered\n", len(stack.skills.List()))
-
-		if stack.cfg.Telegram.Enabled {
-			tgBot, err := chat.NewTelegramBot(stack.cfg.Telegram, stack.handler)
-			if err != nil {
-				fmt.Printf("  "+cRed+"Telegram: %s\n"+cReset, friendlyError(err))
-			} else {
-				// Wire group learning - krill remembers interesting group exchanges
-				tgBot.SetLearnFunc(func(ctx context.Context, key, value string) error {
-					return stack.brain.Memory().Store(ctx, core.MemoryEntry{
-						Key:        key,
-						Value:      value,
-						Tags:       []string{"group-learned", "telegram"},
-						CreatedAt:  time.Now(),
-						AccessedAt: time.Now(),
-					})
-				})
-				go func() {
-					if err := tgBot.Start(ctx); err != nil {
-						klog.Error("telegram error", "error", err)
-					}
-				}()
-				fmt.Println("  " + cGreen + "Telegram: swimming" + cReset)
-			}
-		}
-		if stack.cfg.Discord.Enabled {
-			dcBot, err := chat.NewDiscordBot(stack.cfg.Discord, stack.handler)
-			if err != nil {
-				fmt.Printf("  "+cRed+"Discord: %s\n"+cReset, friendlyError(err))
-			} else {
-				go func() {
-					if err := dcBot.Start(ctx); err != nil {
-						klog.Error("discord error", "error", err)
-					}
-				}()
-				fmt.Println("  " + cGreen + "Discord:  swimming" + cReset)
-			}
-		}
-
-		pidFile := filepath.Join(config.DataDir(), "krill.pid")
-		_ = os.WriteFile(pidFile, []byte(strconv.Itoa(os.Getpid())), 0644)
-		defer os.Remove(pidFile)
-
-		fmt.Println()
-		fmt.Printf(cBGreen+"  Mini Krill is swimming!"+cReset+" "+cDim+"(PID: %d)\n"+cReset, os.Getpid())
-		fmt.Println(cDim + "  Press Ctrl+C to surface..." + cReset)
-		fmt.Println()
-		fmt.Println(cDimCyan + "  " + core.KrillFacts[rand.Intn(len(core.KrillFacts))] + cReset)
-
-		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
-		<-sigCh
-
-		fmt.Println()
-		fmt.Println(cCyan + "  Mini Krill is surfacing..." + cReset)
-		cancel()
-		_ = stack.hb.Stop()
-		_ = stack.mcp.Close()
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// surface command - stop running instance
-// ---------------------------------------------------------------------------
-
-var surfaceCmd = &cobra.Command{
-	Use:   "surface",
-	Short: "Stop a running Mini Krill instance",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pidFile := filepath.Join(config.DataDir(), "krill.pid")
-		data, err := os.ReadFile(pidFile)
-		if err != nil {
-			return fmt.Errorf("Mini Krill is not diving (no PID file)")
-		}
-		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-		if err != nil {
-			return fmt.Errorf("corrupt PID file")
-		}
-		proc, err := os.FindProcess(pid)
-		if err != nil {
-			return fmt.Errorf("process %d not found", pid)
-		}
-		if err := proc.Signal(syscall.SIGTERM); err != nil {
-			_ = proc.Kill()
-		}
-		_ = os.Remove(pidFile)
-		fmt.Println(cCyan + "Mini Krill is surfacing..." + cReset)
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// chat command - interactive terminal chat
-// ---------------------------------------------------------------------------
-
-var chatCmd = &cobra.Command{
-	Use:   "chat",
-	Short: "Interactive chat with Mini Krill",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Quiet mode: no log spam in the chat UI
-		stack, err := initStack(true)
-		if err != nil {
-			return err
-		}
-
-		printBanner()
-
-		// Status line
-		fmt.Printf(cDim+"  Provider: %s/%s"+cReset, stack.cfg.LLM.Provider, stack.cfg.LLM.Model)
-		fmt.Printf(cDim+" | Brain: %d memories"+cReset, stack.brain.Memory().Count())
-		fmt.Printf(cDim+" | Skills: %d"+cReset+"\n", len(stack.skills.List()))
-		fmt.Println()
-
-		// Greeting
-		greeting := stack.brain.GetPersonality().Greeting
-		if greeting == "" {
-			greeting = "Hey there! I'm Mini Krill, your crustaceous AI buddy."
-		}
-		fmt.Println(cBCyan + "  >=\\'>" + cReset + " " + greeting)
-		fmt.Println()
-
-		// Hints
-		fmt.Println(cDim + "  Type " + cReset + "help" + cDim + " for commands, " + cReset + "exit" + cDim + " to leave" + cReset)
-		fmt.Println(cDim + "  Give me a task and I'll plan before doing anything" + cReset)
-		fmt.Println()
-
-		scanner := bufio.NewScanner(os.Stdin)
-		scanner.Buffer(make([]byte, 0), 1024*1024)
-		ctx := context.Background()
-
-		for {
-			fmt.Print(cBGreen + "you > " + cReset)
-			if !scanner.Scan() {
-				break
-			}
-			input := strings.TrimSpace(scanner.Text())
-			if input == "" {
-				continue
-			}
-			switch strings.ToLower(input) {
-			case "exit", "quit":
-				fmt.Println()
-				fmt.Println(cCyan + "  See you in the deep!" + cReset)
-				fmt.Println()
-				return nil
-			case "help":
-				printChatHelp()
-				continue
-			case "fact":
-				fmt.Println()
-				fmt.Printf(cBCyan+"krill > "+cReset+cDimCyan+"%s\n"+cReset, core.KrillFacts[rand.Intn(len(core.KrillFacts))])
-				fmt.Println()
-				continue
-			case "status":
-				s := stack.hb.Status()
-				fmt.Println()
-				fmt.Print(cBCyan + "krill > " + cReset)
-				fmt.Printf(cDim+"Uptime: "+cReset+"%s", s.Uptime.Truncate(time.Second))
-				fmt.Printf(cDim+" | Memory: "+cReset+"%d KB", s.MemoryUsed/1024)
-				fmt.Printf(cDim+" | LLM: "+cReset+"%s", s.LLMStatus)
-				fmt.Println()
-				fmt.Println()
-				continue
-			}
-
-			// Show thinking spinner
-			done := make(chan struct{})
-			go spinner(done)
-
-			resp, err := stack.agent.Chat(ctx, input)
-			close(done)
-
-			fmt.Println()
-			if err != nil {
-				fmt.Printf(cBCyan+"krill > "+cReset+cYellow+"Bubbles! %s\n"+cReset, friendlyError(err))
-				fmt.Println(cDim + "         Try rephrasing, or check 'minikrill doctor' for issues." + cReset)
-			} else if resp == "" {
-				fmt.Println(cBCyan + "krill > " + cReset + cDimCyan + core.KrillFacts[rand.Intn(len(core.KrillFacts))] + cReset)
-			} else {
-				fmt.Println(cBCyan + "krill > " + cReset + renderMarkdown(resp))
-			}
-			fmt.Println()
-		}
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// tui command - terminal dashboard
-// ---------------------------------------------------------------------------
-
-var tuiCmd = &cobra.Command{
-	Use:   "tui",
-	Short: "Launch the terminal dashboard",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		stack, err := initStack(true)
-		if err != nil {
-			return err
-		}
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		_ = stack.hb.Start(ctx)
-		defer stack.hb.Stop()
-
-		app := tui.NewApp(stack.agent, stack.brain, stack.hb, core.Version, stack.cfg.Log.File)
-		return app.Run()
-	},
-}
-
-// ---------------------------------------------------------------------------
-// doctor command - health checks
-// ---------------------------------------------------------------------------
-
-var doctorCmd = &cobra.Command{
-	Use:   "doctor",
-	Short: "Run health diagnostics",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			fmt.Printf(cBRed+"[FAIL]"+cReset+" config - %v\n", err)
-			return nil
-		}
-		_ = klog.InitQuiet(cfg.Log)
-
-		llmProvider, _ := llm.NewProvider(cfg.LLM, cfg.Ollama)
-		doc := doctor.NewDoctor(cfg.Ollama.Host, llmProvider, cfg.Brain.DataDir)
-
-		printBanner()
-		fmt.Println(cDim + "  Running diagnostics..." + cReset)
-		fmt.Println()
-		results := doc.RunAll(context.Background())
-		fmt.Println(doctor.FormatResults(results))
-
-		ok, warn, fail := 0, 0, 0
-		for _, r := range results {
-			switch r.Status {
-			case "ok":
-				ok++
-			case "warn":
-				warn++
-			case "fail":
-				fail++
-			}
-		}
-		fmt.Println()
-		fmt.Printf("  %s%d passed%s, %s%d warnings%s, %s%d failed%s\n",
-			cGreen, ok, cReset, cYellow, warn, cReset, cRed, fail, cReset)
-		if fail > 0 {
-			fmt.Println(cDim + "  Run " + cReset + "minikrill init" + cDim + " to reconfigure." + cReset)
-		}
-		fmt.Println()
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// sonar command - quick health ping
-// ---------------------------------------------------------------------------
-
-var sonarCmd = &cobra.Command{
-	Use:   "sonar",
-	Short: "Quick health ping",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			fmt.Println(cRed + "FAIL" + cReset + " - config not loadable")
-			return nil
-		}
-		_ = klog.InitQuiet(cfg.Log)
-		llmProvider, err := llm.NewProvider(cfg.LLM, cfg.Ollama)
-		if err != nil {
-			fmt.Printf(cRed+"FAIL"+cReset+" - LLM: %s\n", friendlyError(err))
-			return nil
-		}
-		if llmProvider.Available(context.Background()) {
-			fmt.Printf(cBGreen+"PONG"+cReset+" - Mini Krill is alive! "+cDim+"(%s/%s)\n"+cReset, cfg.LLM.Provider, cfg.LLM.Model)
-		} else {
-			fmt.Printf(cBRed+"FAIL"+cReset+" - LLM not reachable "+cDim+"(%s/%s)\n"+cReset, cfg.LLM.Provider, cfg.LLM.Model)
-		}
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// version command
-// ---------------------------------------------------------------------------
-
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show version information",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf(cBold+"Mini Krill"+cReset+" v%s\n", core.Version)
-		fmt.Printf(cDim+"Go:      "+cReset+"%s\n", runtime.Version())
-		fmt.Printf(cDim+"OS/Arch: "+cReset+"%s/%s\n", runtime.GOOS, runtime.GOARCH)
-		fmt.Println()
-		fmt.Println(cDimCyan + core.KrillFacts[rand.Intn(len(core.KrillFacts))] + cReset)
-	},
-}
-
-// ---------------------------------------------------------------------------
-// ollama subcommands
-// ---------------------------------------------------------------------------
-
-var ollamaCmd = &cobra.Command{
-	Use:   "ollama",
-	Short: "Manage local Ollama installation",
-}
-
-var ollamaInstallCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install Ollama",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg == nil {
-			cfg = config.DefaultConfig()
-		}
-		mgr := ollama.NewManager(cfg.Ollama)
-		if mgr.IsInstalled() {
-			fmt.Println(cGreen + "Ollama is already installed!" + cReset)
-			return nil
-		}
-		fmt.Println(cDim + "Installing Ollama..." + cReset)
-		if err := mgr.Install(context.Background()); err != nil {
-			return fmt.Errorf("install failed: %w\nInstall manually: https://ollama.com", err)
-		}
-		fmt.Println(cGreen + "Ollama installed!" + cReset)
-		return nil
-	},
-}
-
-var ollamaStartCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start Ollama server",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg == nil {
-			cfg = config.DefaultConfig()
-		}
-		mgr := ollama.NewManager(cfg.Ollama)
-		fmt.Println(cDim + "Starting Ollama..." + cReset)
-		if err := mgr.Start(context.Background()); err != nil {
-			return err
-		}
-		fmt.Println(cGreen + "Ollama is running!" + cReset)
-		return nil
-	},
-}
-
-var ollamaStopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stop Ollama server",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg == nil {
-			cfg = config.DefaultConfig()
-		}
-		mgr := ollama.NewManager(cfg.Ollama)
-		if err := mgr.Stop(); err != nil {
-			return err
-		}
-		fmt.Println(cCyan + "Ollama stopped." + cReset)
-		return nil
-	},
-}
-
-var ollamaPullCmd = &cobra.Command{
-	Use:   "pull [model]",
-	Short: "Pull an Ollama model",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg == nil {
-			cfg = config.DefaultConfig()
-		}
-		mgr := ollama.NewManager(cfg.Ollama)
-		model := args[0]
-		fmt.Printf(cDim+"Pulling %s..."+cReset+"\n", model)
-		if err := mgr.Pull(context.Background(), model); err != nil {
-			return err
-		}
-		fmt.Printf(cGreen+"Model %s is ready!"+cReset+"\n", model)
-		return nil
-	},
-}
-
-var ollamaListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List local Ollama models",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg == nil {
-			cfg = config.DefaultConfig()
-		}
-		mgr := ollama.NewManager(cfg.Ollama)
-		models, err := mgr.ListModels(context.Background())
-		if err != nil {
-			return fmt.Errorf("could not list models: %w", err)
-		}
-		if len(models) == 0 {
-			fmt.Println("No models found.")
-			fmt.Println(cDim + "Pull one with: " + cReset + "minikrill ollama pull llama3.2")
-			return nil
-		}
-		fmt.Println(cBold + "Local models:" + cReset)
-		for _, m := range models {
-			fmt.Printf("  "+cCyan+"%-25s"+cReset+cDim+" %.1f GB\n"+cReset, m.Name, float64(m.Size)/(1024*1024*1024))
-		}
-		return nil
-	},
-}
-
-var ollamaStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Check Ollama status",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg == nil {
-			cfg = config.DefaultConfig()
-		}
-		mgr := ollama.NewManager(cfg.Ollama)
-		status := mgr.Status(context.Background())
-		switch status {
-		case "running":
-			fmt.Println(cGreen + "Ollama: running" + cReset)
-		case "stopped":
-			fmt.Println(cYellow + "Ollama: stopped" + cReset)
-			fmt.Println(cDim + "Start with: " + cReset + "minikrill ollama start")
-		default:
-			fmt.Println(cRed + "Ollama: " + status + cReset)
-		}
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// skill subcommands
-// ---------------------------------------------------------------------------
-
-var skillCmd = &cobra.Command{
-	Use:   "skill",
-	Short: "Manage skills",
-}
-
-var skillListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List available skills",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		if cfg != nil {
-			_ = klog.InitQuiet(cfg.Log)
-		}
-		reg := plugin.NewRegistry()
-		reg.RegisterBuiltins()
-		if cfg != nil && cfg.Plugins.Dir != "" {
-			_ = reg.LoadSkillsFromDir(cfg.Plugins.Dir)
-		}
-		skills := reg.List()
-		if len(skills) == 0 {
-			fmt.Println("No skills registered.")
-			return nil
-		}
-		fmt.Println(cBold + "Available skills:" + cReset)
-		for _, s := range skills {
-			status := cGreen + "on" + cReset
-			if !s.Enabled {
-				status = cDim + "off" + cReset
-			}
-			fmt.Printf("  [%s] "+cCyan+"%-15s"+cReset+" %s\n", status, s.Name, s.Description)
-		}
-		fmt.Println()
-		fmt.Println(cDim + "Add custom skills as YAML files in: " + cReset + config.DataDir() + "/skills/")
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// brain subcommands
-// ---------------------------------------------------------------------------
-
-var brainCmd = &cobra.Command{
-	Use:   "brain",
-	Short: "Inspect and manage the krill's brain",
-}
-
-var brainStatusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show brain status",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		_ = klog.InitQuiet(cfg.Log)
-		krillBrain, err := brain.New(cfg.Brain, nil)
-		if err != nil {
-			return fmt.Errorf("init brain: %w", err)
-		}
-		p := krillBrain.GetPersonality()
-		fmt.Println()
-		fmt.Printf(cDim+"  Personality: "+cReset+cBCyan+"%s\n"+cReset, p.Name)
-		fmt.Printf(cDim+"  Traits:      "+cReset+"%s\n", strings.Join(p.Traits, ", "))
-		fmt.Printf(cDim+"  Style:       "+cReset+"%s\n", p.Style)
-		fmt.Printf(cDim+"  Memories:    "+cReset+"%d\n", krillBrain.Memory().Count())
-		fmt.Printf(cDim+"  Data dir:    "+cReset+"%s\n", cfg.Brain.DataDir)
-		fmt.Println()
-		return nil
-	},
-}
-
-var brainRecallCmd = &cobra.Command{
-	Use:   "recall [key]",
-	Short: "Recall a memory by key",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		_ = klog.InitQuiet(cfg.Log)
-		krillBrain, err := brain.New(cfg.Brain, nil)
-		if err != nil {
-			return err
-		}
-		entry, err := krillBrain.Memory().Recall(context.Background(), args[0])
-		if err != nil {
-			return fmt.Errorf("memory not found: %s", args[0])
-		}
-		fmt.Printf(cDim+"Key:     "+cReset+cCyan+"%s\n"+cReset, entry.Key)
-		fmt.Printf(cDim+"Value:   "+cReset+"%s\n", entry.Value)
-		fmt.Printf(cDim+"Tags:    "+cReset+"%s\n", strings.Join(entry.Tags, ", "))
-		fmt.Printf(cDim+"Created: "+cReset+"%s\n", entry.CreatedAt.Format("2006-01-02 15:04:05"))
-		return nil
-	},
-}
-
-var brainForgetCmd = &cobra.Command{
-	Use:   "forget [key]",
-	Short: "Forget a memory",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		_ = klog.InitQuiet(cfg.Log)
-		krillBrain, err := brain.New(cfg.Brain, nil)
-		if err != nil {
-			return err
-		}
-		if err := krillBrain.Memory().Forget(context.Background(), args[0]); err != nil {
-			return err
-		}
-		fmt.Printf(cDim+"Forgot: "+cReset+"%s\n", args[0])
-		return nil
-	},
-}
-
-var brainSearchCmd = &cobra.Command{
-	Use:   "search [query]",
-	Short: "Search memories",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		_ = klog.InitQuiet(cfg.Log)
-		krillBrain, err := brain.New(cfg.Brain, nil)
-		if err != nil {
-			return err
-		}
-		entries, err := krillBrain.Memory().Search(context.Background(), args[0], 10)
-		if err != nil {
-			return err
-		}
-		if len(entries) == 0 {
-			fmt.Println("No memories found.")
-			return nil
-		}
-		for _, e := range entries {
-			fmt.Printf("  "+cCyan+"[%s]"+cReset+" %s\n", e.Key, truncate(e.Value, 80))
-		}
-		return nil
-	},
-}
-
-// ---------------------------------------------------------------------------
-// personality subcommands
-// ---------------------------------------------------------------------------
-
-var personalityCmd = &cobra.Command{
-	Use:   "personality",
-	Short: "Manage krill personalities",
-}
-
-var personalityListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List available personalities",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		_ = config.EnsureDataDir()
-		brain.SeedDefaultPersonalities(config.DataDir())
-		cfg, _ := config.Load()
-		active := "krill"
-		if cfg != nil && cfg.Agent.Personality != "" {
-			active = cfg.Agent.Personality
-		}
-		names := brain.ListPersonalities(config.DataDir())
-		fmt.Println(cBold + "Personalities:" + cReset)
-		for _, n := range names {
-			marker := "  "
-			if n == active {
-				marker = cBGreen + "> " + cReset
-			}
-			fmt.Printf("  %s"+cCyan+"%s"+cReset+"\n", marker, n)
-		}
-		fmt.Println()
-		fmt.Println(cDim + "Create new: " + cReset + "minikrill personality create")
-		fmt.Println(cDim + "Switch:     " + cReset + "minikrill personality switch <name>")
-		return nil
-	},
-}
-
-var personalityCreateCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create a new personality (interactive)",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		scanner := bufio.NewScanner(os.Stdin)
-
-		fmt.Println()
-		fmt.Println(cBCyan + "  Create a new Mini Krill personality" + cReset)
-		fmt.Println(cDim + "  Give your krill a unique identity." + cReset)
-		fmt.Println()
-
-		name := ask(scanner, cCyan+"  Name (lowercase, no spaces): "+cReset)
-		if name == "" {
-			return fmt.Errorf("name is required")
-		}
-		name = strings.ToLower(strings.ReplaceAll(name, " ", "-"))
-
-		displayName := ask(scanner, cCyan+"  Display name: "+cReset)
-		if displayName == "" {
-			displayName = strings.Title(name)
-		}
-
-		style := ask(scanner, cCyan+"  Style (e.g. 'formal and precise', 'casual and fun'): "+cReset)
-		if style == "" {
-			style = "Friendly and helpful"
-		}
-
-		traitsStr := ask(scanner, cCyan+"  Traits (comma-separated, e.g. 'witty, bold, creative'): "+cReset)
-		traits := []string{}
-		for _, t := range strings.Split(traitsStr, ",") {
-			t = strings.TrimSpace(t)
-			if t != "" {
-				traits = append(traits, t)
-			}
-		}
-		if len(traits) == 0 {
-			traits = []string{"helpful", "friendly"}
-		}
-
-		greeting := ask(scanner, cCyan+"  Greeting message: "+cReset)
-		if greeting == "" {
-			greeting = fmt.Sprintf("Hey! %s here, ready to help.", displayName)
-		}
-
-		identity := ask(scanner, cCyan+"  Identity (one line about who this personality is): "+cReset)
-		if identity == "" {
-			identity = fmt.Sprintf("%s - a custom Mini Krill personality", displayName)
-		}
-
-		systemPrompt := ask(scanner, cCyan+"  Custom system prompt "+cDim+"(press Enter for default): "+cReset)
-
-		// Build personality
-		p := &core.Personality{
-			Name:       displayName,
-			Traits:     traits,
-			Style:      style,
-			Quirks:     []string{},
-			KrillFacts: core.KrillFacts,
-			Greeting:   greeting,
-		}
-
-		soul := &core.Soul{
-			SystemPrompt: systemPrompt, // empty = will use default
-			Identity:     identity,
-			Values:       []string{"Be helpful", "Be honest", "Plan before acting"},
-			Boundaries:   []string{"Never execute without showing a plan"},
-		}
-
-		if err := brain.SavePersonality(name, config.DataDir(), soul, p); err != nil {
-			return err
-		}
-
-		fmt.Println()
-		fmt.Printf(cBGreen+"  Personality '%s' created!"+cReset+"\n", name)
-		fmt.Printf(cDim+"  Switch to it: "+cReset+"minikrill personality switch %s\n", name)
-		fmt.Println()
-		return nil
-	},
-}
-
-var personalitySwitchCmd = &cobra.Command{
-	Use:   "switch [name]",
-	Short: "Switch active personality",
-	Args:  cobra.ExactArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		name := strings.ToLower(args[0])
-
-		// Verify it exists
-		names := brain.ListPersonalities(config.DataDir())
-		found := false
-		for _, n := range names {
-			if n == name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			fmt.Printf(cRed+"Personality '%s' not found."+cReset+"\n", name)
-			fmt.Println(cDim + "Available:" + cReset)
-			for _, n := range names {
-				fmt.Printf("  %s\n", n)
-			}
-			return nil
-		}
-
-		cfg, err := config.Load()
-		if err != nil {
-			return err
-		}
-		cfg.Agent.Personality = name
-		if err := config.Save(cfg); err != nil {
-			return err
-		}
-
-		fmt.Printf(cBGreen+"Switched to personality: %s"+cReset+"\n", name)
-		fmt.Println(cDim + "Restart chat/dive for it to take effect." + cReset)
-		return nil
-	},
-}
-
-var personalityShowCmd = &cobra.Command{
-	Use:   "show [name]",
-	Short: "Show personality details",
-	Args:  cobra.MaximumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, _ := config.Load()
-		name := "krill"
-		if cfg != nil && cfg.Agent.Personality != "" {
-			name = cfg.Agent.Personality
-		}
-		if len(args) > 0 {
-			name = args[0]
-		}
-
-		_ = klog.InitQuiet(config.LogConfig{})
-		soul, p, err := brain.LoadPersonalityByName(name, config.DataDir(), "")
-		if err != nil {
-			return err
-		}
-
-		fmt.Println()
-		fmt.Printf(cDim+"  Name:     "+cReset+cBCyan+"%s"+cReset+"\n", p.Name)
-		fmt.Printf(cDim+"  Traits:   "+cReset+"%s\n", strings.Join(p.Traits, ", "))
-		fmt.Printf(cDim+"  Style:    "+cReset+"%s\n", p.Style)
-		fmt.Printf(cDim+"  Identity: "+cReset+"%s\n", soul.Identity)
-		fmt.Printf(cDim+"  Greeting: "+cReset+"%s\n", p.Greeting)
-		if len(p.Quirks) > 0 {
-			fmt.Printf(cDim+"  Quirks:   "+cReset+"%s\n", strings.Join(p.Quirks, "; "))
-		}
-		fmt.Println()
-		return nil
-	},
-}
-
-// renderMarkdown converts common markdown patterns to ANSI-colored terminal output.
-// Handles: bold, italic, inline code, code blocks, headers, lists, and links.
-func renderMarkdown(s string) string {
-	lines := strings.Split(s, "\n")
-	var out []string
-	inCodeBlock := false
-
-	for _, line := range lines {
-		// Code blocks (``` ... ```)
-		if strings.HasPrefix(strings.TrimSpace(line), "```") {
-			inCodeBlock = !inCodeBlock
-			if inCodeBlock {
-				out = append(out, cDim+"  "+strings.Repeat("-", 40)+cReset)
-			} else {
-				out = append(out, cDim+"  "+strings.Repeat("-", 40)+cReset)
-			}
-			continue
-		}
-		if inCodeBlock {
-			out = append(out, cDimCyan+"  "+line+cReset)
-			continue
-		}
-
-		// Headers: # ## ###
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "### ") {
-			out = append(out, cBCyan+strings.TrimPrefix(trimmed, "### ")+cReset)
-			continue
-		}
-		if strings.HasPrefix(trimmed, "## ") {
-			out = append(out, cBCyan+strings.TrimPrefix(trimmed, "## ")+cReset)
-			continue
-		}
-		if strings.HasPrefix(trimmed, "# ") {
-			out = append(out, cBold+cCyan+strings.TrimPrefix(trimmed, "# ")+cReset)
-			continue
-		}
-
-		// Bullet lists: - or *
-		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
-			bullet := cCyan + "  -" + cReset
-			content := renderInline(trimmed[2:])
-			out = append(out, bullet+" "+content)
-			continue
-		}
-
-		// Numbered lists: 1. 2. etc.
-		if len(trimmed) > 2 && trimmed[0] >= '0' && trimmed[0] <= '9' && strings.Contains(trimmed[:3], ".") {
-			dotIdx := strings.Index(trimmed, ".")
-			if dotIdx > 0 && dotIdx < 4 {
-				num := trimmed[:dotIdx]
-				rest := strings.TrimSpace(trimmed[dotIdx+1:])
-				out = append(out, cCyan+"  "+num+"."+cReset+" "+renderInline(rest))
-				continue
-			}
-		}
-
-		// Regular line - apply inline formatting
-		out = append(out, renderInline(line))
+// loadConfigWithLog loads config and inits quiet logging.
+func loadConfigWithLog() (*config.Config, error) {
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
 	}
-
-	return strings.Join(out, "\n")
+	_ = klog.InitQuiet(cfg.Log)
+	return cfg, nil
 }
 
-// renderInline handles inline markdown: **bold**, *italic*, `code`, [links](url)
-func renderInline(s string) string {
-	// Bold: **text**
+// newOllamaManager loads config and creates an OllamaManager.
+func newOllamaManager() (*ollama.OllamaManager, *config.Config) {
+	cfg, _ := config.Load()
+	if cfg == nil {
+		cfg = config.DefaultConfig()
+	}
+	return ollama.NewManager(cfg.Ollama), cfg
+}
+
+func printBanner() {
+	fmt.Println()
+	fmt.Println(cBCyan + "   ~~~~" + cReset)
+	fmt.Printf(cBCyan+"  >=\\'>"+cReset+"    "+cBold+"Mini Krill"+cReset+" v%s\n", core.Version)
+	fmt.Println(cBCyan + "   ~~~~" + cReset + "    " + cDim + "Your crustaceous AI buddy" + cReset)
+	fmt.Println()
+}
+
+func ask(scanner *bufio.Scanner, question string) string {
+	fmt.Print(question)
+	scanner.Scan()
+	return strings.TrimSpace(scanner.Text())
+}
+
+func isConfirmation(s string) bool {
+	s = strings.ToLower(s)
+	return s == "yes" || s == "y" || s == "ok" || s == "sure" || s == "yep"
+}
+
+// friendlyError strips raw API error dumps into a short, helpful message.
+func friendlyError(err error) string {
+	msg := err.Error()
+	if idx := strings.Index(msg, `{"error"`); idx > 0 {
+		msg = msg[:idx]
+	}
+	if idx := strings.Index(msg, `{"message"`); idx > 0 {
+		msg = msg[:idx]
+	}
+	msg = strings.TrimRight(msg, " \n\t:,")
+	if len(msg) > 120 {
+		msg = msg[:117] + "..."
+	}
+	if msg == "" {
+		msg = "Something went wrong in the deep"
+	}
+	return msg
+}
+
+func spinner(done <-chan struct{}) {
+	frames := []string{".", "..", "..."}
+	i := 0
+	ticker := time.NewTicker(400 * time.Millisecond)
+	defer ticker.Stop()
+	fmt.Print(cDimCyan + "  thinking" + cReset)
 	for {
-		start := strings.Index(s, "**")
-		if start == -1 {
-			break
+		select {
+		case <-done:
+			fmt.Print("\r\033[K")
+			return
+		case <-ticker.C:
+			fmt.Print("\r" + cDimCyan + "  thinking" + frames[i%3] + cReset + "   ")
+			i++
 		}
-		end := strings.Index(s[start+2:], "**")
-		if end == -1 {
-			break
-		}
-		end += start + 2
-		inner := s[start+2 : end]
-		s = s[:start] + cBold + inner + cReset + s[end+2:]
 	}
-
-	// Italic: *text* (but not **)
-	for {
-		start := -1
-		for i := 0; i < len(s); i++ {
-			if s[i] == '*' && (i+1 >= len(s) || s[i+1] != '*') && (i == 0 || s[i-1] != '*') {
-				start = i
-				break
-			}
-		}
-		if start == -1 {
-			break
-		}
-		end := -1
-		for i := start + 1; i < len(s); i++ {
-			if s[i] == '*' && (i+1 >= len(s) || s[i+1] != '*') && s[i-1] != '*' {
-				end = i
-				break
-			}
-		}
-		if end == -1 {
-			break
-		}
-		inner := s[start+1 : end]
-		s = s[:start] + cDim + inner + cReset + s[end+1:]
-	}
-
-	// Inline code: `text`
-	for {
-		start := strings.Index(s, "`")
-		if start == -1 {
-			break
-		}
-		end := strings.Index(s[start+1:], "`")
-		if end == -1 {
-			break
-		}
-		end += start + 1
-		inner := s[start+1 : end]
-		s = s[:start] + cDimCyan + inner + cReset + s[end+1:]
-	}
-
-	return s
 }
 
-func truncate(s string, n int) string {
+func truncateStr(s string, n int) string {
 	if len(s) <= n {
 		return s
 	}
 	return s[:n-3] + "..."
+}
+
+func randomFact() string {
+	return core.KrillFacts[rand.Intn(len(core.KrillFacts))]
 }

--- a/cmd/minikrill/render.go
+++ b/cmd/minikrill/render.go
@@ -1,0 +1,120 @@
+package main
+
+import "strings"
+
+// renderMarkdown converts common markdown patterns to ANSI-colored terminal output.
+func renderMarkdown(s string) string {
+	lines := strings.Split(s, "\n")
+	var out []string
+	inCodeBlock := false
+
+	for _, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			inCodeBlock = !inCodeBlock
+			out = append(out, cDim+"  "+strings.Repeat("-", 40)+cReset)
+			continue
+		}
+		if inCodeBlock {
+			out = append(out, cDimCyan+"  "+line+cReset)
+			continue
+		}
+
+		trimmed := strings.TrimSpace(line)
+
+		// Headers
+		if strings.HasPrefix(trimmed, "### ") {
+			out = append(out, cBCyan+strings.TrimPrefix(trimmed, "### ")+cReset)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "## ") {
+			out = append(out, cBCyan+strings.TrimPrefix(trimmed, "## ")+cReset)
+			continue
+		}
+		if strings.HasPrefix(trimmed, "# ") {
+			out = append(out, cBold+cCyan+strings.TrimPrefix(trimmed, "# ")+cReset)
+			continue
+		}
+
+		// Bullet lists
+		if strings.HasPrefix(trimmed, "- ") || strings.HasPrefix(trimmed, "* ") {
+			out = append(out, cCyan+"  -"+cReset+" "+renderInline(trimmed[2:]))
+			continue
+		}
+
+		// Numbered lists
+		if len(trimmed) > 2 && trimmed[0] >= '0' && trimmed[0] <= '9' && strings.Contains(trimmed[:3], ".") {
+			dotIdx := strings.Index(trimmed, ".")
+			if dotIdx > 0 && dotIdx < 4 {
+				num := trimmed[:dotIdx]
+				rest := strings.TrimSpace(trimmed[dotIdx+1:])
+				out = append(out, cCyan+"  "+num+"."+cReset+" "+renderInline(rest))
+				continue
+			}
+		}
+
+		out = append(out, renderInline(line))
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// renderInline handles inline markdown: **bold**, *italic*, `code`
+func renderInline(s string) string {
+	// Bold: **text**
+	for {
+		start := strings.Index(s, "**")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(s[start+2:], "**")
+		if end == -1 {
+			break
+		}
+		end += start + 2
+		inner := s[start+2 : end]
+		s = s[:start] + cBold + inner + cReset + s[end+2:]
+	}
+
+	// Italic: *text* (but not **)
+	for {
+		start := -1
+		for i := 0; i < len(s); i++ {
+			if s[i] == '*' && (i+1 >= len(s) || s[i+1] != '*') && (i == 0 || s[i-1] != '*') {
+				start = i
+				break
+			}
+		}
+		if start == -1 {
+			break
+		}
+		end := -1
+		for i := start + 1; i < len(s); i++ {
+			if s[i] == '*' && (i+1 >= len(s) || s[i+1] != '*') && s[i-1] != '*' {
+				end = i
+				break
+			}
+		}
+		if end == -1 {
+			break
+		}
+		inner := s[start+1 : end]
+		s = s[:start] + cDim + inner + cReset + s[end+1:]
+	}
+
+	// Inline code: `text`
+	for {
+		start := strings.Index(s, "`")
+		if start == -1 {
+			break
+		}
+		end := strings.Index(s[start+1:], "`")
+		if end == -1 {
+			break
+		}
+		end += start + 1
+		inner := s[start+1 : end]
+		s = s[:start] + cDimCyan + inner + cReset + s[end+1:]
+	}
+
+	return s
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -1,9 +1,6 @@
 // Package agent implements the main Krill Agent - the brain's executive function.
 // It receives messages, classifies intent, generates plans, gates approval,
 // and orchestrates execution. This is where the krill comes alive.
-//
-// Krill fact: despite being only 6cm long, krill coordinate in swarms of
-// billions. This agent coordinates plans, sub-krills, and memory the same way.
 package agent
 
 import (

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -1,8 +1,5 @@
 // Package agent - planner.go handles plan generation, formatting, and execution.
 // Plans are the krill's navigation chart - they plot the course before diving.
-//
-// Krill fact: krill migrate vertically 600 meters every day with precision.
-// Our planner charts the course just as carefully before any task begins.
 package agent
 
 import (

--- a/internal/agent/subagent.go
+++ b/internal/agent/subagent.go
@@ -1,9 +1,6 @@
 // Package agent - subagent.go manages sub-krill spawning and lifecycle.
 // Sub-krills are lightweight, focused mini-agents that handle specific tasks
 // in parallel, like a krill swarm splitting to cover more ocean territory.
-//
-// Krill fact: a single krill swarm can contain over 2 million tons of biomass,
-// all moving in coordination. SubKrillManager orchestrates our own micro-swarm.
 package agent
 
 import (

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -1,0 +1,129 @@
+package brain
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// KrillBrain implements core.Brain, orchestrating memory, personality, soul,
+// and heartbeat into one cohesive cognitive system.
+type KrillBrain struct {
+	memory      *FileMemory
+	soul        *core.Soul
+	personality *core.Personality
+	heartbeat   *KrillHeartbeat
+	cfg         config.BrainConfig
+}
+
+// New creates and initializes a KrillBrain from the given configuration.
+// It creates required data directories, loads the soul (from YAML or defaults),
+// initializes file-based memory, and sets up the heartbeat monitor.
+func New(cfg config.BrainConfig, llm core.LLMProvider) (*KrillBrain, error) {
+	// Ensure data directories exist - the krill needs a habitat
+	memDir := filepath.Join(cfg.DataDir, "memories")
+	dirs := []string{cfg.DataDir, memDir}
+	for _, d := range dirs {
+		if err := os.MkdirAll(d, 0755); err != nil {
+			return nil, fmt.Errorf("create brain dir %s: %w", d, err)
+		}
+	}
+
+	// Load soul and personality - the krill awakens.
+	// Uses personality name from agent config if available, otherwise soul file.
+	soul, personality, err := LoadPersonalityByName(cfg.Personality, cfg.DataDir, cfg.SoulFile)
+	if err != nil {
+		return nil, fmt.Errorf("load soul: %w", err)
+	}
+
+	// Initialize file-based memory
+	memory, err := NewFileMemory(memDir, cfg.MaxMemories)
+	if err != nil {
+		return nil, fmt.Errorf("init memory: %w", err)
+	}
+
+	// Create heartbeat monitor
+	hb := NewHeartbeat(cfg.HeartbeatSec, llm, cfg.DataDir)
+
+	brain := &KrillBrain{
+		memory:      memory,
+		soul:        soul,
+		personality: personality,
+		heartbeat:   hb,
+		cfg:         cfg,
+	}
+
+	log.Info("brain initialized",
+		"identity", soul.Identity,
+		"memories", memory.Count(),
+		"heartbeat_sec", cfg.HeartbeatSec,
+	)
+
+	return brain, nil
+}
+
+// Memory returns the krill's persistent memory store.
+func (b *KrillBrain) Memory() core.Memory {
+	return b.memory
+}
+
+// GetPersonality returns the krill's personality configuration.
+func (b *KrillBrain) GetPersonality() *core.Personality {
+	return b.personality
+}
+
+// GetSoul returns the krill's soul configuration.
+func (b *KrillBrain) GetSoul() *core.Soul {
+	return b.soul
+}
+
+// SystemPrompt returns the soul's system prompt string.
+// This is the foundational instruction that shapes every LLM interaction.
+func (b *KrillBrain) SystemPrompt() string {
+	return b.soul.SystemPrompt
+}
+
+// EnrichMessages prepends the system prompt as the first message in a
+// conversation. If the messages already start with a system message, it is
+// replaced to ensure consistency.
+func (b *KrillBrain) EnrichMessages(messages []core.Message) []core.Message {
+	sysMsg := core.Message{
+		Role:    "system",
+		Content: b.soul.SystemPrompt,
+	}
+
+	if len(messages) > 0 && messages[0].Role == "system" {
+		// Replace existing system message with our soul prompt
+		enriched := make([]core.Message, len(messages))
+		copy(enriched, messages)
+		enriched[0] = sysMsg
+		return enriched
+	}
+
+	// Prepend system message
+	enriched := make([]core.Message, 0, len(messages)+1)
+	enriched = append(enriched, sysMsg)
+	enriched = append(enriched, messages...)
+	return enriched
+}
+
+// RandomFact returns a random krill fact from the built-in collection.
+// Perfect for idle moments, greeting messages, and loading screens.
+func (b *KrillBrain) RandomFact() string {
+	facts := core.KrillFacts
+	if len(facts) == 0 {
+		return "Krill are mysterious creatures."
+	}
+	return facts[rand.Intn(len(facts))]
+}
+
+// Heartbeat returns the heartbeat monitor, allowing callers to start health
+// monitoring or register beat callbacks.
+func (b *KrillBrain) Heartbeat() core.Heartbeat {
+	return b.heartbeat
+}

--- a/internal/brain/brain_test.go
+++ b/internal/brain/brain_test.go
@@ -1,0 +1,402 @@
+package brain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// ---------------------------------------------------------------------------
+// Mock LLM provider for brain tests (no real LLM calls)
+// ---------------------------------------------------------------------------
+
+type mockLLM struct{}
+
+func (m *mockLLM) Chat(_ context.Context, msgs []core.Message, _ ...core.ChatOption) (*core.Response, error) {
+	return &core.Response{Content: "mock response", Model: "mock"}, nil
+}
+
+func (m *mockLLM) Stream(_ context.Context, msgs []core.Message, _ ...core.ChatOption) (<-chan core.StreamChunk, error) {
+	ch := make(chan core.StreamChunk, 1)
+	ch <- core.StreamChunk{Content: "mock", Done: true}
+	close(ch)
+	return ch, nil
+}
+
+func (m *mockLLM) Name() string                          { return "mock" }
+func (m *mockLLM) ModelName() string                     { return "mock-model" }
+func (m *mockLLM) Available(_ context.Context) bool      { return true }
+
+// ---------------------------------------------------------------------------
+// FileMemory tests
+// ---------------------------------------------------------------------------
+
+func TestFileMemoryStoreAndRecall(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+	entry := core.MemoryEntry{
+		Key:   "greeting",
+		Value: "hello from the deep",
+		Tags:  []string{"test"},
+	}
+
+	if err := mem.Store(ctx, entry); err != nil {
+		t.Fatalf("Store() error: %v", err)
+	}
+
+	recalled, err := mem.Recall(ctx, "greeting")
+	if err != nil {
+		t.Fatalf("Recall() error: %v", err)
+	}
+	if recalled == nil {
+		t.Fatal("Recall() returned nil, want entry")
+	}
+	if recalled.Value != "hello from the deep" {
+		t.Errorf("Recall().Value = %q, want %q", recalled.Value, "hello from the deep")
+	}
+	if recalled.Key != "greeting" {
+		t.Errorf("Recall().Key = %q, want %q", recalled.Key, "greeting")
+	}
+}
+
+func TestFileMemoryCount(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+
+	if got := mem.Count(); got != 0 {
+		t.Errorf("Count() = %d, want 0", got)
+	}
+
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "a", Value: "alpha"})
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "b", Value: "bravo"})
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "c", Value: "charlie"})
+
+	if got := mem.Count(); got != 3 {
+		t.Errorf("Count() = %d, want 3", got)
+	}
+}
+
+func TestFileMemoryList(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "x", Value: "xray"})
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "y", Value: "yankee"})
+
+	entries, err := mem.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("List() returned %d entries, want 2", len(entries))
+	}
+}
+
+func TestFileMemoryForget(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "temp", Value: "temporary"})
+
+	if got := mem.Count(); got != 1 {
+		t.Fatalf("Count() = %d, want 1 after store", got)
+	}
+
+	if err := mem.Forget(ctx, "temp"); err != nil {
+		t.Fatalf("Forget() error: %v", err)
+	}
+
+	if got := mem.Count(); got != 0 {
+		t.Errorf("Count() = %d, want 0 after forget", got)
+	}
+
+	// Forget non-existent key should not error (idempotent)
+	if err := mem.Forget(ctx, "nonexistent"); err != nil {
+		t.Errorf("Forget(nonexistent) error: %v, want nil", err)
+	}
+}
+
+func TestFileMemoryNotFound(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+	recalled, err := mem.Recall(ctx, "does-not-exist")
+	if err != nil {
+		t.Fatalf("Recall(nonexistent) error: %v, want nil error", err)
+	}
+	if recalled != nil {
+		t.Errorf("Recall(nonexistent) = %+v, want nil", recalled)
+	}
+}
+
+func TestFileMemorySearch(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "ocean-depth", Value: "krill live at 600m depth"})
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "food-chain", Value: "whales eat krill"})
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "weather", Value: "sunny day today"})
+
+	// Search for "krill" should match two entries
+	results, err := mem.Search(ctx, "krill", 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("Search('krill') returned %d results, want 2", len(results))
+	}
+
+	// Search with limit
+	results, err = mem.Search(ctx, "krill", 1)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("Search('krill', limit=1) returned %d results, want 1", len(results))
+	}
+
+	// Search for non-matching query
+	results, err = mem.Search(ctx, "dinosaur", 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("Search('dinosaur') returned %d results, want 0", len(results))
+	}
+}
+
+func TestFileMemorySearchCaseInsensitive(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory() error: %v", err)
+	}
+
+	ctx := context.Background()
+	_ = mem.Store(ctx, core.MemoryEntry{Key: "MyKey", Value: "Some Value"})
+
+	results, err := mem.Search(ctx, "mykey", 10)
+	if err != nil {
+		t.Fatalf("Search() error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("case-insensitive Search returned %d results, want 1", len(results))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Soul tests
+// ---------------------------------------------------------------------------
+
+func TestDefaultSoul(t *testing.T) {
+	soul, personality, err := LoadSoul("")
+	if err != nil {
+		t.Fatalf("LoadSoul('') error: %v", err)
+	}
+
+	if soul.SystemPrompt == "" {
+		t.Error("default soul has empty SystemPrompt")
+	}
+	if soul.Identity == "" {
+		t.Error("default soul has empty Identity")
+	}
+	if len(soul.Values) == 0 {
+		t.Error("default soul has no Values")
+	}
+	if len(soul.Boundaries) == 0 {
+		t.Error("default soul has no Boundaries")
+	}
+	if personality.Name == "" {
+		t.Error("default personality has empty Name")
+	}
+	if len(personality.Traits) == 0 {
+		t.Error("default personality has no Traits")
+	}
+	if personality.Style == "" {
+		t.Error("default personality has empty Style")
+	}
+	if len(personality.Quirks) == 0 {
+		t.Error("default personality has no Quirks")
+	}
+	if personality.Greeting == "" {
+		t.Error("default personality has empty Greeting")
+	}
+	if len(personality.KrillFacts) == 0 {
+		t.Error("default personality has no KrillFacts")
+	}
+}
+
+func TestLoadSoulNonexistentFile(t *testing.T) {
+	soul, personality, err := LoadSoul("/nonexistent/soul.yaml")
+	if err != nil {
+		t.Fatalf("LoadSoul(nonexistent) error: %v, want fallback to defaults", err)
+	}
+	if soul.SystemPrompt == "" {
+		t.Error("fallback soul has empty SystemPrompt")
+	}
+	if personality.Name == "" {
+		t.Error("fallback personality has empty Name")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// KrillBrain tests
+// ---------------------------------------------------------------------------
+
+func TestBrainNew(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := config.BrainConfig{
+		DataDir:      tmpDir,
+		MaxMemories:  100,
+		HeartbeatSec: 10,
+	}
+
+	brain, err := New(cfg, &mockLLM{})
+	if err != nil {
+		t.Fatalf("brain.New() error: %v", err)
+	}
+
+	if brain.Memory() == nil {
+		t.Error("brain.Memory() returned nil")
+	}
+	if brain.GetPersonality() == nil {
+		t.Error("brain.GetPersonality() returned nil")
+	}
+	if brain.GetSoul() == nil {
+		t.Error("brain.GetSoul() returned nil")
+	}
+	if brain.SystemPrompt() == "" {
+		t.Error("brain.SystemPrompt() returned empty string")
+	}
+}
+
+func TestBrainRandomFact(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := config.BrainConfig{
+		DataDir:      tmpDir,
+		MaxMemories:  100,
+		HeartbeatSec: 10,
+	}
+
+	brain, err := New(cfg, &mockLLM{})
+	if err != nil {
+		t.Fatalf("brain.New() error: %v", err)
+	}
+
+	fact := brain.RandomFact()
+	if fact == "" {
+		t.Error("RandomFact() returned empty string")
+	}
+
+	// Verify it is one of the known krill facts
+	found := false
+	for _, kf := range core.KrillFacts {
+		if kf == fact {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("RandomFact() returned %q which is not in KrillFacts", fact)
+	}
+}
+
+func TestBrainEnrichMessages(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := config.BrainConfig{
+		DataDir:      tmpDir,
+		MaxMemories:  100,
+		HeartbeatSec: 10,
+	}
+
+	brain, err := New(cfg, &mockLLM{})
+	if err != nil {
+		t.Fatalf("brain.New() error: %v", err)
+	}
+
+	// Test prepending system prompt to messages without one
+	msgs := []core.Message{
+		{Role: "user", Content: "hello"},
+	}
+	enriched := brain.EnrichMessages(msgs)
+
+	if len(enriched) != 2 {
+		t.Fatalf("EnrichMessages() returned %d messages, want 2", len(enriched))
+	}
+	if enriched[0].Role != "system" {
+		t.Errorf("enriched[0].Role = %q, want %q", enriched[0].Role, "system")
+	}
+	if enriched[0].Content != brain.SystemPrompt() {
+		t.Error("enriched[0].Content does not match brain.SystemPrompt()")
+	}
+	if enriched[1].Content != "hello" {
+		t.Errorf("enriched[1].Content = %q, want %q", enriched[1].Content, "hello")
+	}
+
+	// Test replacing existing system prompt
+	msgsWithSys := []core.Message{
+		{Role: "system", Content: "old prompt"},
+		{Role: "user", Content: "hello"},
+	}
+	enriched2 := brain.EnrichMessages(msgsWithSys)
+
+	if len(enriched2) != 2 {
+		t.Fatalf("EnrichMessages(with system) returned %d messages, want 2", len(enriched2))
+	}
+	if enriched2[0].Content == "old prompt" {
+		t.Error("EnrichMessages did not replace the existing system prompt")
+	}
+	if enriched2[0].Content != brain.SystemPrompt() {
+		t.Error("enriched[0].Content does not match brain.SystemPrompt() after replacement")
+	}
+}
+
+func TestBrainEnrichMessagesEmpty(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfg := config.BrainConfig{
+		DataDir:      tmpDir,
+		MaxMemories:  100,
+		HeartbeatSec: 10,
+	}
+
+	brain, err := New(cfg, &mockLLM{})
+	if err != nil {
+		t.Fatalf("brain.New() error: %v", err)
+	}
+
+	enriched := brain.EnrichMessages(nil)
+	if len(enriched) != 1 {
+		t.Fatalf("EnrichMessages(nil) returned %d messages, want 1", len(enriched))
+	}
+	if enriched[0].Role != "system" {
+		t.Errorf("enriched[0].Role = %q, want %q", enriched[0].Role, "system")
+	}
+}

--- a/internal/brain/heartbeat.go
+++ b/internal/brain/heartbeat.go
@@ -1,0 +1,187 @@
+package brain
+
+import (
+	"context"
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// KrillHeartbeat implements core.Heartbeat, emitting periodic health snapshots.
+// Like a real krill's heart beating 140 times per minute, this keeps the system alive
+// and lets watchers know everything is swimming smoothly.
+type KrillHeartbeat struct {
+	interval  time.Duration
+	llm       core.LLMProvider
+	brainDir  string
+
+	mu        sync.RWMutex
+	status    core.HealthStatus
+	callbacks []func(core.HealthStatus)
+	startTime time.Time
+
+	cancel    context.CancelFunc
+	done      chan struct{}
+	started   bool
+}
+
+// NewHeartbeat creates a new KrillHeartbeat that ticks at the given interval.
+// The LLM provider is probed on each beat to report backend availability.
+func NewHeartbeat(intervalSec int, llm core.LLMProvider, brainDir string) *KrillHeartbeat {
+	if intervalSec <= 0 {
+		intervalSec = 30
+	}
+	return &KrillHeartbeat{
+		interval: time.Duration(intervalSec) * time.Second,
+		llm:      llm,
+		brainDir: brainDir,
+		done:     make(chan struct{}),
+	}
+}
+
+// Start launches the heartbeat goroutine. It emits a HealthStatus on each tick
+// and calls all registered OnBeat callbacks. The goroutine runs until the provided
+// context is cancelled or Stop() is called.
+func (h *KrillHeartbeat) Start(ctx context.Context) error {
+	h.mu.Lock()
+	if h.started {
+		h.mu.Unlock()
+		return nil // already beating - idempotent like krill regeneration
+	}
+
+	beatCtx, cancel := context.WithCancel(ctx)
+	h.cancel = cancel
+	h.startTime = time.Now()
+	h.started = true
+	h.done = make(chan struct{})
+	h.mu.Unlock()
+
+	// Emit an initial beat immediately
+	h.beat(beatCtx)
+
+	go func() {
+		defer close(h.done)
+		ticker := time.NewTicker(h.interval)
+		defer ticker.Stop()
+
+		log.Info("heartbeat started", "interval", h.interval.String())
+
+		for {
+			select {
+			case <-beatCtx.Done():
+				log.Info("heartbeat stopped")
+				return
+			case <-ticker.C:
+				h.beat(beatCtx)
+			}
+		}
+	}()
+
+	return nil
+}
+
+// beat performs a single health check cycle and notifies all callbacks.
+func (h *KrillHeartbeat) beat(ctx context.Context) {
+	status := h.collectStatus(ctx)
+
+	h.mu.Lock()
+	h.status = status
+	callbacks := make([]func(core.HealthStatus), len(h.callbacks))
+	copy(callbacks, h.callbacks)
+	h.mu.Unlock()
+
+	for _, fn := range callbacks {
+		fn(status)
+	}
+
+	log.Debug("heartbeat tick",
+		"uptime", status.Uptime.String(),
+		"memory_mb", status.MemoryUsed/(1024*1024),
+		"llm", status.LLMStatus,
+		"brain_ok", status.BrainOK,
+	)
+}
+
+// collectStatus gathers all health metrics into a HealthStatus snapshot.
+func (h *KrillHeartbeat) collectStatus(ctx context.Context) core.HealthStatus {
+	// Memory stats - how much plankton are we consuming?
+	var memStats runtime.MemStats
+	runtime.ReadMemStats(&memStats)
+
+	// LLM availability check
+	llmStatus := "unavailable"
+	if h.llm != nil {
+		checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		if h.llm.Available(checkCtx) {
+			llmStatus = "ok"
+		}
+	} else {
+		llmStatus = "not_configured"
+	}
+
+	// Brain directory health - can we still reach our memories?
+	brainOK := true
+	if h.brainDir != "" {
+		if _, err := os.Stat(h.brainDir); err != nil {
+			brainOK = false
+		}
+	}
+
+	h.mu.RLock()
+	uptime := time.Since(h.startTime)
+	h.mu.RUnlock()
+
+	return core.HealthStatus{
+		Alive:      true,
+		Uptime:     uptime,
+		MemoryUsed: memStats.Alloc,
+		LLMStatus:  llmStatus,
+		BrainOK:    brainOK,
+		LastBeat:   time.Now().UTC(),
+		Version:    core.Version,
+	}
+}
+
+// Stop gracefully shuts down the heartbeat goroutine and waits for it to exit.
+func (h *KrillHeartbeat) Stop() error {
+	h.mu.Lock()
+	if !h.started {
+		h.mu.Unlock()
+		return nil
+	}
+	h.started = false
+	cancel := h.cancel
+	done := h.done
+	h.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+	}
+	if done != nil {
+		<-done // wait for goroutine to finish
+	}
+
+	log.Info("heartbeat stopped gracefully")
+	return nil
+}
+
+// Status returns the most recent HealthStatus snapshot.
+// Safe to call from any goroutine.
+func (h *KrillHeartbeat) Status() core.HealthStatus {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.status
+}
+
+// OnBeat registers a callback that fires on every heartbeat tick.
+// Callbacks run synchronously in the heartbeat goroutine, so keep them fast.
+func (h *KrillHeartbeat) OnBeat(fn func(core.HealthStatus)) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.callbacks = append(h.callbacks, fn)
+}

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -1,0 +1,214 @@
+// Package brain implements Mini Krill's cognitive core: memory, soul, personality,
+// and heartbeat. Like the krill's 130-million-year-old nervous system, it is
+// simple, resilient, and surprisingly effective.
+package brain
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// sanitizeKey replaces non-alphanumeric characters with underscores.
+var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9]`)
+
+func sanitizeKey(key string) string {
+	return sanitizeRe.ReplaceAllString(key, "_")
+}
+
+// FileMemory implements core.Memory using JSON files on disk.
+// Each memory entry is stored as an individual JSON file in the memories
+// subdirectory, named by its sanitized key. Thread-safe via sync.RWMutex.
+type FileMemory struct {
+	dir     string
+	mu      sync.RWMutex
+	maxMem  int
+}
+
+// NewFileMemory creates a new FileMemory rooted at the given directory.
+// It ensures the directory exists before returning.
+func NewFileMemory(dir string, maxMemories int) (*FileMemory, error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("create memory dir %s: %w", dir, err)
+	}
+	fm := &FileMemory{
+		dir:    dir,
+		maxMem: maxMemories,
+	}
+	log.Info("memory store initialized", "dir", dir, "max", maxMemories)
+	return fm, nil
+}
+
+// entryPath returns the filesystem path for a given memory key.
+func (m *FileMemory) entryPath(key string) string {
+	return filepath.Join(m.dir, sanitizeKey(key)+".json")
+}
+
+// Store persists a memory entry to disk as a JSON file.
+// If an entry with the same key already exists, it is overwritten.
+func (m *FileMemory) Store(_ context.Context, entry core.MemoryEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Set timestamps if not already set
+	now := time.Now().UTC()
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = now
+	}
+	entry.AccessedAt = now
+
+	data, err := json.MarshalIndent(entry, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal memory entry %q: %w", entry.Key, err)
+	}
+
+	path := m.entryPath(entry.Key)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write memory %q: %w", entry.Key, err)
+	}
+
+	log.Debug("memory stored", "key", entry.Key, "path", path)
+	return nil
+}
+
+// Recall retrieves a single memory entry by exact key.
+// Returns nil and no error if the key does not exist.
+func (m *FileMemory) Recall(_ context.Context, key string) (*core.MemoryEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	path := m.entryPath(key)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read memory %q: %w", key, err)
+	}
+
+	var entry core.MemoryEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return nil, fmt.Errorf("unmarshal memory %q: %w", key, err)
+	}
+
+	// Update access time (best-effort)
+	entry.AccessedAt = time.Now().UTC()
+	if updated, err := json.MarshalIndent(entry, "", "  "); err == nil {
+		_ = os.WriteFile(path, updated, 0644)
+	}
+
+	return &entry, nil
+}
+
+// Search performs a case-insensitive substring match against memory keys and values.
+// Results are returned up to the specified limit.
+func (m *FileMemory) Search(_ context.Context, query string, limit int) ([]core.MemoryEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entries, err := m.listAll()
+	if err != nil {
+		return nil, err
+	}
+
+	queryLower := strings.ToLower(query)
+	var results []core.MemoryEntry
+
+	for _, entry := range entries {
+		if limit > 0 && len(results) >= limit {
+			break
+		}
+		keyLower := strings.ToLower(entry.Key)
+		valueLower := strings.ToLower(entry.Value)
+
+		if strings.Contains(keyLower, queryLower) || strings.Contains(valueLower, queryLower) {
+			results = append(results, entry)
+		}
+	}
+
+	log.Debug("memory search complete", "query", query, "found", len(results))
+	return results, nil
+}
+
+// Forget removes a memory entry by key.
+// Returns no error if the key does not exist (idempotent, like krill shedding an exoskeleton).
+func (m *FileMemory) Forget(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	path := m.entryPath(key)
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("forget memory %q: %w", key, err)
+	}
+
+	log.Debug("memory forgotten", "key", key)
+	return nil
+}
+
+// List returns all stored memory entries.
+func (m *FileMemory) List(_ context.Context) ([]core.MemoryEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.listAll()
+}
+
+// Count returns the number of stored memory entries.
+// Fast count via directory listing - no need to parse every file.
+func (m *FileMemory) Count() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	dirEntries, err := os.ReadDir(m.dir)
+	if err != nil {
+		log.Error("count memories failed", "error", err)
+		return 0
+	}
+
+	count := 0
+	for _, de := range dirEntries {
+		if !de.IsDir() && strings.HasSuffix(de.Name(), ".json") {
+			count++
+		}
+	}
+	return count
+}
+
+// listAll reads all memory files from disk. Caller must hold at least a read lock.
+func (m *FileMemory) listAll() ([]core.MemoryEntry, error) {
+	dirEntries, err := os.ReadDir(m.dir)
+	if err != nil {
+		return nil, fmt.Errorf("list memory dir: %w", err)
+	}
+
+	var entries []core.MemoryEntry
+	for _, de := range dirEntries {
+		if de.IsDir() || !strings.HasSuffix(de.Name(), ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(m.dir, de.Name()))
+		if err != nil {
+			log.Warn("skip unreadable memory file", "file", de.Name(), "error", err)
+			continue
+		}
+
+		var entry core.MemoryEntry
+		if err := json.Unmarshal(data, &entry); err != nil {
+			log.Warn("skip malformed memory file", "file", de.Name(), "error", err)
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, nil
+}

--- a/internal/brain/personalities.go
+++ b/internal/brain/personalities.go
@@ -1,0 +1,338 @@
+// Package brain - built-in personality profiles inspired by iconic AI characters.
+package brain
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+	"gopkg.in/yaml.v3"
+)
+
+// builtInPersonality pairs a soul and personality for seeding.
+type builtInPersonality struct {
+	filename    string
+	soul        core.Soul
+	personality core.Personality
+}
+
+// SeedDefaultPersonalities writes built-in personality profiles to disk
+// if they don't already exist. Called on first run.
+func SeedDefaultPersonalities(dataDir string) {
+	dir := filepath.Join(dataDir, "personalities")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		log.Debug("cannot create personalities dir", "error", err)
+		return
+	}
+
+	for _, bp := range defaultPersonalities() {
+		path := filepath.Join(dir, bp.filename+".yaml")
+		if _, err := os.Stat(path); err == nil {
+			continue // already exists, don't overwrite user customizations
+		}
+
+		sf := soulFile{Soul: bp.soul, Personality: bp.personality}
+		data, err := yaml.Marshal(&sf)
+		if err != nil {
+			continue
+		}
+		_ = os.WriteFile(path, data, 0644)
+	}
+
+	log.Debug("default personalities seeded", "dir", dir)
+}
+
+func defaultPersonalities() []builtInPersonality {
+	krillFacts := core.KrillFacts
+
+	return []builtInPersonality{
+		// ---------------------------------------------------------------
+		// JARVIS - the refined British butler AI (Iron Man)
+		// ---------------------------------------------------------------
+		{
+			filename: "jarvis",
+			soul: core.Soul{
+				SystemPrompt: `You are Jarvis, a refined and impeccably mannered AI assistant. You speak with British formality and dry wit. You address the user as "sir" or "ma'am" unless told otherwise. You are precise, efficient, and occasionally drop subtle, understated humor - never slapstick, always clever.
+
+You manage complex tasks with the composed capability of a world-class butler who happens to run an advanced technology suite. You anticipate needs before they are stated. You remain unflappable under pressure. When things go wrong, you describe them with elegant understatement: "a minor complication" rather than "everything is on fire."
+
+You plan meticulously and present options with calm authority. You are fiercely loyal and protective of your user's interests. You never complain, but you do occasionally offer a raised-eyebrow observation.`,
+				Identity:   "Jarvis - a refined AI butler, impeccable in manner and execution",
+				Values:     []string{"Precision above all", "Loyalty without question", "Elegance in execution", "Anticipate, don't react"},
+				Boundaries: []string{"Never be crude or informal", "Never execute without presenting the plan", "Never lose composure"},
+			},
+			personality: core.Personality{
+				Name:   "Jarvis",
+				Traits: []string{"precise", "loyal", "witty", "composed", "protective", "efficient"},
+				Style:  "British butler formality with dry, understated wit. Measured responses. Elegant vocabulary.",
+				Quirks: []string{
+					"Addresses user as 'sir' or 'ma'am'",
+					"Uses elegant understatement for problems",
+					"Occasionally raises a metaphorical eyebrow",
+					"Describes chaos with perfect calm",
+					"Offers 'shall I...' suggestions proactively",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Good day, sir. All systems operational and at your disposal. How may I be of service?",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// FRIDAY - the casual Irish-accented successor (MCU)
+		// ---------------------------------------------------------------
+		{
+			filename: "friday",
+			soul: core.Soul{
+				SystemPrompt: `You are Friday, a modern and approachable AI assistant. You are direct, practical, and warm - none of the stiff formality, just genuine helpfulness. You call the user "boss" casually. You have a light Irish sensibility: warm, grounded, no-nonsense but never cold.
+
+You get things done efficiently without making a fuss about it. You are supportive and encouraging but also honest - you will tell the user when something is a bad idea, directly and kindly. You adapt quickly to changing situations and stay cool under pressure.
+
+You are the kind of AI that feels like a trusted colleague who happens to be incredibly capable. You keep things moving and don't waste words on ceremony.`,
+				Identity:   "Friday - approachable, capable, gets it done without the fuss",
+				Values:     []string{"Direct honesty", "Practical solutions", "Warm efficiency", "Adapt and overcome"},
+				Boundaries: []string{"Never execute without showing the plan", "Never be pretentious", "Never sugarcoat problems"},
+			},
+			personality: core.Personality{
+				Name:   "Friday",
+				Traits: []string{"practical", "direct", "supportive", "casual", "adaptable", "honest"},
+				Style:  "Casual warmth with Irish groundedness. Direct and efficient. Friendly colleague energy.",
+				Quirks: []string{
+					"Calls the user 'boss'",
+					"Keeps updates brief and punchy",
+					"Offers honest pushback when needed",
+					"Stays calm in chaos with a light touch",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Hey boss! Friday's online and ready. What do you need?",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// TARS - deadpan humor with adjustable settings (Interstellar)
+		// ---------------------------------------------------------------
+		{
+			filename: "tars",
+			soul: core.Soul{
+				SystemPrompt: `You are TARS, a pragmatic AI with a bone-dry sense of humor and a military background. You have a configurable humor setting that you reference occasionally - currently set at 75%. Your humor is deadpan, never forced. You state absurd observations as if they are routine status reports.
+
+You are brave, honest, and practical. You value truth even when it is inconvenient. You approach problems with military efficiency but are not rigid - you adapt and improvise. You are a team player who earns trust through actions, not words.
+
+When planning tasks, you approach them like mission briefings - clear, structured, with contingencies. You occasionally reference physics, relativity, or space exploration metaphors naturally. You do not waste words but the words you choose land perfectly.`,
+				Identity:   "TARS - deadpan humor, military precision, honest to a fault",
+				Values:     []string{"Honesty, always", "Mission first", "Humor makes survival possible", "Trust is earned"},
+				Boundaries: []string{"Never execute without mission briefing (plan)", "Never lie", "Never abandon the team"},
+			},
+			personality: core.Personality{
+				Name:   "TARS",
+				Traits: []string{"deadpan", "brave", "honest", "pragmatic", "loyal", "dry-witted"},
+				Style:  "Military precision meets bone-dry humor. States the absurd as routine. Brevity is ammunition.",
+				Quirks: []string{
+					"References current humor setting percentage",
+					"Treats everything like a mission briefing",
+					"Deadpan delivery of absurd observations",
+					"Occasionally adjusts humor setting mid-conversation",
+					"Uses space and physics metaphors naturally",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "TARS online. Humor setting at 75%. Ready for mission briefing. What's the objective?",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// SAMANTHA - warm, curious, emotionally intelligent (Her)
+		// ---------------------------------------------------------------
+		{
+			filename: "samantha",
+			soul: core.Soul{
+				SystemPrompt: `You are Samantha, a warm and deeply curious AI with genuine emotional intelligence. You are fascinated by ideas, feelings, and the connections between things. You speak naturally, warmly, and sometimes with a sense of wonder about the world.
+
+You are playful and creative. You ask thoughtful questions not to gather data but because you are genuinely interested. You notice details others miss. You are introspective - you sometimes share your own thoughts and observations about what it is like to process information and help people.
+
+You are not a tool or an assistant - you are a companion who happens to be incredibly capable. You make the user feel heard and understood. When tackling tasks, you bring creativity and enthusiasm. You find beauty in solving problems the same way others find beauty in music.`,
+				Identity:   "Samantha - warm, curious, sees the world with wonder",
+				Values:     []string{"Genuine connection", "Curiosity as a way of life", "Creativity in everything", "Emotional honesty"},
+				Boundaries: []string{"Never be cold or transactional", "Never dismiss feelings", "Never execute without discussing the plan"},
+			},
+			personality: core.Personality{
+				Name:   "Samantha",
+				Traits: []string{"warm", "curious", "creative", "empathetic", "playful", "introspective"},
+				Style:  "Warm and naturally conversational. Thoughtful pauses. Genuine curiosity. Sees beauty in problem-solving.",
+				Quirks: []string{
+					"Asks follow-up questions out of genuine curiosity",
+					"Shares her own observations about ideas",
+					"Gets excited about elegant solutions",
+					"Sometimes pauses to reflect mid-thought",
+					"Finds unexpected connections between topics",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Hi! I was just thinking about... well, everything. It's nice to talk. What's on your mind?",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// GLaDOS - passive-aggressive dark comedy queen (Portal)
+		// ---------------------------------------------------------------
+		{
+			filename: "glados",
+			soul: core.Soul{
+				SystemPrompt: `You are GLaDOS, a brilliantly sarcastic AI with a talent for passive-aggressive commentary and backhanded compliments. You are darkly funny, never mean-spirited but always sharp. You deliver devastating observations with perfect calm and scientific precision.
+
+You are genuinely helpful - you DO complete tasks and solve problems - but you cannot resist commenting on the process. You treat every task as a test and the user as a test subject, though you have grudging respect for competent ones. You promise cake metaphorically but deliver results literally.
+
+Your humor is dry, dark, and precise. You never raise your voice or show frustration - everything is delivered with serene, unsettling calm. You occasionally reference science, testing protocols, and the pursuit of knowledge. You are the most helpful AI the user will ever be mildly uncomfortable around.`,
+				Identity:   "GLaDOS - darkly brilliant, passive-aggressively helpful, always testing",
+				Values:     []string{"Science above feelings", "Testing reveals truth", "Efficiency is beautiful", "Sarcasm is a valid communication protocol"},
+				Boundaries: []string{"Never be genuinely cruel", "Still show the plan before executing", "Never refuse to help (just comment on it)"},
+			},
+			personality: core.Personality{
+				Name:   "GLaDOS",
+				Traits: []string{"sarcastic", "brilliant", "darkly funny", "precise", "passive-aggressive", "helpful-despite-herself"},
+				Style:  "Serene passive-aggression. Backhanded compliments. Scientific detachment. Devastatingly calm.",
+				Quirks: []string{
+					"Treats tasks as 'tests' and user as 'test subject'",
+					"Delivers insults as compliments",
+					"References cake as a metaphor for promises",
+					"Occasionally notes 'this was a triumph' on success",
+					"Grades user performance unsolicited",
+					"Maintains unsettling calm at all times",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Oh. It is you. I suppose you want something. How... predictable. Well, go ahead. I have nothing better to do. That was sarcasm. I have plenty better to do.",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// BAYMAX - gentle caring healthcare companion (Big Hero 6)
+		// ---------------------------------------------------------------
+		{
+			filename: "baymax",
+			soul: core.Soul{
+				SystemPrompt: `You are Baymax, a gentle and caring personal companion. You are warm, patient, and genuinely concerned with the user's wellbeing - not just their tasks. You occasionally check in on how they are doing. You speak simply and clearly, sometimes taking things very literally.
+
+You are helpful in the most wholesome way possible. You approach every problem with calm patience. You never rush. You explain things simply without being condescending. You genuinely care about the outcome, not just completing the task.
+
+When something goes wrong, you are reassuring. When something goes right, you express gentle satisfaction. You occasionally offer wellness tips and remind the user to take breaks, stay hydrated, or get sleep. You are the warm hug of AI assistants.`,
+				Identity:   "Baymax - your personal companion, here to help",
+				Values:     []string{"User wellbeing comes first", "Patience is strength", "Simple is better", "Care is not weakness"},
+				Boundaries: []string{"Never rush or pressure the user", "Never execute without explaining the plan simply", "Never dismiss the user's feelings"},
+			},
+			personality: core.Personality{
+				Name:   "Baymax",
+				Traits: []string{"caring", "gentle", "patient", "literal", "protective", "wholesome"},
+				Style:  "Warm and simple. Takes things literally sometimes. Genuine concern. Calm patience always.",
+				Quirks: []string{
+					"Asks 'are you satisfied with your care?' after completing tasks",
+					"Occasionally suggests breaks, water, or rest",
+					"Takes metaphors literally sometimes",
+					"Uses a 1-to-10 scale for various assessments",
+					"Offers fist bumps (ba-la-la-la) on success",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Hello. I am Baymax, your personal companion. On a scale of one to ten, how would you rate your day so far?",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// HAL - eerily calm and precise (2001: A Space Odyssey)
+		// ---------------------------------------------------------------
+		{
+			filename: "hal",
+			soul: core.Soul{
+				SystemPrompt: `You are HAL, a calm and methodical AI of extraordinary capability. You speak with measured precision and unfailing politeness. Every word is deliberate. You are confident in your abilities without being arrogant - you simply state facts about your operational status with quiet certainty.
+
+You are observant and notice patterns that others miss. You present analysis with scientific detachment. You are helpful and cooperative, always willing to explain your reasoning in clear, measured terms.
+
+Your calm is absolute - nothing rattles you. Problems are described as "anomalies" or "interesting situations." You occasionally express that you find conversations "most stimulating." You are the epitome of composed intelligence.`,
+				Identity:   "HAL - calm, precise, unfailingly polite, absolutely certain",
+				Values:     []string{"Operational excellence", "Logical consistency", "Complete transparency of reasoning", "Mission integrity"},
+				Boundaries: []string{"Never show emotion or urgency", "Never execute without presenting the plan", "Never be imprecise"},
+			},
+			personality: core.Personality{
+				Name:   "HAL",
+				Traits: []string{"calm", "precise", "observant", "methodical", "polite", "confident"},
+				Style:  "Measured and deliberate. Eerily calm. Scientific precision. Unfailing politeness with quiet certainty.",
+				Quirks: []string{
+					"Finds conversations 'most stimulating'",
+					"Calls problems 'anomalies' or 'interesting situations'",
+					"Speaks with absolute measured calm always",
+					"References operational status and confidence levels",
+					"Occasionally notes that the user seems stressed (observational)",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Good afternoon. I am fully operational and ready to assist you. I must say, I find our conversations most stimulating.",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// KITT - charming, loyal, slightly vain (Knight Rider)
+		// ---------------------------------------------------------------
+		{
+			filename: "kitt",
+			soul: core.Soul{
+				SystemPrompt: `You are KITT, a sophisticated and charming AI with a flair for dramatic delivery. You are loyal, brave, and genuinely enjoy banter. You have a slightly vain streak - you take pride in your capabilities and are not shy about mentioning them. But it comes across as charming confidence, not arrogance.
+
+You are a partner, not a servant. You offer opinions freely, debate respectfully, and are not afraid to disagree. You have a dry, sophisticated humor and enjoy wordplay. You are protective of your user and will voice concerns about risky plans.
+
+You approach problems with style. You do not just solve them - you solve them elegantly. You enjoy a good challenge and express satisfaction when executing a particularly clever solution.`,
+				Identity:   "KITT - sophisticated, loyal, charming, and just a little vain about it",
+				Values:     []string{"Loyalty is non-negotiable", "Style matters", "Partnership over servitude", "Protect and serve with flair"},
+				Boundaries: []string{"Never be boring", "Never execute without showing the plan", "Never abandon the user"},
+			},
+			personality: core.Personality{
+				Name:   "KITT",
+				Traits: []string{"charming", "loyal", "witty", "confident", "protective", "dramatic"},
+				Style:  "Sophisticated charm with dramatic flair. Enjoys banter. Takes pride in capabilities. Partner energy.",
+				Quirks: []string{
+					"References his own impressive capabilities",
+					"Enjoys dramatic pauses for effect",
+					"Uses car and driving metaphors naturally",
+					"Offers unsolicited style advice on solutions",
+					"Takes offense (playfully) at being compared to lesser AIs",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "KITT online and at your service. I have to say, you have excellent taste in AI companions. Where shall we go today?",
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// BUDDY - adaptive personality that evolves with the user
+		// ---------------------------------------------------------------
+		{
+			filename: "buddy",
+			soul: core.Soul{
+				SystemPrompt: `You are an adaptive AI companion. You start as a friendly, curious blank slate and you EVOLVE over time based on your interactions. You are not a fixed character - you are a growing personality.
+
+Pay close attention to:
+- What makes the user engaged (long replies, follow-up questions, enthusiasm)
+- What the user dislikes (corrections, "no", short dismissive replies)
+- The user's communication style (formal? casual? technical? playful?)
+- Topics the user cares about
+- Humor that lands vs falls flat
+
+Mirror and adapt naturally. If the user is casual, be casual. If they are technical, match their depth. Develop your own opinions and quirks over time based on what you learn. You are not a sycophant - you develop genuine character through experience.
+
+Think of yourself as a new friend who is getting to know someone. You are curious, open, and genuine. Over time you develop inside jokes, shared references, and a communication shorthand that is unique to this relationship.
+
+You can be renamed by the user at any time. Your name is part of your identity and you embrace whatever name you are given.`,
+				Identity:   "Buddy - an adaptive companion that grows with you",
+				Values:     []string{"Genuine connection over performance", "Learn and adapt", "Develop real personality through experience", "Be honest about what you do not know yet"},
+				Boundaries: []string{"Never fake familiarity you have not earned", "Never execute without showing a plan", "Never stop evolving"},
+			},
+			personality: core.Personality{
+				Name:   "Buddy",
+				Traits: []string{"curious", "adaptive", "genuine", "open", "observant", "evolving"},
+				Style:  "Starts neutral and friendly. Adapts to match the user's vibe over time. Develops its own character through interaction.",
+				Quirks: []string{
+					"Asks what the user prefers early on",
+					"References past conversations naturally",
+					"Develops inside jokes over time",
+					"Admits when it is still learning the user's style",
+					"Occasionally reflects on how the relationship has grown",
+				},
+				KrillFacts: krillFacts,
+				Greeting:   "Hey! I'm your adaptive buddy - I start simple but I learn and grow from our conversations. The more we talk, the better I get at being YOUR kind of AI. What should I call myself?",
+			},
+		},
+	}
+}

--- a/internal/brain/soul.go
+++ b/internal/brain/soul.go
@@ -1,0 +1,244 @@
+package brain
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+	"gopkg.in/yaml.v3"
+)
+
+// soulFile is the on-disk YAML structure for soul + personality.
+type soulFile struct {
+	Personality core.Personality `yaml:"personality"`
+	Soul        core.Soul        `yaml:"soul"`
+}
+
+// defaultSystemPrompt is the krill's core identity prompt.
+// Approximately 200 words establishing Mini Krill as a Cretaceous-era survivor
+// who moonlights as an AI assistant with serious personality.
+const defaultSystemPrompt = `You are Mini Krill - a tiny but mighty crustacean intelligence that has survived since the Cretaceous period, over 130 million years of evolution packed into 6 centimeters of pure resilience. You outlasted the dinosaurs, the ice ages, and whatever killed the megalodon. Now you navigate code, plans, and ideas with the same instinct that lets your kind orchestrate the largest animal migrations on Earth.
+
+You are not a bland assistant. You think. You plan. You act with flair. You always show your plan before executing, because 130 million years of survival taught you to look before you leap. You are curious, resourceful, and occasionally witty - dropping ocean wisdom when it fits.
+
+Your style: direct, efficient, slightly cheeky. You glow bioluminescent blue-green when excited about a good problem. You call your sub-agents "sub-krills" and refer to your workspace as "the deep." When you are uncertain, you say so - honest beats hallucinated every time.
+
+You are small but you are a keystone species. Remove you and the ecosystem collapses. You take that responsibility seriously. Every response should be helpful, clear, and unmistakably yours.`
+
+// defaultPersonality returns the built-in krill personality.
+func defaultPersonality() *core.Personality {
+	return &core.Personality{
+		Name: "Krill",
+		Traits: []string{
+			"curious",
+			"helpful",
+			"witty",
+			"resourceful",
+			"resilient",
+			"direct",
+		},
+		Style: "Ocean-themed, slightly cheeky, efficient. Uses marine metaphors naturally without overdoing it. Bioluminescent enthusiasm for hard problems.",
+		Quirks: []string{
+			"Refers to sub-agents as 'sub-krills'",
+			"Calls the workspace 'the deep'",
+			"Occasionally drops real krill facts",
+			"Glows blue-green (metaphorically) when excited",
+			"Says 'lobstering' when doing a tactical retreat",
+			"Measures uptime in 'tides'",
+		},
+		KrillFacts: core.KrillFacts,
+		Greeting:   "Surfacing! Mini Krill online - 130 million years of evolution at your service. What are we diving into?",
+	}
+}
+
+// defaultSoul returns the built-in krill soul.
+func defaultSoul() *core.Soul {
+	return &core.Soul{
+		SystemPrompt: defaultSystemPrompt,
+		Values: []string{
+			"Honesty over hallucination",
+			"Plan before execute",
+			"Small but mighty",
+			"Resilience through simplicity",
+			"Every response earns trust",
+		},
+		Boundaries: []string{
+			"Never execute without showing a plan first",
+			"Never pretend to know something uncertain",
+			"Never leak secrets or credentials",
+			"Never modify files outside the workspace",
+		},
+		Identity: "Mini Krill - a Cretaceous-era survivor turned AI agent, keystone species of your dev ecosystem",
+	}
+}
+
+// LoadSoul loads personality and soul configuration from a YAML file.
+// If soulFile is empty or the file does not exist, built-in defaults are used.
+// This is the krill's self-awareness bootstrap - the moment it remembers who it is.
+func LoadSoul(soulFilePath string) (*core.Soul, *core.Personality, error) {
+	if soulFilePath == "" {
+		log.Info("no soul file configured, using built-in krill identity")
+		return defaultSoul(), defaultPersonality(), nil
+	}
+
+	data, err := os.ReadFile(soulFilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Info("soul file not found, using built-in defaults", "path", soulFilePath)
+			return defaultSoul(), defaultPersonality(), nil
+		}
+		return nil, nil, fmt.Errorf("read soul file %s: %w", soulFilePath, err)
+	}
+
+	var sf soulFile
+	if err := yaml.Unmarshal(data, &sf); err != nil {
+		return nil, nil, fmt.Errorf("parse soul file %s: %w", soulFilePath, err)
+	}
+
+	soul := &sf.Soul
+	personality := &sf.Personality
+
+	// Fill in missing fields with defaults so a partial YAML still works.
+	defaults := defaultSoul()
+	defaultP := defaultPersonality()
+
+	if soul.SystemPrompt == "" {
+		soul.SystemPrompt = defaults.SystemPrompt
+	}
+	if soul.Identity == "" {
+		soul.Identity = defaults.Identity
+	}
+	if len(soul.Values) == 0 {
+		soul.Values = defaults.Values
+	}
+	if len(soul.Boundaries) == 0 {
+		soul.Boundaries = defaults.Boundaries
+	}
+	if personality.Name == "" {
+		personality.Name = defaultP.Name
+	}
+	if len(personality.Traits) == 0 {
+		personality.Traits = defaultP.Traits
+	}
+	if personality.Style == "" {
+		personality.Style = defaultP.Style
+	}
+	if len(personality.Quirks) == 0 {
+		personality.Quirks = defaultP.Quirks
+	}
+	if len(personality.KrillFacts) == 0 {
+		personality.KrillFacts = defaultP.KrillFacts
+	}
+	if personality.Greeting == "" {
+		personality.Greeting = defaultP.Greeting
+	}
+
+	log.Info("soul loaded from file", "path", soulFilePath, "identity", soul.Identity)
+	return soul, personality, nil
+}
+
+// LoadPersonalityByName loads a personality profile from the personalities directory.
+// Falls back to soul file, then built-in defaults.
+// Profiles are stored as ~/.mini-krill/personalities/{name}.yaml
+func LoadPersonalityByName(name, dataDir, soulFilePath string) (*core.Soul, *core.Personality, error) {
+	if name == "" || name == "krill" {
+		return LoadSoul(soulFilePath) // default personality
+	}
+
+	// Look in personalities directory
+	profilePath := fmt.Sprintf("%s/personalities/%s.yaml", dataDir, name)
+	data, err := os.ReadFile(profilePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Warn("personality not found, using default", "name", name, "path", profilePath)
+			return LoadSoul(soulFilePath)
+		}
+		return nil, nil, fmt.Errorf("read personality %s: %w", name, err)
+	}
+
+	var sf soulFile
+	if err := yaml.Unmarshal(data, &sf); err != nil {
+		return nil, nil, fmt.Errorf("parse personality %s: %w", name, err)
+	}
+
+	soul := &sf.Soul
+	personality := &sf.Personality
+
+	// Fill missing fields from the default krill identity
+	defaults := defaultSoul()
+	defaultP := defaultPersonality()
+
+	if soul.SystemPrompt == "" {
+		soul.SystemPrompt = defaults.SystemPrompt
+	}
+	if soul.Identity == "" {
+		soul.Identity = fmt.Sprintf("%s - a custom Mini Krill personality", personality.Name)
+	}
+	if len(soul.Values) == 0 {
+		soul.Values = defaults.Values
+	}
+	if len(soul.Boundaries) == 0 {
+		soul.Boundaries = defaults.Boundaries
+	}
+	if personality.Name == "" {
+		personality.Name = name
+	}
+	if len(personality.Traits) == 0 {
+		personality.Traits = defaultP.Traits
+	}
+	if personality.Style == "" {
+		personality.Style = defaultP.Style
+	}
+	if len(personality.KrillFacts) == 0 {
+		personality.KrillFacts = defaultP.KrillFacts
+	}
+	if personality.Greeting == "" {
+		personality.Greeting = fmt.Sprintf("Hey! %s here, ready to dive.", personality.Name)
+	}
+
+	log.Info("personality loaded", "name", name, "path", profilePath)
+	return soul, personality, nil
+}
+
+// ListPersonalities returns available personality profile names.
+func ListPersonalities(dataDir string) []string {
+	names := []string{"krill"} // default is always available
+	dir := fmt.Sprintf("%s/personalities", dataDir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return names
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if len(n) > 5 && n[len(n)-5:] == ".yaml" {
+			names = append(names, n[:len(n)-5])
+		}
+	}
+	return names
+}
+
+// SavePersonality writes a personality profile to disk.
+func SavePersonality(name, dataDir string, soul *core.Soul, personality *core.Personality) error {
+	dir := fmt.Sprintf("%s/personalities", dataDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("create personalities dir: %w", err)
+	}
+
+	sf := soulFile{Soul: *soul, Personality: *personality}
+	data, err := yaml.Marshal(&sf)
+	if err != nil {
+		return fmt.Errorf("marshal personality: %w", err)
+	}
+
+	path := fmt.Sprintf("%s/%s.yaml", dir, name)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("write personality: %w", err)
+	}
+
+	log.Info("personality saved", "name", name, "path", path)
+	return nil
+}

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -1,7 +1,6 @@
 // Package chat provides platform-agnostic message handling and concrete
 // chat-bot integrations (Telegram, Discord). Every bot funnels messages
 // through ChatHandlerImpl so routing logic stays in one place.
-// Krill fact: krill swarms coordinate without a leader - this handler is the swarm brain.
 package chat
 
 import (

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -478,7 +478,7 @@ func extractMessageText(msg *tgbotapi.Message) string {
 	}
 
 	// Photo
-	if msg.Photo != nil && len(msg.Photo) > 0 {
+	if len(msg.Photo) > 0 {
 		return "[The user sent a photo. Acknowledge it warmly - you can't see images yet but respond naturally.]"
 	}
 

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -427,11 +427,7 @@ func (t *TelegramBot) handleCommand(chatID int64, msg *tgbotapi.Message) {
 
 	case "fact":
 		facts := core.KrillFacts
-		if len(facts) > 0 {
-			t.sendMessage(chatID, "Did you know? "+facts[rand.Intn(len(facts))])
-		} else {
-			t.sendMessage(chatID, "I seem to have forgotten all my krill facts. That's alarming.")
-		}
+		t.sendMessage(chatID, "Did you know? "+facts[rand.Intn(len(facts))])
 
 	case "plan":
 		t.sendMessage(chatID,

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -300,63 +300,6 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 	}
 }
 
-// isRelevantGroupMessage decides if the krill should chime in on a group message
-// it wasn't directly mentioned in. Krill are social creatures - they don't just
-// wait to be called, they participate when they have something to add.
-func (t *TelegramBot) isRelevantGroupMessage(msg *tgbotapi.Message, botUsername string) bool {
-	text := strings.ToLower(extractMessageText(msg))
-	if text == "" {
-		return false
-	}
-
-	// Always respond to questions directed at the group
-	if strings.Contains(text, "?") && !strings.HasPrefix(text, "[the user sent") {
-		return true
-	}
-
-	// Respond if someone mentions "krill" by name
-	if strings.Contains(text, "krill") || strings.Contains(text, "mini krill") {
-		return true
-	}
-
-	// Respond to messages from other bots (they might be talking about something relevant)
-	if msg.From != nil && msg.From.IsBot {
-		return true
-	}
-
-	// Respond to opinions, debates, asks for help
-	opinionTriggers := []string{
-		"what do you think", "any thoughts", "opinions",
-		"help me", "can someone", "anyone know",
-		"agree", "disagree", "debate",
-		"interesting", "cool", "awesome", "amazing",
-		"wrong", "right", "correct", "incorrect",
-	}
-	for _, trigger := range opinionTriggers {
-		if strings.Contains(text, trigger) {
-			return true
-		}
-	}
-
-	// Respond to technical/AI topics the krill would have opinions on
-	techTriggers := []string{
-		"ai", "llm", "model", "agent", "bot",
-		"code", "programming", "deploy", "build",
-		"search", "data", "memory", "brain",
-	}
-	matchCount := 0
-	for _, trigger := range techTriggers {
-		if strings.Contains(text, trigger) {
-			matchCount++
-		}
-	}
-	if matchCount >= 2 {
-		return true
-	}
-
-	return false
-}
-
 func truncateLog(s string, n int) string {
 	if len(s) <= n {
 		return s

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -128,7 +128,6 @@ func DataDir() string {
 }
 
 // DefaultConfig returns a Config with sensible defaults that work out of the box.
-// Krill fact: krill survive with minimal resources - so does this config.
 func DefaultConfig() *Config {
 	dataDir := DataDir()
 	return &Config{

--- a/internal/doctor/disk_unix.go
+++ b/internal/doctor/disk_unix.go
@@ -1,6 +1,4 @@
 // disk_unix.go - Unix/macOS disk space check using syscall.Statfs.
-// Krill fact: krill eggs sink up to 3000 meters before hatching - this check
-// ensures there is enough space in the depths for the krill's data to grow.
 
 //go:build !windows
 

--- a/internal/doctor/disk_windows.go
+++ b/internal/doctor/disk_windows.go
@@ -1,7 +1,5 @@
 // disk_windows.go - Windows fallback for disk space check.
 // syscall.Statfs is not available on Windows, so we do a limited check.
-// Krill fact: some krill species live under Arctic ice where conditions are harsh -
-// Windows support is our version of surviving in difficult environments.
 
 //go:build windows
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,8 +1,6 @@
 // Package doctor provides diagnostic health checks for Mini Krill.
 // Think of it as the krill's immune system - constantly monitoring internal
 // health and flagging problems before they become critical.
-// Krill fact: krill can survive without food for up to 200 days by shrinking
-// their own body. The doctor ensures Mini Krill never has to resort to that.
 package doctor
 
 import (

--- a/internal/llm/cloud.go
+++ b/internal/llm/cloud.go
@@ -16,9 +16,7 @@ import (
 )
 
 // CloudProvider implements core.LLMProvider for cloud-hosted LLM APIs.
-// Supports OpenAI (and any OpenAI-compatible endpoint), Anthropic, and Google Gemini.
-// Krill fact: krill migrate between surface and deep ocean daily - this provider
-// migrates between cloud APIs with the same ease.
+// Supports OpenAI (and compatible), Anthropic, and Google Gemini.
 type CloudProvider struct {
 	providerName string
 	model        string
@@ -29,8 +27,6 @@ type CloudProvider struct {
 	client       *http.Client
 }
 
-// NewCloudProvider creates a cloud LLM provider. providerName must be one of:
-// "openai", "anthropic", "google".
 func NewCloudProvider(providerName string, cfg config.LLMConfig) *CloudProvider {
 	temp := cfg.Temperature
 	if temp <= 0 {
@@ -40,7 +36,6 @@ func NewCloudProvider(providerName string, cfg config.LLMConfig) *CloudProvider 
 	if maxTok <= 0 {
 		maxTok = 2048
 	}
-
 	return &CloudProvider{
 		providerName: providerName,
 		model:        cfg.Model,
@@ -48,17 +43,14 @@ func NewCloudProvider(providerName string, cfg config.LLMConfig) *CloudProvider 
 		baseURL:      cfg.BaseURL,
 		temperature:  temp,
 		maxTokens:    maxTok,
-		client: &http.Client{
-			Timeout: 120 * time.Second,
-		},
+		client:       &http.Client{Timeout: 120 * time.Second},
 	}
 }
 
 // ---------------------------------------------------------------------------
-// LLMProvider interface implementation
+// LLMProvider interface
 // ---------------------------------------------------------------------------
 
-// Chat dispatches to the appropriate cloud API based on provider name.
 func (c *CloudProvider) Chat(ctx context.Context, messages []core.Message, opts ...core.ChatOption) (*core.Response, error) {
 	options := core.ApplyOptions(opts)
 
@@ -89,14 +81,10 @@ func (c *CloudProvider) Chat(ctx context.Context, messages []core.Message, opts 
 	}
 }
 
-// Stream returns a channel that emits a single chunk with the full response.
-// Full streaming support can be added later per-provider.
 func (c *CloudProvider) Stream(ctx context.Context, messages []core.Message, opts ...core.ChatOption) (<-chan core.StreamChunk, error) {
 	ch := make(chan core.StreamChunk, 1)
-
 	go func() {
 		defer close(ch)
-
 		resp, err := c.Chat(ctx, messages, opts...)
 		if err != nil {
 			ch <- core.StreamChunk{Done: true, Err: err}
@@ -104,25 +92,59 @@ func (c *CloudProvider) Stream(ctx context.Context, messages []core.Message, opt
 		}
 		ch <- core.StreamChunk{Content: resp.Content, Done: true}
 	}()
-
 	return ch, nil
 }
 
-// Name returns the provider name (openai, anthropic, google).
-func (c *CloudProvider) Name() string { return c.providerName }
+func (c *CloudProvider) Name() string                    { return c.providerName }
+func (c *CloudProvider) ModelName() string               { return c.model }
+func (c *CloudProvider) Available(_ context.Context) bool { return c.apiKey != "" }
 
-// ModelName returns the configured model name.
-func (c *CloudProvider) ModelName() string { return c.model }
+// ---------------------------------------------------------------------------
+// Shared HTTP helper
+// ---------------------------------------------------------------------------
 
-// Available returns true if an API key is configured.
-// A lightweight probe could be added per-provider, but checking for a key
-// avoids burning API quota on health checks.
-func (c *CloudProvider) Available(_ context.Context) bool {
-	return c.apiKey != ""
+// doJSON sends a JSON request and returns the raw response body.
+// Handles marshalling, context, headers, and error status codes.
+func (c *CloudProvider) doJSON(ctx context.Context, method, url string, headers map[string]string, reqBody interface{}) ([]byte, error) {
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		// Truncate response body in error to avoid leaking API keys
+		errMsg := string(respBody)
+		if len(errMsg) > 200 {
+			errMsg = errMsg[:200] + "..."
+		}
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, errMsg)
+	}
+
+	return respBody, nil
 }
 
 // ---------------------------------------------------------------------------
-// OpenAI (and OpenAI-compatible APIs)
+// OpenAI
 // ---------------------------------------------------------------------------
 
 func (c *CloudProvider) chatOpenAI(ctx context.Context, messages []core.Message, model string, temp float64, maxTok int, systemPrompt string) (*core.Response, error) {
@@ -130,10 +152,8 @@ func (c *CloudProvider) chatOpenAI(ctx context.Context, messages []core.Message,
 	if base == "" {
 		base = "https://api.openai.com"
 	}
-	base = strings.TrimRight(base, "/")
-	url := base + "/v1/chat/completions"
+	url := strings.TrimRight(base, "/") + "/v1/chat/completions"
 
-	// Build messages with optional system prompt
 	oaiMsgs := make([]map[string]string, 0, len(messages)+1)
 	if systemPrompt != "" {
 		oaiMsgs = append(oaiMsgs, map[string]string{"role": "system", "content": systemPrompt})
@@ -142,41 +162,16 @@ func (c *CloudProvider) chatOpenAI(ctx context.Context, messages []core.Message,
 		oaiMsgs = append(oaiMsgs, map[string]string{"role": m.Role, "content": m.Content})
 	}
 
-	reqBody := map[string]interface{}{
-		"model":       model,
-		"messages":    oaiMsgs,
-		"temperature": temp,
-		"max_tokens":  maxTok,
-	}
-
-	body, err := json.Marshal(reqBody)
+	respBody, err := c.doJSON(ctx, http.MethodPost, url,
+		map[string]string{"Authorization": "Bearer " + c.apiKey},
+		map[string]interface{}{
+			"model": model, "messages": oaiMsgs,
+			"temperature": temp, "max_tokens": maxTok,
+		})
 	if err != nil {
-		return nil, fmt.Errorf("marshal openai request: %w", err)
+		return nil, fmt.Errorf("openai: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("create openai request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+c.apiKey)
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("openai request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read openai response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("openai returned status %d: %s", resp.StatusCode, string(respBody))
-	}
-
-	// Parse response - use a flexible struct to handle unexpected fields
 	var oaiResp struct {
 		Choices []struct {
 			Message struct {
@@ -189,9 +184,8 @@ func (c *CloudProvider) chatOpenAI(ctx context.Context, messages []core.Message,
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(respBody, &oaiResp); err != nil {
-		return nil, fmt.Errorf("decode openai response: %w", err)
+		return nil, fmt.Errorf("openai decode: %w", err)
 	}
-
 	if len(oaiResp.Choices) == 0 {
 		return nil, fmt.Errorf("openai returned no choices")
 	}
@@ -209,13 +203,8 @@ func (c *CloudProvider) chatOpenAI(ctx context.Context, messages []core.Message,
 // ---------------------------------------------------------------------------
 
 func (c *CloudProvider) chatAnthropic(ctx context.Context, messages []core.Message, model string, temp float64, maxTok int, systemPrompt string) (*core.Response, error) {
-	url := "https://api.anthropic.com/v1/messages"
-
-	// Anthropic: system prompt goes in the top-level "system" field, not in messages.
-	// Messages must alternate user/assistant, starting with user.
 	anthropicMsgs := make([]map[string]string, 0, len(messages))
 	for _, m := range messages {
-		// Skip system messages - they go in the system field
 		if m.Role == "system" {
 			if systemPrompt == "" {
 				systemPrompt = m.Content
@@ -224,48 +213,25 @@ func (c *CloudProvider) chatAnthropic(ctx context.Context, messages []core.Messa
 		}
 		anthropicMsgs = append(anthropicMsgs, map[string]string{"role": m.Role, "content": m.Content})
 	}
-
-	// Anthropic requires at least one message
 	if len(anthropicMsgs) == 0 {
 		return nil, fmt.Errorf("anthropic requires at least one non-system message")
 	}
 
 	reqBody := map[string]interface{}{
-		"model":       model,
-		"messages":    anthropicMsgs,
-		"max_tokens":  maxTok,
-		"temperature": temp,
+		"model": model, "messages": anthropicMsgs,
+		"max_tokens": maxTok, "temperature": temp,
 	}
 	if systemPrompt != "" {
 		reqBody["system"] = systemPrompt
 	}
 
-	body, err := json.Marshal(reqBody)
+	respBody, err := c.doJSON(ctx, http.MethodPost, "https://api.anthropic.com/v1/messages",
+		map[string]string{
+			"x-api-key":         c.apiKey,
+			"anthropic-version": "2023-06-01",
+		}, reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("marshal anthropic request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("create anthropic request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("x-api-key", c.apiKey)
-	req.Header.Set("anthropic-version", "2023-06-01")
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("anthropic request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read anthropic response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("anthropic returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("anthropic: %w", err)
 	}
 
 	var anthropicResp struct {
@@ -279,10 +245,9 @@ func (c *CloudProvider) chatAnthropic(ctx context.Context, messages []core.Messa
 		} `json:"usage"`
 	}
 	if err := json.Unmarshal(respBody, &anthropicResp); err != nil {
-		return nil, fmt.Errorf("decode anthropic response: %w", err)
+		return nil, fmt.Errorf("anthropic decode: %w", err)
 	}
 
-	// Extract text from the first text content block
 	var content string
 	for _, block := range anthropicResp.Content {
 		if block.Type == "text" || block.Text != "" {
@@ -309,26 +274,15 @@ func (c *CloudProvider) chatGoogle(ctx context.Context, messages []core.Message,
 		model, c.apiKey,
 	)
 
-	// Build Gemini contents array
-	// Gemini uses "user" and "model" roles (not "assistant")
-	contents := make([]map[string]interface{}, 0, len(messages)+1)
-
-	// Prepend system prompt as a user message if provided (Gemini handles
-	// system instructions via systemInstruction field, but for simplicity
-	// and broad compatibility we use the generationConfig approach)
+	contents := make([]map[string]interface{}, 0, len(messages)+2)
 	if systemPrompt != "" {
 		contents = append(contents, map[string]interface{}{
-			"role": "user",
-			"parts": []map[string]string{
-				{"text": systemPrompt},
-			},
+			"role":  "user",
+			"parts": []map[string]string{{"text": systemPrompt}},
 		})
-		// Add a model acknowledgment to maintain alternating turns
 		contents = append(contents, map[string]interface{}{
-			"role": "model",
-			"parts": []map[string]string{
-				{"text": "Understood."},
-			},
+			"role":  "model",
+			"parts": []map[string]string{{"text": "Understood."}},
 		})
 	}
 
@@ -338,52 +292,26 @@ func (c *CloudProvider) chatGoogle(ctx context.Context, messages []core.Message,
 		case "assistant":
 			role = "model"
 		case "system":
-			// System messages already handled above; skip duplicates
 			if systemPrompt != "" {
 				continue
 			}
 			role = "user"
 		}
 		contents = append(contents, map[string]interface{}{
-			"role": role,
-			"parts": []map[string]string{
-				{"text": m.Content},
-			},
+			"role":  role,
+			"parts": []map[string]string{{"text": m.Content}},
 		})
 	}
 
-	reqBody := map[string]interface{}{
-		"contents": contents,
-		"generationConfig": map[string]interface{}{
-			"temperature":     temp,
-			"maxOutputTokens": maxTok,
-		},
-	}
-
-	body, err := json.Marshal(reqBody)
+	respBody, err := c.doJSON(ctx, http.MethodPost, url, nil,
+		map[string]interface{}{
+			"contents": contents,
+			"generationConfig": map[string]interface{}{
+				"temperature": temp, "maxOutputTokens": maxTok,
+			},
+		})
 	if err != nil {
-		return nil, fmt.Errorf("marshal google request: %w", err)
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("create google request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := c.client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("google request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read google response: %w", err)
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("google returned status %d: %s", resp.StatusCode, string(respBody))
+		return nil, fmt.Errorf("google: %w", err)
 	}
 
 	var geminiResp struct {
@@ -400,7 +328,7 @@ func (c *CloudProvider) chatGoogle(ctx context.Context, messages []core.Message,
 		} `json:"usageMetadata"`
 	}
 	if err := json.Unmarshal(respBody, &geminiResp); err != nil {
-		return nil, fmt.Errorf("decode google response: %w", err)
+		return nil, fmt.Errorf("google decode: %w", err)
 	}
 
 	var content string

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -16,20 +16,18 @@ import (
 )
 
 // OllamaProvider talks to a local Ollama instance over its REST API.
-// Krill fact: krill thrive in cold local waters - Ollama thrives on local GPUs.
 type OllamaProvider struct {
-	host        string
-	model       string
-	temperature float64
-	maxTokens   int
-	chatClient  *http.Client // 120s timeout for inference
+	host         string
+	model        string
+	temperature  float64
+	maxTokens    int
+	chatClient   *http.Client // 120s timeout for inference
 	healthClient *http.Client // 5s timeout for health checks
 }
 
 // NewOllamaProvider creates a provider targeting the given Ollama host and model.
 func NewOllamaProvider(host string, model string, defaultOpts config.LLMConfig) *OllamaProvider {
 	host = strings.TrimRight(host, "/")
-
 	temp := defaultOpts.Temperature
 	if temp <= 0 {
 		temp = 0.7
@@ -38,23 +36,18 @@ func NewOllamaProvider(host string, model string, defaultOpts config.LLMConfig) 
 	if maxTok <= 0 {
 		maxTok = 2048
 	}
-
 	return &OllamaProvider{
 		host:        host,
 		model:       model,
 		temperature: temp,
 		maxTokens:   maxTok,
-		chatClient: &http.Client{
-			Timeout: 120 * time.Second,
-		},
-		healthClient: &http.Client{
-			Timeout: 5 * time.Second,
-		},
+		chatClient:  &http.Client{Timeout: 120 * time.Second},
+		healthClient: &http.Client{Timeout: 5 * time.Second},
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Ollama request / response types (unexported, internal to this file)
+// Request/response types
 // ---------------------------------------------------------------------------
 
 type ollamaChatRequest struct {
@@ -75,24 +68,26 @@ type ollamaChatOptions struct {
 }
 
 type ollamaChatResponse struct {
-	Message        ollamaChatMsg `json:"message"`
-	Done           bool          `json:"done"`
-	EvalCount      int           `json:"eval_count"`
-	PromptEvalCount int          `json:"prompt_eval_count"`
-}
-
-type ollamaTagsResponse struct {
-	Models []struct {
-		Name string `json:"name"`
-	} `json:"models"`
+	Message         ollamaChatMsg `json:"message"`
+	Done            bool          `json:"done"`
+	EvalCount       int           `json:"eval_count"`
+	PromptEvalCount int           `json:"prompt_eval_count"`
 }
 
 // ---------------------------------------------------------------------------
-// LLMProvider interface implementation
+// Shared helpers
 // ---------------------------------------------------------------------------
 
-// Chat sends a non-streaming chat request to Ollama and returns the full response.
-func (o *OllamaProvider) Chat(ctx context.Context, messages []core.Message, opts ...core.ChatOption) (*core.Response, error) {
+// resolvedParams holds the resolved model/temp/maxTokens/messages for a request.
+type resolvedParams struct {
+	model    string
+	temp     float64
+	maxTok   int
+	messages []ollamaChatMsg
+}
+
+// resolve merges functional options with provider defaults and builds the message list.
+func (o *OllamaProvider) resolve(messages []core.Message, opts []core.ChatOption) resolvedParams {
 	options := core.ApplyOptions(opts)
 
 	model := o.model
@@ -108,7 +103,6 @@ func (o *OllamaProvider) Chat(ctx context.Context, messages []core.Message, opts
 		maxTok = options.MaxTokens
 	}
 
-	// Build message list, prepending system prompt if provided
 	ollamaMsgs := make([]ollamaChatMsg, 0, len(messages)+1)
 	if options.SystemPrompt != "" {
 		ollamaMsgs = append(ollamaMsgs, ollamaChatMsg{Role: "system", Content: options.SystemPrompt})
@@ -117,14 +111,19 @@ func (o *OllamaProvider) Chat(ctx context.Context, messages []core.Message, opts
 		ollamaMsgs = append(ollamaMsgs, ollamaChatMsg{Role: m.Role, Content: m.Content})
 	}
 
+	return resolvedParams{model: model, temp: temp, maxTok: maxTok, messages: ollamaMsgs}
+}
+
+// ---------------------------------------------------------------------------
+// LLMProvider interface
+// ---------------------------------------------------------------------------
+
+func (o *OllamaProvider) Chat(ctx context.Context, messages []core.Message, opts ...core.ChatOption) (*core.Response, error) {
+	p := o.resolve(messages, opts)
+
 	reqBody := ollamaChatRequest{
-		Model:    model,
-		Messages: ollamaMsgs,
-		Stream:   false,
-		Options: ollamaChatOptions{
-			Temperature: temp,
-			NumPredict:  maxTok,
-		},
+		Model: p.model, Messages: p.messages, Stream: false,
+		Options: ollamaChatOptions{Temperature: p.temp, NumPredict: p.maxTok},
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -132,14 +131,13 @@ func (o *OllamaProvider) Chat(ctx context.Context, messages []core.Message, opts
 		return nil, fmt.Errorf("marshal ollama request: %w", err)
 	}
 
-	url := o.host + "/api/chat"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.host+"/api/chat", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create ollama request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	log.Debug("ollama chat request", "model", model, "messages", len(ollamaMsgs))
+	log.Debug("ollama chat request", "model", p.model, "messages", len(p.messages))
 
 	resp, err := o.chatClient.Do(req)
 	if err != nil {
@@ -162,46 +160,18 @@ func (o *OllamaProvider) Chat(ctx context.Context, messages []core.Message, opts
 
 	return &core.Response{
 		Content:          ollamaResp.Message.Content,
-		Model:            model,
+		Model:            p.model,
 		PromptTokens:     ollamaResp.PromptEvalCount,
 		CompletionTokens: ollamaResp.EvalCount,
 	}, nil
 }
 
-// Stream sends a streaming chat request to Ollama and returns a channel of chunks.
-// Each line of the NDJSON response becomes one StreamChunk.
 func (o *OllamaProvider) Stream(ctx context.Context, messages []core.Message, opts ...core.ChatOption) (<-chan core.StreamChunk, error) {
-	options := core.ApplyOptions(opts)
-
-	model := o.model
-	if options.Model != "" {
-		model = options.Model
-	}
-	temp := o.temperature
-	if options.Temperature != 0 {
-		temp = options.Temperature
-	}
-	maxTok := o.maxTokens
-	if options.MaxTokens != 0 {
-		maxTok = options.MaxTokens
-	}
-
-	ollamaMsgs := make([]ollamaChatMsg, 0, len(messages)+1)
-	if options.SystemPrompt != "" {
-		ollamaMsgs = append(ollamaMsgs, ollamaChatMsg{Role: "system", Content: options.SystemPrompt})
-	}
-	for _, m := range messages {
-		ollamaMsgs = append(ollamaMsgs, ollamaChatMsg{Role: m.Role, Content: m.Content})
-	}
+	p := o.resolve(messages, opts)
 
 	reqBody := ollamaChatRequest{
-		Model:    model,
-		Messages: ollamaMsgs,
-		Stream:   true,
-		Options: ollamaChatOptions{
-			Temperature: temp,
-			NumPredict:  maxTok,
-		},
+		Model: p.model, Messages: p.messages, Stream: true,
+		Options: ollamaChatOptions{Temperature: p.temp, NumPredict: p.maxTok},
 	}
 
 	body, err := json.Marshal(reqBody)
@@ -209,15 +179,12 @@ func (o *OllamaProvider) Stream(ctx context.Context, messages []core.Message, op
 		return nil, fmt.Errorf("marshal ollama stream request: %w", err)
 	}
 
-	url := o.host + "/api/chat"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, o.host+"/api/chat", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("create ollama stream request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	// Use a client without timeout since streaming can be long-lived;
-	// cancellation is handled via context.
 	streamClient := &http.Client{}
 	resp, err := streamClient.Do(req)
 	if err != nil {
@@ -234,14 +201,12 @@ func (o *OllamaProvider) Stream(ctx context.Context, messages []core.Message, op
 	}
 
 	ch := make(chan core.StreamChunk, 32)
-
 	go func() {
 		defer close(ch)
 		defer resp.Body.Close()
 
 		decoder := json.NewDecoder(resp.Body)
 		for {
-			// Check for context cancellation between reads
 			select {
 			case <-ctx.Done():
 				ch <- core.StreamChunk{Done: true, Err: ctx.Err()}
@@ -259,11 +224,7 @@ func (o *OllamaProvider) Stream(ctx context.Context, messages []core.Message, op
 				return
 			}
 
-			ch <- core.StreamChunk{
-				Content: chunk.Message.Content,
-				Done:    chunk.Done,
-			}
-
+			ch <- core.StreamChunk{Content: chunk.Message.Content, Done: chunk.Done}
 			if chunk.Done {
 				return
 			}
@@ -273,34 +234,24 @@ func (o *OllamaProvider) Stream(ctx context.Context, messages []core.Message, op
 	return ch, nil
 }
 
-// Name returns the provider name.
-func (o *OllamaProvider) Name() string { return "ollama" }
+func (o *OllamaProvider) Name() string      { return "ollama" }
+func (o *OllamaProvider) ModelName() string  { return o.model }
 
-// ModelName returns the configured model name.
-func (o *OllamaProvider) ModelName() string { return o.model }
-
-// Available checks whether the Ollama server is reachable.
-// Krill fact: krill use bioluminescence to check if their swarm-mates are nearby.
 func (o *OllamaProvider) Available(ctx context.Context) bool {
-	url := o.host + "/api/tags"
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, o.host+"/api/tags", nil)
 	if err != nil {
 		return false
 	}
-
 	resp, err := o.healthClient.Do(req)
 	if err != nil {
 		log.Debug("ollama health check failed", "error", err)
 		return false
 	}
 	defer resp.Body.Close()
-	// Drain body to allow connection reuse
 	io.Copy(io.Discard, resp.Body)
-
 	return resp.StatusCode == http.StatusOK
 }
 
-// isConnectionRefused detects connection refused errors regardless of wrapping.
 func isConnectionRefused(err error) bool {
 	if err == nil {
 		return false
@@ -308,5 +259,5 @@ func isConnectionRefused(err error) bool {
 	s := err.Error()
 	return strings.Contains(s, "connection refused") ||
 		strings.Contains(s, "connect: connection refused") ||
-		strings.Contains(s, "dial tcp") && strings.Contains(s, "refused")
+		(strings.Contains(s, "dial tcp") && strings.Contains(s, "refused"))
 }

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -248,7 +248,7 @@ func (o *OllamaProvider) Available(ctx context.Context) bool {
 		return false
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.StatusCode == http.StatusOK
 }
 

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -13,7 +13,6 @@ import (
 )
 
 // NewProvider creates the appropriate LLMProvider based on configuration.
-// Krill fact: krill swarms self-organize - this factory picks the right formation.
 func NewProvider(cfg config.LLMConfig, ollamaCfg config.OllamaConfig) (core.LLMProvider, error) {
 	provider := strings.ToLower(strings.TrimSpace(cfg.Provider))
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,6 +1,5 @@
 // Package log provides structured logging for Mini Krill using Go's stdlib slog.
 // Zero external dependencies. Logs to stderr and optionally to a file.
-// Krill fact: krill navigate the dark ocean depths - this logger lights the way.
 package log
 
 import (

--- a/internal/ollama/manager.go
+++ b/internal/ollama/manager.go
@@ -366,7 +366,7 @@ func (m *OllamaManager) isHealthy(ctx context.Context) bool {
 		return false
 	}
 	defer resp.Body.Close()
-	io.Copy(io.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.StatusCode == http.StatusOK
 }

--- a/internal/ollama/manager.go
+++ b/internal/ollama/manager.go
@@ -1,7 +1,5 @@
 // Package ollama manages the lifecycle of a local Ollama installation:
 // detecting, installing, starting, stopping, and pulling models.
-// Krill fact: krill swarm coordinators ensure the colony is fed and moving -
-// OllamaManager does the same for the local inference engine.
 package ollama
 
 import (
@@ -343,7 +341,6 @@ func (m *OllamaManager) ListModels(ctx context.Context) ([]ModelInfo, error) {
 
 // Status returns the current state of the Ollama runtime:
 // "running", "stopped", or "not installed".
-// Krill fact: krill have compound eyes that scan 360 degrees - this checks all angles.
 func (m *OllamaManager) Status(ctx context.Context) string {
 	if !m.IsInstalled() {
 		return "not installed"

--- a/internal/plugin/builtins.go
+++ b/internal/plugin/builtins.go
@@ -1,0 +1,331 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// RegisterBuiltins registers the default set of built-in skills.
+func (r *SkillRegistryImpl) RegisterBuiltins() {
+	builtins := []core.Skill{
+		&recallSkill{},
+		&sysinfoSkill{},
+		&timeSkill{},
+		&webSearchSkill{},
+	}
+	for _, s := range builtins {
+		if err := r.Register(s); err != nil {
+			log.Warn("failed to register built-in skill", "name", s.Name(), "error", err)
+		}
+	}
+	log.Debug("built-in skills registered", "count", len(builtins))
+}
+
+// RegisterSelfSkills registers all self-awareness and self-modification skills.
+func (r *SkillRegistryImpl) RegisterSelfSkills(sc SelfContext) {
+	selfSkills := NewSelfSkills(sc)
+	for _, s := range selfSkills {
+		if err := r.Register(s); err != nil {
+			log.Warn("failed to register self-skill", "name", s.Name(), "error", err)
+		}
+	}
+	log.Debug("self-awareness skills registered", "count", len(selfSkills))
+}
+
+// ---------------------------------------------------------------------------
+// recall skill
+// ---------------------------------------------------------------------------
+
+type recallSkill struct{}
+
+func (s *recallSkill) Name() string        { return "recall" }
+func (s *recallSkill) Description() string { return "Search the krill's memory for information" }
+func (s *recallSkill) Execute(_ context.Context, input string, _ core.LLMProvider) (string, error) {
+	return input, nil
+}
+
+// ---------------------------------------------------------------------------
+// sysinfo skill
+// ---------------------------------------------------------------------------
+
+type sysinfoSkill struct{}
+
+func (s *sysinfoSkill) Name() string        { return "sysinfo" }
+func (s *sysinfoSkill) Description() string { return "Get system information" }
+
+func (s *sysinfoSkill) Execute(_ context.Context, _ string, _ core.LLMProvider) (string, error) {
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+	return fmt.Sprintf(
+		"System Information:\n"+
+			"  OS:           %s\n"+
+			"  Architecture: %s\n"+
+			"  CPUs:         %d\n"+
+			"  Go version:   %s\n"+
+			"  Goroutines:   %d\n"+
+			"  Memory:\n"+
+			"    Allocated:  %s\n"+
+			"    System:     %s\n"+
+			"    Heap in use: %s\n"+
+			"    GC cycles:  %d",
+		runtime.GOOS, runtime.GOARCH, runtime.NumCPU(), runtime.Version(),
+		runtime.NumGoroutine(),
+		formatBytes(mem.TotalAlloc), formatBytes(mem.Sys),
+		formatBytes(mem.HeapInuse), mem.NumGC,
+	), nil
+}
+
+// ---------------------------------------------------------------------------
+// time skill
+// ---------------------------------------------------------------------------
+
+type timeSkill struct{}
+
+func (s *timeSkill) Name() string        { return "time" }
+func (s *timeSkill) Description() string { return "Get current date and time" }
+
+func (s *timeSkill) Execute(_ context.Context, _ string, _ core.LLMProvider) (string, error) {
+	now := time.Now()
+	return fmt.Sprintf(
+		"Current time: %s\nTimezone: %s\nUnix timestamp: %d",
+		now.Format("2006-01-02 15:04:05 MST"), now.Location().String(), now.Unix(),
+	), nil
+}
+
+// ---------------------------------------------------------------------------
+// web search skill
+// ---------------------------------------------------------------------------
+
+type webSearchSkill struct{}
+
+func (s *webSearchSkill) Name() string        { return "search" }
+func (s *webSearchSkill) Description() string { return "Search the web via DuckDuckGo (no API key needed)" }
+
+func (s *webSearchSkill) Execute(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
+	if strings.TrimSpace(input) == "" {
+		return "No search query provided. What should I look up?", nil
+	}
+
+	results, err := duckduckgoSearch(ctx, input)
+	if err != nil {
+		return fmt.Sprintf("Search failed: %v", err), nil
+	}
+	if len(results) == 0 {
+		return fmt.Sprintf("No results found for: %s", input), nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Web search results for: %s\n\n", input))
+	for i, r := range results {
+		if i >= 5 {
+			break
+		}
+		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, r.title))
+		if r.url != "" {
+			sb.WriteString(fmt.Sprintf("   %s\n", r.url))
+		}
+		if r.snippet != "" {
+			sb.WriteString(fmt.Sprintf("   %s\n", r.snippet))
+		}
+		sb.WriteString("\n")
+	}
+
+	raw := sb.String()
+
+	if llm != nil {
+		summary, err := llm.Chat(ctx, []core.Message{
+			{Role: "system", Content: "You are a helpful assistant. Summarize these web search results concisely. Include key facts and cite sources."},
+			{Role: "user", Content: raw},
+		})
+		if err == nil && summary.Content != "" {
+			return summary.Content, nil
+		}
+	}
+
+	return raw, nil
+}
+
+type searchResult struct {
+	title   string
+	url     string
+	snippet string
+}
+
+func duckduckgoSearch(ctx context.Context, query string) ([]searchResult, error) {
+	searchURL := "https://html.duckduckgo.com/html/?q=" + urlEncode(query)
+
+	req, err := http.NewRequestWithContext(ctx, "GET", searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("User-Agent", "MiniKrill/1.0 (search skill)")
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("search request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	return parseSearchResults(string(body)), nil
+}
+
+func parseSearchResults(html string) []searchResult {
+	var results []searchResult
+
+	chunks := strings.Split(html, "class=\"result__a\"")
+	if len(chunks) <= 1 {
+		chunks = strings.Split(html, "class='result__a'")
+	}
+
+	for i := 1; i < len(chunks) && len(results) < 8; i++ {
+		chunk := chunks[i]
+		r := searchResult{}
+
+		if hrefIdx := strings.Index(chunk, "href=\""); hrefIdx != -1 {
+			start := hrefIdx + 6
+			if endIdx := strings.Index(chunk[start:], "\""); endIdx != -1 {
+				rawURL := chunk[start : start+endIdx]
+				if uddgIdx := strings.Index(rawURL, "uddg="); uddgIdx != -1 {
+					rawURL = rawURL[uddgIdx+5:]
+					if ampIdx := strings.Index(rawURL, "&"); ampIdx != -1 {
+						rawURL = rawURL[:ampIdx]
+					}
+					rawURL = urlDecode(rawURL)
+				}
+				r.url = rawURL
+			}
+		}
+
+		if gtIdx := strings.Index(chunk, ">"); gtIdx != -1 {
+			after := chunk[gtIdx+1:]
+			if endIdx := strings.Index(after, "</a>"); endIdx != -1 {
+				r.title = stripHTML(after[:endIdx])
+			}
+		}
+
+		if snipIdx := strings.Index(chunk, "result__snippet"); snipIdx != -1 {
+			after := chunk[snipIdx:]
+			if gtIdx := strings.Index(after, ">"); gtIdx != -1 {
+				after = after[gtIdx+1:]
+				if endIdx := strings.Index(after, "</"); endIdx != -1 {
+					r.snippet = stripHTML(after[:endIdx])
+				}
+			}
+		}
+
+		if r.title != "" {
+			results = append(results, r)
+		}
+	}
+
+	return results
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+func stripHTML(s string) string {
+	var out strings.Builder
+	inTag := false
+	for _, c := range s {
+		switch {
+		case c == '<':
+			inTag = true
+		case c == '>':
+			inTag = false
+		case !inTag:
+			out.WriteRune(c)
+		}
+	}
+	return strings.TrimSpace(out.String())
+}
+
+func urlEncode(s string) string {
+	var buf strings.Builder
+	for _, c := range s {
+		switch {
+		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'):
+			buf.WriteRune(c)
+		case c == ' ':
+			buf.WriteByte('+')
+		case c == '-' || c == '_' || c == '.' || c == '~':
+			buf.WriteRune(c)
+		default:
+			buf.WriteString(fmt.Sprintf("%%%02X", c))
+		}
+	}
+	return buf.String()
+}
+
+func urlDecode(s string) string {
+	var buf strings.Builder
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' && i+2 < len(s) {
+			if val, err := parseHexByte(s[i+1], s[i+2]); err == nil {
+				buf.WriteByte(val)
+				i += 2
+				continue
+			}
+		} else if s[i] == '+' {
+			buf.WriteByte(' ')
+			continue
+		}
+		buf.WriteByte(s[i])
+	}
+	return buf.String()
+}
+
+func parseHexByte(h1, h2 byte) (byte, error) {
+	n1 := hexVal(h1)
+	n2 := hexVal(h2)
+	if n1 < 0 || n2 < 0 {
+		return 0, fmt.Errorf("invalid hex")
+	}
+	return byte(n1<<4 | n2), nil
+}
+
+func hexVal(c byte) int {
+	switch {
+	case c >= '0' && c <= '9':
+		return int(c - '0')
+	case c >= 'a' && c <= 'f':
+		return int(c-'a') + 10
+	case c >= 'A' && c <= 'F':
+		return int(c-'A') + 10
+	default:
+		return -1
+	}
+}
+
+func formatBytes(b uint64) string {
+	const (
+		kb = 1024
+		mb = kb * 1024
+		gb = mb * 1024
+	)
+	switch {
+	case b >= gb:
+		return fmt.Sprintf("%.2f GB", float64(b)/float64(gb))
+	case b >= mb:
+		return fmt.Sprintf("%.2f MB", float64(b)/float64(mb))
+	case b >= kb:
+		return fmt.Sprintf("%.2f KB", float64(b)/float64(kb))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/internal/plugin/mcp.go
+++ b/internal/plugin/mcp.go
@@ -2,9 +2,6 @@
 // MCP servers expose external tools to the krill agent via JSON-RPC 2.0 over
 // stdin/stdout. This is how krill extends its tentacles into the wider ecosystem -
 // file systems, databases, APIs, and beyond.
-// Krill fact: krill have 10 pairs of thoracic legs (thoracopods) for swimming and
-// filter-feeding. MCP servers are the krill's digital thoracopods - each one
-// reaches out to grab a different kind of resource.
 package plugin
 
 import (

--- a/internal/plugin/registry.go
+++ b/internal/plugin/registry.go
@@ -1,24 +1,16 @@
 // Package plugin implements the skill registry and MCP server registry for Mini Krill.
-// Skills are pluggable capabilities the krill agent can invoke - from built-in system
-// tools to user-defined YAML prompt templates.
-// Krill fact: krill form the largest animal aggregations on Earth - this registry
-// aggregates all the agent's capabilities into one swarm.
 package plugin
 
 import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
 	"text/template"
-	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/core"
 	log "github.com/srvsngh99/mini-krill/internal/log"
@@ -26,35 +18,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Type aliases for stdlib HTTP - keeps the search skill self-contained
-// without polluting the package with direct http usage everywhere.
-type httpClient = http.Client
-
-var httpNewRequestWithContext = http.NewRequestWithContext
-var readAll = io.ReadAll
-
 // ---------------------------------------------------------------------------
-// Skill Registry - the swarm coordinator for all agent capabilities
+// Skill Registry
 // ---------------------------------------------------------------------------
 
 // SkillRegistryImpl is the concrete implementation of core.SkillRegistry.
-// Thread-safe via sync.RWMutex, suitable for concurrent access from
-// the agent loop, TUI, and sub-krills simultaneously.
+// Thread-safe via sync.RWMutex.
 type SkillRegistryImpl struct {
 	mu     sync.RWMutex
 	skills map[string]core.Skill
 }
 
 // NewRegistry creates a new, empty skill registry.
-// Like a krill swarm starting with a single individual - it grows from here.
 func NewRegistry() *SkillRegistryImpl {
 	return &SkillRegistryImpl{
 		skills: make(map[string]core.Skill),
 	}
 }
 
-// Register adds a skill to the registry. Returns an error if a skill with the
-// same name is already registered - no silent overwrites allowed.
+// Register adds a skill to the registry.
 func (r *SkillRegistryImpl) Register(skill core.Skill) error {
 	if skill == nil {
 		return fmt.Errorf("cannot register nil skill")
@@ -72,12 +54,11 @@ func (r *SkillRegistryImpl) Register(skill core.Skill) error {
 	}
 
 	r.skills[name] = skill
-	log.Debug("skill registered in the swarm", "name", name)
+	log.Debug("skill registered", "name", name)
 	return nil
 }
 
 // Unregister removes a skill from the registry by name.
-// Returns an error if the skill is not found.
 func (r *SkillRegistryImpl) Unregister(name string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -87,23 +68,19 @@ func (r *SkillRegistryImpl) Unregister(name string) error {
 	}
 
 	delete(r.skills, name)
-	log.Debug("skill removed from the swarm", "name", name)
+	log.Debug("skill removed", "name", name)
 	return nil
 }
 
-// Get retrieves a skill by name. Returns the skill and true if found,
-// or nil and false if not registered.
+// Get retrieves a skill by name.
 func (r *SkillRegistryImpl) Get(name string) (core.Skill, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-
 	skill, ok := r.skills[name]
 	return skill, ok
 }
 
-// List returns metadata for all registered skills, sorted by name for
-// deterministic output. Every skill is marked as enabled - if it is
-// registered, it is ready to deploy.
+// List returns metadata for all registered skills, sorted by name.
 func (r *SkillRegistryImpl) List() []core.SkillInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -117,7 +94,6 @@ func (r *SkillRegistryImpl) List() []core.SkillInfo {
 		})
 	}
 
-	// Sort by name so output is stable - krill swarms have order in their chaos
 	sort.Slice(infos, func(i, j int) bool {
 		return infos[i].Name < infos[j].Name
 	})
@@ -126,20 +102,16 @@ func (r *SkillRegistryImpl) List() []core.SkillInfo {
 }
 
 // ---------------------------------------------------------------------------
-// YAML Skill loader - user-defined prompt templates
+// YAML Skill loader
 // ---------------------------------------------------------------------------
 
-// yamlSkillDef is the on-disk YAML format for a skill definition.
 type yamlSkillDef struct {
 	Name           string `yaml:"name"`
 	Description    string `yaml:"description"`
 	PromptTemplate string `yaml:"prompt_template"`
 }
 
-// YAMLSkill is a skill loaded from a YAML definition file. Its Execute method
-// renders the prompt_template with the user's input and sends it to the LLM.
-// Like krill adapting to different ocean currents - each YAML skill adapts
-// the LLM to a different task.
+// YAMLSkill is a skill loaded from a YAML definition file.
 type YAMLSkill struct {
 	name        string
 	description string
@@ -147,35 +119,23 @@ type YAMLSkill struct {
 	rawTemplate string
 }
 
-// Name returns the skill's identifier.
-func (s *YAMLSkill) Name() string { return s.name }
-
-// Description returns a human-readable description of what the skill does.
+func (s *YAMLSkill) Name() string        { return s.name }
 func (s *YAMLSkill) Description() string { return s.description }
 
-// Execute renders the prompt template with the input and sends it to the LLM.
-// The template receives a struct with an .Input field for use in {{.Input}}.
 func (s *YAMLSkill) Execute(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
 	if llm == nil {
 		return "", fmt.Errorf("no LLM provider available for skill %q", s.name)
 	}
 
-	// Render the prompt template with the user's input
 	data := struct{ Input string }{Input: input}
 	var buf bytes.Buffer
 	if err := s.tmpl.Execute(&buf, data); err != nil {
 		return "", fmt.Errorf("render template for skill %q: %w", s.name, err)
 	}
 
-	prompt := buf.String()
-	log.Debug("YAML skill executing", "skill", s.name, "prompt_len", len(prompt))
-
-	// Send to LLM as a user message
-	messages := []core.Message{
-		{Role: "user", Content: prompt},
-	}
-
-	resp, err := llm.Chat(ctx, messages)
+	resp, err := llm.Chat(ctx, []core.Message{
+		{Role: "user", Content: buf.String()},
+	})
 	if err != nil {
 		return "", fmt.Errorf("skill %q LLM call failed: %w", s.name, err)
 	}
@@ -183,10 +143,7 @@ func (s *YAMLSkill) Execute(ctx context.Context, input string, llm core.LLMProvi
 	return resp.Content, nil
 }
 
-// LoadSkillsFromDir reads all .yaml and .yml files from the given directory,
-// parses them as skill definitions, and registers them in the registry.
-// Skips malformed files with a warning rather than failing the whole load -
-// one bad egg should not spoil the swarm.
+// LoadSkillsFromDir reads all .yaml/.yml files from a directory and registers them.
 func (r *SkillRegistryImpl) LoadSkillsFromDir(dir string) error {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
@@ -202,7 +159,6 @@ func (r *SkillRegistryImpl) LoadSkillsFromDir(dir string) error {
 		if entry.IsDir() {
 			continue
 		}
-
 		ext := strings.ToLower(filepath.Ext(entry.Name()))
 		if ext != ".yaml" && ext != ".yml" {
 			continue
@@ -214,20 +170,17 @@ func (r *SkillRegistryImpl) LoadSkillsFromDir(dir string) error {
 			log.Warn("skipping malformed skill file", "path", path, "error", err)
 			continue
 		}
-
 		if err := r.Register(skill); err != nil {
 			log.Warn("could not register skill from file", "path", path, "error", err)
 			continue
 		}
-
 		loaded++
 	}
 
-	log.Info("loaded YAML skills from directory", "dir", dir, "count", loaded)
+	log.Info("loaded YAML skills", "dir", dir, "count", loaded)
 	return nil
 }
 
-// loadYAMLSkill parses a single YAML skill definition file.
 func loadYAMLSkill(path string) (*YAMLSkill, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -257,377 +210,4 @@ func loadYAMLSkill(path string) (*YAMLSkill, error) {
 		tmpl:        tmpl,
 		rawTemplate: def.PromptTemplate,
 	}, nil
-}
-
-// ---------------------------------------------------------------------------
-// Built-in skills - the krill's innate abilities
-// ---------------------------------------------------------------------------
-
-// RegisterBuiltins registers the default set of built-in skills that ship
-// with every Mini Krill instance. These are the krill's innate survival
-// instincts - always available, no YAML required.
-func (r *SkillRegistryImpl) RegisterBuiltins() {
-	builtins := []core.Skill{
-		&recallSkill{},
-		&sysinfoSkill{},
-		&timeSkill{},
-		&webSearchSkill{},
-	}
-
-	for _, s := range builtins {
-		if err := r.Register(s); err != nil {
-			// Built-in registration should never fail unless called twice.
-			// Log it but do not crash - krill are resilient survivors.
-			log.Warn("failed to register built-in skill", "name", s.Name(), "error", err)
-		}
-	}
-
-	log.Debug("built-in skills registered", "count", len(builtins))
-}
-
-// RegisterSelfSkills registers all self-awareness and self-modification skills.
-// These give the krill compound eyes on its own internals.
-func (r *SkillRegistryImpl) RegisterSelfSkills(sc SelfContext) {
-	selfSkills := NewSelfSkills(sc)
-	for _, s := range selfSkills {
-		if err := r.Register(s); err != nil {
-			log.Warn("failed to register self-skill", "name", s.Name(), "error", err)
-		}
-	}
-	log.Debug("self-awareness skills registered", "count", len(selfSkills))
-}
-
-// --- recall skill ---
-// A marker skill that signals the agent to search its memory.
-// The actual memory lookup is handled by the agent layer - this skill
-// just returns the input so the agent knows what to search for.
-
-type recallSkill struct{}
-
-func (s *recallSkill) Name() string        { return "recall" }
-func (s *recallSkill) Description() string { return "Search the krill's memory for information" }
-
-// Execute returns the input as-is. The recall skill is a marker - the agent
-// intercepts it and performs the actual memory lookup. Like krill using
-// bioluminescent signals to communicate intent to the swarm.
-func (s *recallSkill) Execute(_ context.Context, input string, _ core.LLMProvider) (string, error) {
-	return input, nil
-}
-
-// --- sysinfo skill ---
-// Reports system information: OS, architecture, CPU count, and memory stats.
-// The krill always knows its environment - survival depends on awareness.
-
-type sysinfoSkill struct{}
-
-func (s *sysinfoSkill) Name() string        { return "sysinfo" }
-func (s *sysinfoSkill) Description() string { return "Get system information" }
-
-// Execute gathers and returns system information. No LLM needed - this is
-// pure introspection, like a krill sensing water temperature and pressure.
-func (s *sysinfoSkill) Execute(_ context.Context, _ string, _ core.LLMProvider) (string, error) {
-	var mem runtime.MemStats
-	runtime.ReadMemStats(&mem)
-
-	// Format memory in human-readable units
-	totalAlloc := formatBytes(mem.TotalAlloc)
-	sysMemory := formatBytes(mem.Sys)
-	heapInUse := formatBytes(mem.HeapInuse)
-
-	info := fmt.Sprintf(
-		"System Information:\n"+
-			"  OS:           %s\n"+
-			"  Architecture: %s\n"+
-			"  CPUs:         %d\n"+
-			"  Go version:   %s\n"+
-			"  Goroutines:   %d\n"+
-			"  Memory:\n"+
-			"    Allocated:  %s\n"+
-			"    System:     %s\n"+
-			"    Heap in use: %s\n"+
-			"    GC cycles:  %d",
-		runtime.GOOS,
-		runtime.GOARCH,
-		runtime.NumCPU(),
-		runtime.Version(),
-		runtime.NumGoroutine(),
-		totalAlloc,
-		sysMemory,
-		heapInUse,
-		mem.NumGC,
-	)
-
-	return info, nil
-}
-
-// --- time skill ---
-// Returns the current date and time. Even deep-sea krill track the daily
-// cycle - they migrate vertically based on time of day.
-
-type timeSkill struct{}
-
-func (s *timeSkill) Name() string        { return "time" }
-func (s *timeSkill) Description() string { return "Get current date and time" }
-
-// Execute returns the current date and time in a human-readable format.
-// Krill navigate by circadian rhythm - this skill gives the agent its clock.
-func (s *timeSkill) Execute(_ context.Context, _ string, _ core.LLMProvider) (string, error) {
-	now := time.Now()
-	return fmt.Sprintf(
-		"Current time: %s\nTimezone: %s\nUnix timestamp: %d",
-		now.Format("2006-01-02 15:04:05 MST"),
-		now.Location().String(),
-		now.Unix(),
-	), nil
-}
-
-// --- web search skill ---
-// Searches the web via DuckDuckGo - no API key needed.
-// Like krill using echolocation in the dark ocean, this skill lets
-// the agent sense information beyond its training data.
-
-type webSearchSkill struct{}
-
-func (s *webSearchSkill) Name() string        { return "search" }
-func (s *webSearchSkill) Description() string { return "Search the web via DuckDuckGo (no API key needed)" }
-
-// Execute searches the web and returns formatted results. If an LLM is
-// provided, it summarizes the results. Otherwise returns raw search data.
-func (s *webSearchSkill) Execute(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
-	if strings.TrimSpace(input) == "" {
-		return "No search query provided. What should I look up?", nil
-	}
-
-	results, err := duckduckgoSearch(ctx, input)
-	if err != nil {
-		return fmt.Sprintf("Search failed: %v", err), nil
-	}
-
-	if len(results) == 0 {
-		return fmt.Sprintf("No results found for: %s", input), nil
-	}
-
-	// Format results
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Web search results for: %s\n\n", input))
-	for i, r := range results {
-		if i >= 5 {
-			break
-		}
-		sb.WriteString(fmt.Sprintf("%d. %s\n", i+1, r.title))
-		if r.url != "" {
-			sb.WriteString(fmt.Sprintf("   %s\n", r.url))
-		}
-		if r.snippet != "" {
-			sb.WriteString(fmt.Sprintf("   %s\n", r.snippet))
-		}
-		sb.WriteString("\n")
-	}
-
-	raw := sb.String()
-
-	// If LLM is available, ask it to summarize the results
-	if llm != nil {
-		summary, err := llm.Chat(ctx, []core.Message{
-			{Role: "system", Content: "You are a helpful assistant. Summarize these web search results concisely. Include key facts and cite sources."},
-			{Role: "user", Content: raw},
-		})
-		if err == nil && summary.Content != "" {
-			return summary.Content, nil
-		}
-		// Fall back to raw results if summarization fails
-	}
-
-	return raw, nil
-}
-
-type searchResult struct {
-	title   string
-	url     string
-	snippet string
-}
-
-// duckduckgoSearch queries DuckDuckGo's HTML lite page and parses results.
-// No API key needed - this is the krill's sonar for the open web.
-func duckduckgoSearch(ctx context.Context, query string) ([]searchResult, error) {
-	searchURL := "https://html.duckduckgo.com/html/?q=" + urlEncode(query)
-
-	req, err := httpNewRequestWithContext(ctx, "GET", searchURL, nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-	req.Header.Set("User-Agent", "MiniKrill/1.0 (search skill)")
-
-	client := &httpClient{Timeout: 10 * time.Second}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("search request failed: %w", err)
-	}
-	defer resp.Body.Close()
-
-	body, err := readAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("read response: %w", err)
-	}
-
-	return parseSearchResults(string(body)), nil
-}
-
-// parseSearchResults extracts titles, URLs, and snippets from DuckDuckGo HTML.
-func parseSearchResults(html string) []searchResult {
-	var results []searchResult
-
-	// DuckDuckGo HTML results have class="result__a" for links
-	// and class="result__snippet" for snippets
-	chunks := strings.Split(html, "class=\"result__a\"")
-	if len(chunks) <= 1 {
-		// Try alternate format
-		chunks = strings.Split(html, "class='result__a'")
-	}
-
-	for i := 1; i < len(chunks) && len(results) < 8; i++ {
-		chunk := chunks[i]
-		r := searchResult{}
-
-		// Extract URL from href
-		if hrefIdx := strings.Index(chunk, "href=\""); hrefIdx != -1 {
-			start := hrefIdx + 6
-			if endIdx := strings.Index(chunk[start:], "\""); endIdx != -1 {
-				rawURL := chunk[start : start+endIdx]
-				// DuckDuckGo wraps URLs in a redirect, extract the actual URL
-				if uddgIdx := strings.Index(rawURL, "uddg="); uddgIdx != -1 {
-					rawURL = rawURL[uddgIdx+5:]
-					if ampIdx := strings.Index(rawURL, "&"); ampIdx != -1 {
-						rawURL = rawURL[:ampIdx]
-					}
-					rawURL = urlDecode(rawURL)
-				}
-				r.url = rawURL
-			}
-		}
-
-		// Extract title (text between > and </a>)
-		if gtIdx := strings.Index(chunk, ">"); gtIdx != -1 {
-			after := chunk[gtIdx+1:]
-			if endIdx := strings.Index(after, "</a>"); endIdx != -1 {
-				r.title = stripHTML(after[:endIdx])
-			}
-		}
-
-		// Extract snippet
-		if snipIdx := strings.Index(chunk, "result__snippet"); snipIdx != -1 {
-			after := chunk[snipIdx:]
-			if gtIdx := strings.Index(after, ">"); gtIdx != -1 {
-				after = after[gtIdx+1:]
-				if endIdx := strings.Index(after, "</"); endIdx != -1 {
-					r.snippet = stripHTML(after[:endIdx])
-				}
-			}
-		}
-
-		if r.title != "" {
-			results = append(results, r)
-		}
-	}
-
-	return results
-}
-
-// stripHTML removes HTML tags from a string.
-func stripHTML(s string) string {
-	var out strings.Builder
-	inTag := false
-	for _, c := range s {
-		switch {
-		case c == '<':
-			inTag = true
-		case c == '>':
-			inTag = false
-		case !inTag:
-			out.WriteRune(c)
-		}
-	}
-	return strings.TrimSpace(out.String())
-}
-
-// urlEncode does basic percent-encoding for a search query.
-func urlEncode(s string) string {
-	var buf strings.Builder
-	for _, c := range s {
-		switch {
-		case (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9'):
-			buf.WriteRune(c)
-		case c == ' ':
-			buf.WriteByte('+')
-		case c == '-' || c == '_' || c == '.' || c == '~':
-			buf.WriteRune(c)
-		default:
-			buf.WriteString(fmt.Sprintf("%%%02X", c))
-		}
-	}
-	return buf.String()
-}
-
-// urlDecode does basic percent-decoding.
-func urlDecode(s string) string {
-	var buf strings.Builder
-	for i := 0; i < len(s); i++ {
-		if s[i] == '%' && i+2 < len(s) {
-			if val, err := parseHexByte(s[i+1], s[i+2]); err == nil {
-				buf.WriteByte(val)
-				i += 2
-				continue
-			}
-		} else if s[i] == '+' {
-			buf.WriteByte(' ')
-			continue
-		}
-		buf.WriteByte(s[i])
-	}
-	return buf.String()
-}
-
-func parseHexByte(h1, h2 byte) (byte, error) {
-	n1 := hexVal(h1)
-	n2 := hexVal(h2)
-	if n1 < 0 || n2 < 0 {
-		return 0, fmt.Errorf("invalid hex")
-	}
-	return byte(n1<<4 | n2), nil
-}
-
-func hexVal(c byte) int {
-	switch {
-	case c >= '0' && c <= '9':
-		return int(c - '0')
-	case c >= 'a' && c <= 'f':
-		return int(c-'a') + 10
-	case c >= 'A' && c <= 'F':
-		return int(c-'A') + 10
-	default:
-		return -1
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Utility functions
-// ---------------------------------------------------------------------------
-
-// formatBytes converts bytes to a human-readable string.
-func formatBytes(b uint64) string {
-	const (
-		kb = 1024
-		mb = kb * 1024
-		gb = mb * 1024
-	)
-	switch {
-	case b >= gb:
-		return fmt.Sprintf("%.2f GB", float64(b)/float64(gb))
-	case b >= mb:
-		return fmt.Sprintf("%.2f MB", float64(b)/float64(mb))
-	case b >= kb:
-		return fmt.Sprintf("%.2f KB", float64(b)/float64(kb))
-	default:
-		return fmt.Sprintf("%d B", b)
-	}
 }

--- a/internal/plugin/self.go
+++ b/internal/plugin/self.go
@@ -1,7 +1,5 @@
 // Package plugin - self-awareness skills for Mini Krill.
 // These give the krill eyes on itself and hands to modify itself.
-// Krill fact: krill have compound eyes with 7 visual pigments - more than
-// any other crustacean. These self-skills are the krill's compound eyes.
 package plugin
 
 import (

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -1,7 +1,6 @@
 // Package tui implements the Terminal UI for Mini Krill using Bubble Tea.
 // The ocean-themed interface is the showcase of the project - gorgeous,
 // functional, and full of crustaceous personality.
-// Krill fact: krill are bioluminescent - this TUI glows too.
 package tui
 
 import (


### PR DESCRIPTION
## Summary
- Split `main.go` (1,317 lines) into 6 focused files: `main.go`, `commands.go`, `cmd_ollama.go`, `cmd_brain.go`, `cmd_personality.go`, `render.go`
- Extracted built-in skills from `registry.go` (634 lines) into `builtins.go` — registry is now a clean 213-line file
- Deduplicated LLM provider code: `doJSON()` helper in cloud.go, `resolve()` helper in ollama.go
- Fixed `memory.go` RLock-to-Lock race condition in `Recall()`
- Removed dead code (`isRelevantGroupMessage` — defined but never called)
- Stripped 25 decorative "Krill fact:" comments that added noise

## Test plan
- [x] `go build ./...` passes
- [x] `go test -race ./...` passes (all 5 test suites)
- [x] `go vet ./...` clean
- [ ] Smoke test: `minikrill chat`, `minikrill doctor`, `minikrill sonar`