### PR TITLE
Added shared Ollama process ownership with health monitor

### DIFF
--- a/cmd/minikrill/cmd_ollama.go
+++ b/cmd/minikrill/cmd_ollama.go
@@ -113,3 +113,42 @@ var ollamaStatusCmd = &cobra.Command{
 		return nil
 	},
 }
+
+var ollamaEnsureCmd = &cobra.Command{
+	Use:   "ensure",
+	Short: "Install, start, and pull the default model in one shot",
+	Long:  "Ensures Ollama is installed, running, and has the default model ready. Other bots can call this at startup.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		mgr, cfg := newOllamaManager()
+		ctx := context.Background()
+
+		// Install if missing
+		if !mgr.IsInstalled() {
+			fmt.Println(cDim + "Installing Ollama..." + cReset)
+			if err := mgr.Install(ctx); err != nil {
+				return fmt.Errorf("install failed: %w", err)
+			}
+			fmt.Println(cGreen + "Installed." + cReset)
+		}
+
+		// Start if stopped
+		if err := mgr.EnsureRunning(ctx); err != nil {
+			return fmt.Errorf("start failed: %w", err)
+		}
+
+		// Pull default model if not present
+		model := cfg.Ollama.DefaultModel
+		if model == "" {
+			model = "gemma4:e2b"
+		}
+		if !mgr.HasModel(ctx, model) {
+			fmt.Printf(cDim+"Pulling %s..."+cReset+"\n", model)
+			if err := mgr.Pull(ctx, model); err != nil {
+				return fmt.Errorf("pull failed: %w", err)
+			}
+		}
+
+		fmt.Println("ready")
+		return nil
+	},
+}

