### PR TITLE
Fix chat input bar visibility and tab navigation

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -34,6 +34,9 @@ const (
 	TabChat      = 1
 	TabLogs      = 2
 	TabHelp      = 3
+
+	// layoutMargins is the vertical breathing room reserved between layout sections.
+	layoutMargins = 3
 )
 
 // ---------------------------------------------------------------------------
@@ -152,16 +155,7 @@ func (a *App) View() string {
 	body := a.renderBody()
 	footer := a.renderFooter()
 
-	// Calculate body height: total - header - tabs - footer - margins
-	headerLines := strings.Count(header, "\n") + 1
-	tabLines := strings.Count(tabBar, "\n") + 1
-	footerLines := strings.Count(footer, "\n") + 1
-	margins := 3 // breathing room
-
-	bodyHeight := a.height - headerLines - tabLines - footerLines - margins
-	if bodyHeight < 5 {
-		bodyHeight = 5
-	}
+	bodyHeight := a.bodyHeight()
 
 	// Constrain body to exact height
 	bodyStyled := lipgloss.NewStyle().
@@ -206,8 +200,8 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 	case "esc":
 		if inChat {
 			a.chat.Blur()
-			return nil
 		}
+		return nil
 
 	case "q":
 		if !inChat {
@@ -325,8 +319,16 @@ func (a *App) updateActiveView(msg tea.Msg) tea.Cmd {
 
 // resizeViews propagates terminal dimensions to all views.
 func (a *App) resizeViews() {
-	// Calculate body height exactly the same way View() does so
-	// the chat input bar doesn't get clipped off-screen.
+	h := a.bodyHeight()
+	a.dashboard.SetSize(a.width, h)
+	a.chat.SetSize(a.width, h)
+	a.logs.SetSize(a.width, h)
+	a.help.SetSize(a.width, h)
+}
+
+// bodyHeight computes the available vertical space for view content
+// by subtracting the actual rendered header, tab bar, and footer heights.
+func (a *App) bodyHeight() int {
 	header := RenderHeader(a.version, a.width)
 	tabBar := a.renderTabBar()
 	footer := a.renderFooter()
@@ -334,17 +336,12 @@ func (a *App) resizeViews() {
 	headerLines := strings.Count(header, "\n") + 1
 	tabLines := strings.Count(tabBar, "\n") + 1
 	footerLines := strings.Count(footer, "\n") + 1
-	margins := 3
 
-	bodyHeight := a.height - headerLines - tabLines - footerLines - margins
-	if bodyHeight < 5 {
-		bodyHeight = 5
+	h := a.height - headerLines - tabLines - footerLines - layoutMargins
+	if h < 5 {
+		h = 5
 	}
-
-	a.dashboard.SetSize(a.width, bodyHeight)
-	a.chat.SetSize(a.width, bodyHeight)
-	a.logs.SetSize(a.width, bodyHeight)
-	a.help.SetSize(a.width, bodyHeight)
+	return h
 }
 
 // renderTabBar builds the horizontal tab bar with active highlighting.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -203,20 +203,38 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 		a.quitting = true
 		return tea.Quit
 
+	case "esc":
+		if inChat {
+			a.chat.Blur()
+			return nil
+		}
+
 	case "q":
 		if !inChat {
 			a.quitting = true
 			return tea.Quit
 		}
 
-	case "tab", "right":
+	case "tab":
+		// Tab always switches tabs, even when chat input is focused
+		a.activeTab = (a.activeTab + 1) % len(a.tabs)
+		a.onTabSwitch()
+		return nil
+
+	case "shift+tab":
+		// Shift+Tab always switches tabs
+		a.activeTab = (a.activeTab - 1 + len(a.tabs)) % len(a.tabs)
+		a.onTabSwitch()
+		return nil
+
+	case "right":
 		if !inChat {
 			a.activeTab = (a.activeTab + 1) % len(a.tabs)
 			a.onTabSwitch()
 			return nil
 		}
 
-	case "shift+tab", "left":
+	case "left":
 		if !inChat {
 			a.activeTab = (a.activeTab - 1 + len(a.tabs)) % len(a.tabs)
 			a.onTabSwitch()
@@ -307,8 +325,18 @@ func (a *App) updateActiveView(msg tea.Msg) tea.Cmd {
 
 // resizeViews propagates terminal dimensions to all views.
 func (a *App) resizeViews() {
-	// Reserve space for header, tabs, footer
-	bodyHeight := a.height - 10
+	// Calculate body height exactly the same way View() does so
+	// the chat input bar doesn't get clipped off-screen.
+	header := RenderHeader(a.version, a.width)
+	tabBar := a.renderTabBar()
+	footer := a.renderFooter()
+
+	headerLines := strings.Count(header, "\n") + 1
+	tabLines := strings.Count(tabBar, "\n") + 1
+	footerLines := strings.Count(footer, "\n") + 1
+	margins := 3
+
+	bodyHeight := a.height - headerLines - tabLines - footerLines - margins
 	if bodyHeight < 5 {
 		bodyHeight = 5
 	}

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -2,6 +2,8 @@ package tui
 
 import (
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestSetInitialTab(t *testing.T) {
@@ -36,5 +38,69 @@ func TestSetInitialTab(t *testing.T) {
 		if app.activeTab != tab {
 			t.Errorf("expected tab %d, got %d", tab, app.activeTab)
 		}
+	}
+}
+
+// newSizedApp creates an App with dimensions set so handleKey works correctly.
+func newSizedApp() *App {
+	app := NewApp(nil, nil, nil, "test", "")
+	app.width = 100
+	app.height = 40
+	return app
+}
+
+func TestTabAlwaysSwitchesTabs(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Focus()
+
+	if !app.chat.Focused() {
+		t.Fatal("expected chat input to be focused")
+	}
+
+	// Tab should switch away from chat even when input is focused
+	app.handleKey(tea.KeyMsg{Type: tea.KeyTab})
+	if app.activeTab != TabLogs {
+		t.Errorf("expected Tab to switch to TabLogs (%d), got %d", TabLogs, app.activeTab)
+	}
+}
+
+func TestShiftTabAlwaysSwitchesTabs(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Focus()
+
+	app.handleKey(tea.KeyMsg{Type: tea.KeyShiftTab})
+	if app.activeTab != TabDashboard {
+		t.Errorf("expected Shift+Tab to switch to TabDashboard (%d), got %d", TabDashboard, app.activeTab)
+	}
+}
+
+func TestEscBlursChatInput(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Focus()
+
+	if !app.chat.Focused() {
+		t.Fatal("expected chat input to be focused before Esc")
+	}
+
+	app.handleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	if app.chat.Focused() {
+		t.Error("expected chat input to be blurred after Esc")
+	}
+}
+
+func TestEscDoesNotForwardWhenNotInChat(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabDashboard
+	startTab := app.activeTab
+
+	cmd := app.handleKey(tea.KeyMsg{Type: tea.KeyEscape})
+	if cmd != nil {
+		t.Error("expected Esc on Dashboard to return nil cmd")
+	}
+	if app.activeTab != startTab {
+		t.Errorf("expected tab to stay %d, got %d", startTab, app.activeTab)
 	}
 }

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -478,9 +478,10 @@ func (h *HelpView) View() string {
 
 	// --- Keyboard Shortcuts ---
 	shortcuts := []struct{ key, desc string }{
-		{"Tab / Shift+Tab", "Switch between tabs"},
+		{"Tab / Shift+Tab", "Switch between tabs (always works)"},
 		{"1 2 3 4", "Jump directly to tab"},
 		{"Right / Left", "Next / previous tab"},
+		{"Esc", "Unfocus chat input"},
 		{"j / k", "Scroll down / up (logs)"},
 		{"Enter", "Send message (chat)"},
 		{"q / Ctrl+C", "Quit (not in chat input)"},


### PR DESCRIPTION
## Summary
- **Chat input bar invisible**: `resizeViews()` hardcoded 10 lines of overhead for header/tabs/footer, but the ASCII art header takes 14 lines (full mode). This over-allocated body height by ~11 lines, pushing the input bar off-screen. Fixed by computing body height identically to `View()` — rendering actual header/tabbar/footer and counting lines.
- **Tab switching stuck on Chat tab**: Tab/Shift+Tab were blocked when chat input was focused, trapping users. Now Tab/Shift+Tab always switch tabs regardless of input focus. Arrow keys and number keys still require Esc to blur first (needed for cursor movement and typing).
- **Escape key handling**: Added explicit Esc handler to blur chat input and documented it in the Help tab.

## Test plan
- [ ] Run `minikrill chat` — verify the chat input bar with cyan border is visible at the bottom
- [ ] Type a message and press Enter — verify text is visible while typing and message sends
- [ ] Press Tab/Shift+Tab from any tab — verify it cycles through Dashboard, Chat, Logs, Help
- [ ] On Chat tab with input focused, press Tab — verify it switches to the next tab
- [ ] Press Esc on Chat tab — verify input blurs (cursor disappears)
- [ ] Resize terminal window — verify input bar stays visible at all sizes
- [ ] Check Help tab — verify Esc shortcut is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)