--- a/cmd/minikrill/cmd_ollama.go
+++ b/cmd/minikrill/cmd_ollama.go
@@ -84,7 +84,7 @@ var ollamaListCmd = &cobra.Command{
 		}
 		if len(models) == 0 {
 			fmt.Println("No models found.")
-			fmt.Println(cDim + "Pull one with: " + cReset + "minikrill ollama pull llama3.2")
+			fmt.Println(cDim + "Pull one with: " + cReset + "minikrill ollama pull gemma4:e2b")
 			return nil
 		}
 		fmt.Println(cBold + "Local models:" + cReset)

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -257,6 +257,18 @@ var diveCmd = &cobra.Command{
 
 // diveDaemon re-execs the dive command as a detached background process.
 func diveDaemon() error {
+	// Check if a daemon is already running
+	pidFile := filepath.Join(config.DataDir(), "krill.pid")
+	if data, err := os.ReadFile(pidFile); err == nil {
+		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+			if proc, err := os.FindProcess(pid); err == nil {
+				if proc.Signal(syscall.Signal(0)) == nil {
+					return fmt.Errorf("Mini Krill is already diving (PID %d). Run 'minikrill surface' first", pid)
+				}
+			}
+		}
+	}
+
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve executable: %w", err)
@@ -290,7 +302,6 @@ func diveDaemon() error {
 	// Detach - the parent does not wait for the child.
 	_ = child.Process.Release()
 
-	pidFile := filepath.Join(config.DataDir(), "krill.pid")
 	_ = os.WriteFile(pidFile, []byte(strconv.Itoa(child.Process.Pid)), 0644)
 
 	printBanner()

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"runtime"
@@ -144,11 +145,34 @@ var initCmd = &cobra.Command{
 // dive command
 // ---------------------------------------------------------------------------
 
+var diveFG bool
+
+func init() {
+	diveCmd.Flags().BoolVarP(&diveFG, "foreground", "f", false, "run in foreground (default: daemonize)")
+}
+
 var diveCmd = &cobra.Command{
 	Use:   "dive",
 	Short: "Start Mini Krill - dive into the deep",
 	Long:  "Starts the agent with all configured services (Telegram, Discord).",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if !diveFG {
+			return diveDaemon()
+		}
+
+		// Auto-start Ollama before initializing the stack
+		var ollamaMgr *ollama.OllamaManager
+		cfg, _ := config.Load()
+		if cfg == nil {
+			cfg = config.DefaultConfig()
+		}
+		if cfg.LLM.Provider == "ollama" && cfg.Ollama.AutoStart {
+			ollamaMgr = ollama.NewManager(cfg.Ollama)
+			if err := ollamaMgr.EnsureRunning(context.Background()); err != nil {
+				klog.Warn("ollama auto-start failed (will retry via health monitor)", "error", err)
+			}
+		}
+
 		stack, err := initStack(false)
 		if err != nil {
 			return err
@@ -157,6 +181,12 @@ var diveCmd = &cobra.Command{
 		printBanner()
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
+
+		// Start health monitor (does NOT stop Ollama on exit)
+		if ollamaMgr != nil {
+			ollamaMgr.StartHealthMonitor()
+			defer ollamaMgr.StopHealthMonitor()
+		}
 
 		if err := stack.hb.Start(ctx); err != nil {
 			klog.Warn("heartbeat start failed", "error", err)
@@ -213,7 +243,7 @@ var diveCmd = &cobra.Command{
 		fmt.Println(cDimCyan + "  " + randomFact() + cReset)
 
 		sigCh := make(chan os.Signal, 1)
-		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+		signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 		<-sigCh
 
 		fmt.Println()
@@ -223,6 +253,53 @@ var diveCmd = &cobra.Command{
 		_ = stack.mcp.Close()
 		return nil
 	},
+}
+
+// diveDaemon re-execs the dive command as a detached background process.
+func diveDaemon() error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve executable: %w", err)
+	}
+
+	logDir := filepath.Join(config.DataDir(), "logs")
+	_ = os.MkdirAll(logDir, 0755)
+	logPath := filepath.Join(logDir, "dive.log")
+
+	out, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("open log file: %w", err)
+	}
+
+	childArgs := []string{"dive", "--foreground"}
+	if verbose {
+		childArgs = append(childArgs, "--verbose")
+	}
+
+	child := exec.Command(exe, childArgs...)
+	child.Stdout = out
+	child.Stderr = out
+	child.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	if err := child.Start(); err != nil {
+		out.Close()
+		return fmt.Errorf("start daemon: %w", err)
+	}
+	out.Close()
+
+	// Detach - the parent does not wait for the child.
+	_ = child.Process.Release()
+
+	pidFile := filepath.Join(config.DataDir(), "krill.pid")
+	_ = os.WriteFile(pidFile, []byte(strconv.Itoa(child.Process.Pid)), 0644)
+
+	printBanner()
+	fmt.Printf(cBGreen+"  Mini Krill is swimming!"+cReset+" "+cDim+"(PID: %d)\n"+cReset, child.Process.Pid)
+	fmt.Printf(cDim+"  Log: %s\n"+cReset, logPath)
+	fmt.Println()
+	fmt.Println(cDim + "  Stop with: " + cReset + "minikrill surface")
+	fmt.Println()
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -72,7 +72,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "enable debug logging")
 
 	ollamaCmd.AddCommand(ollamaInstallCmd, ollamaStartCmd, ollamaStopCmd,
-		ollamaPullCmd, ollamaListCmd, ollamaStatusCmd)
+		ollamaPullCmd, ollamaListCmd, ollamaStatusCmd, ollamaEnsureCmd)
 	skillCmd.AddCommand(skillListCmd)
 	brainCmd.AddCommand(brainStatusCmd, brainRecallCmd, brainForgetCmd, brainSearchCmd)
 	personalityCmd.AddCommand(personalityListCmd, personalityCreateCmd, personalitySwitchCmd, personalityShowCmd)

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -25,7 +25,7 @@ ollama:
   host: "http://localhost:11434"
   auto_install: true
   auto_start: true
-  default_model: llama3.2
+  default_model: gemma4:e2b
 
 telegram:
   enabled: false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -138,7 +138,7 @@ func DefaultConfig() *Config {
 		},
 		LLM: LLMConfig{
 			Provider:    "ollama",
-			Model:       "llama3.2",
+			Model:       "gemma4:e2b",
 			Temperature: 0.7,
 			MaxTokens:   2048,
 		},
@@ -152,7 +152,7 @@ func DefaultConfig() *Config {
 			Host:         "http://localhost:11434",
 			AutoInstall:  true,
 			AutoStart:    true,
-			DefaultModel: "llama3.2",
+			DefaultModel: "gemma4:e2b",
 		},
 		Plugins: PluginsConfig{
 			Dir: filepath.Join(dataDir, "skills"),

--- a/internal/ollama/manager.go
+++ b/internal/ollama/manager.go
@@ -32,8 +32,11 @@ type OllamaManager struct {
 	host   string
 	client *http.Client
 
-	mu   sync.Mutex
-	proc *os.Process // tracked "ollama serve" process, if we started it
+	mu          sync.Mutex
+	proc        *os.Process // tracked "ollama serve" process, if we started it
+	weStartedIt bool        // true only if Start() spawned the process
+
+	monitorCancel context.CancelFunc // stops the background health monitor
 }
 
 // NewManager creates an OllamaManager targeting the configured host.
@@ -134,12 +137,28 @@ func (m *OllamaManager) installViaScript(ctx context.Context) error {
 // Lifecycle
 // ---------------------------------------------------------------------------
 
+// EnsureRunning checks if Ollama is healthy and starts it if not.
+// Intended as the single entry point for "make sure Ollama is up".
+func (m *OllamaManager) EnsureRunning(ctx context.Context) error {
+	if m.isHealthy(ctx) {
+		log.Debug("ollama is already running")
+		m.mu.Lock()
+		m.weStartedIt = false
+		m.mu.Unlock()
+		return nil
+	}
+	return m.Start(ctx)
+}
+
 // Start launches "ollama serve" as a background process. If Ollama is already
 // running (health check passes), this is a no-op.
 func (m *OllamaManager) Start(ctx context.Context) error {
 	// Already running?
 	if m.isHealthy(ctx) {
 		log.Debug("ollama is already running")
+		m.mu.Lock()
+		m.weStartedIt = false
+		m.mu.Unlock()
 		return nil
 	}
 
@@ -161,6 +180,7 @@ func (m *OllamaManager) Start(ctx context.Context) error {
 
 	m.mu.Lock()
 	m.proc = cmd.Process
+	m.weStartedIt = true
 	m.mu.Unlock()
 
 	// Release the process so it doesn't become a zombie if we exit
@@ -369,4 +389,107 @@ func (m *OllamaManager) isHealthy(ctx context.Context) bool {
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	return resp.StatusCode == http.StatusOK
+}
+
+// HasModel checks if a model is available locally.
+func (m *OllamaManager) HasModel(ctx context.Context, model string) bool {
+	models, err := m.ListModels(ctx)
+	if err != nil {
+		return false
+	}
+	base := strings.Split(strings.ToLower(model), ":")[0]
+	for _, mi := range models {
+		if strings.Split(strings.ToLower(mi.Name), ":")[0] == base {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Health monitor
+// ---------------------------------------------------------------------------
+
+// StartHealthMonitor begins a background goroutine that probes Ollama every
+// 15 seconds. If Ollama dies and we started it, auto-restart with backoff.
+func (m *OllamaManager) StartHealthMonitor() {
+	ctx, cancel := context.WithCancel(context.Background())
+	m.mu.Lock()
+	m.monitorCancel = cancel
+	m.mu.Unlock()
+
+	go m.healthMonitorLoop(ctx)
+	log.Info("ollama health monitor started")
+}
+
+// StopHealthMonitor stops the background health monitor goroutine.
+func (m *OllamaManager) StopHealthMonitor() {
+	m.mu.Lock()
+	cancel := m.monitorCancel
+	m.monitorCancel = nil
+	m.mu.Unlock()
+
+	if cancel != nil {
+		cancel()
+		log.Info("ollama health monitor stopped")
+	}
+}
+
+func (m *OllamaManager) healthMonitorLoop(ctx context.Context) {
+	const probeInterval = 15 * time.Second
+	const maxCrashes = 5
+	backoff := 2 * time.Second
+	backoffMax := 60 * time.Second
+	consecutiveCrashes := 0
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(probeInterval):
+		}
+
+		if m.isHealthy(ctx) {
+			if consecutiveCrashes > 0 {
+				log.Info("ollama recovered", "after_crashes", consecutiveCrashes)
+				consecutiveCrashes = 0
+				backoff = 2 * time.Second
+			}
+			continue
+		}
+
+		// Ollama is not healthy
+		m.mu.Lock()
+		weStarted := m.weStartedIt
+		m.mu.Unlock()
+
+		if !weStarted {
+			log.Warn("ollama is unreachable (not managed by us - will not restart)")
+			continue
+		}
+
+		consecutiveCrashes++
+		log.Warn("ollama crashed", "consecutive", consecutiveCrashes)
+
+		if consecutiveCrashes >= maxCrashes {
+			log.Error("ollama exceeded max consecutive crashes - giving up", "max", maxCrashes)
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+
+		log.Info("attempting ollama restart", "backoff", backoff)
+		if err := m.Start(ctx); err != nil {
+			log.Error("ollama restart failed", "error", err)
+		}
+
+		backoff = backoff * 2
+		if backoff > backoffMax {
+			backoff = backoffMax
+		}
+	}
 }

--- a/internal/ollama/manager.go
+++ b/internal/ollama/manager.go
@@ -142,9 +142,7 @@ func (m *OllamaManager) installViaScript(ctx context.Context) error {
 func (m *OllamaManager) EnsureRunning(ctx context.Context) error {
 	if m.isHealthy(ctx) {
 		log.Debug("ollama is already running")
-		m.mu.Lock()
-		m.weStartedIt = false
-		m.mu.Unlock()
+		// Don't reset weStartedIt — we may already own this process
 		return nil
 	}
 	return m.Start(ctx)
@@ -156,9 +154,7 @@ func (m *OllamaManager) Start(ctx context.Context) error {
 	// Already running?
 	if m.isHealthy(ctx) {
 		log.Debug("ollama is already running")
-		m.mu.Lock()
-		m.weStartedIt = false
-		m.mu.Unlock()
+		// Don't reset weStartedIt — we may already own this process
 		return nil
 	}
 
@@ -397,9 +393,16 @@ func (m *OllamaManager) HasModel(ctx context.Context, model string) bool {
 	if err != nil {
 		return false
 	}
-	base := strings.Split(strings.ToLower(model), ":")[0]
+	normalize := func(s string) string {
+		s = strings.ToLower(s)
+		if !strings.Contains(s, ":") {
+			s += ":latest"
+		}
+		return s
+	}
+	target := normalize(model)
 	for _, mi := range models {
-		if strings.Split(strings.ToLower(mi.Name), ":")[0] == base {
+		if normalize(mi.Name) == target {
 			return true
 		}
 	}
@@ -447,6 +450,10 @@ func (m *OllamaManager) healthMonitorLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-time.After(probeInterval):
+		}
+
+		if ctx.Err() != nil {
+			return
 		}
 
 		if m.isHealthy(ctx) {


### PR DESCRIPTION
## Summary

- Mini Krill now owns the Ollama process lifecycle for the colony (DeepKrill, Mini Krill, Lab Krill)
- Added `EnsureRunning()` method and `weStartedIt` tracking so we only restart processes we started
- Background health monitor (15s probe interval, exponential backoff restart, max 5 crashes)
- New `minikrill ollama ensure` command: install + start + pull in one shot for scripting
- `dive` command now auto-starts Ollama when `auto_start: true` (was a dead flag, now wired)
- `surface`/exit keeps Ollama running so other bots aren't affected
- Default model updated to `gemma4:e2b` across config and code defaults

## Test plan

- [ ] `minikrill ollama ensure` installs, starts, pulls gemma4:e2b, prints "ready"
- [ ] `minikrill dive` auto-starts Ollama before LLM init
- [ ] Kill Ollama process manually, verify health monitor restarts within 15s
- [ ] `minikrill surface` stops Mini Krill but Ollama keeps running
- [ ] `minikrill ollama stop` actually kills the Ollama process
- [ ] `minikrill ollama status` correctly reports running/stopped state