### PR TITLE
Fix double keypress, start bots from chat/tui, preserve tokens

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -44,7 +44,11 @@ var initCmd = &cobra.Command{
 		fmt.Println(cDim + "  Recommended local model: gemma3:4b. Low-memory fallback: llama3.2:3b." + cReset)
 		fmt.Println()
 
-		cfg := config.DefaultConfig()
+		// Load existing config so tokens and other settings survive re-init.
+		cfg, _ := config.Load()
+		if cfg == nil {
+			cfg = config.DefaultConfig()
+		}
 		scanner := bufio.NewScanner(os.Stdin)
 
 		fmt.Println(cBCyan + "  Choose your LLM provider:" + cReset)
@@ -182,21 +186,44 @@ var initCmd = &cobra.Command{
 		}
 
 		fmt.Println()
-		if ans := ask(scanner, cCyan+"  Enable Telegram bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
+		// Telegram setup - preserve existing token if user skips
+		if cfg.Telegram.Token != "" {
+			fmt.Println(cDim + "  Telegram bot token already configured." + cReset)
+			if ans := ask(scanner, cCyan+"  Replace Telegram token? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
+				fmt.Println(cDim + "  To get a bot token, message @BotFather on Telegram → /newbot → follow the prompts." + cReset)
+				token := ask(scanner, cCyan+"  Bot token: "+cReset)
+				if token != "" {
+					cfg.Telegram.Token = token
+				}
+			}
+			cfg.Telegram.Enabled = true
+		} else if ans := ask(scanner, cCyan+"  Enable Telegram bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
 			fmt.Println(cDim + "  To get a bot token, message @BotFather on Telegram → /newbot → follow the prompts." + cReset)
 			cfg.Telegram.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
 			cfg.Telegram.Enabled = cfg.Telegram.Token != ""
-			if cfg.Telegram.Enabled {
-				fmt.Println(cDim + "  Bot saved! Run " + cReset + "minikrill dive" + cDim + " to start it, then send " + cReset + "/start" + cDim + " to your bot on Telegram." + cReset)
-			}
 		}
-		if ans := ask(scanner, cCyan+"  Enable Discord bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
+		if cfg.Telegram.Enabled {
+			fmt.Println(cDim + "  Telegram bot saved! Run " + cReset + "minikrill dive" + cDim + " to start it, then send " + cReset + "/start" + cDim + " to your bot on Telegram." + cReset)
+		}
+
+		// Discord setup - preserve existing token if user skips
+		if cfg.Discord.Token != "" {
+			fmt.Println(cDim + "  Discord bot token already configured." + cReset)
+			if ans := ask(scanner, cCyan+"  Replace Discord token? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
+				fmt.Println(cDim + "  Create a bot at https://discord.com/developers/applications → Bot → Copy token." + cReset)
+				token := ask(scanner, cCyan+"  Bot token: "+cReset)
+				if token != "" {
+					cfg.Discord.Token = token
+				}
+			}
+			cfg.Discord.Enabled = true
+		} else if ans := ask(scanner, cCyan+"  Enable Discord bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
 			fmt.Println(cDim + "  Create a bot at https://discord.com/developers/applications → Bot → Copy token." + cReset)
 			cfg.Discord.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
 			cfg.Discord.Enabled = cfg.Discord.Token != ""
-			if cfg.Discord.Enabled {
-				fmt.Println(cDim + "  Bot saved! Run " + cReset + "minikrill dive" + cDim + " to start it." + cReset)
-			}
+		}
+		if cfg.Discord.Enabled {
+			fmt.Println(cDim + "  Discord bot saved! Run " + cReset + "minikrill dive" + cDim + " to start it." + cReset)
 		}
 
 		if err := config.EnsureDataDir(); err != nil {
@@ -287,40 +314,19 @@ var diveCmd = &cobra.Command{
 		fmt.Printf("  "+cDim+"Brain:"+cReset+"    %d memories\n", stack.brain.Memory().Count())
 		fmt.Printf("  "+cDim+"Skills:"+cReset+"   %d registered\n", len(stack.skills.List()))
 
+		bs := startBots(ctx, stack)
 		if stack.cfg.Telegram.Enabled {
-			tgBot, err := chat.NewTelegramBot(stack.cfg.Telegram, stack.handler)
-			if err != nil {
-				fmt.Printf("  "+cRed+"Telegram: %s\n"+cReset, friendlyError(err))
-			} else {
-				tgBot.SetProviderManager(stack.llm)
-				tgBot.SetLearnFunc(func(ctx context.Context, key, value string) error {
-					return stack.brain.Memory().Store(ctx, core.MemoryEntry{
-						Key:        key,
-						Value:      value,
-						Tags:       []string{"group-learned", "telegram"},
-						CreatedAt:  time.Now(),
-						AccessedAt: time.Now(),
-					})
-				})
-				go func() {
-					if err := tgBot.Start(ctx); err != nil {
-						klog.Error("telegram error", "error", err)
-					}
-				}()
+			if bs.TelegramOK {
 				fmt.Println("  " + cGreen + "Telegram: swimming" + cReset)
+			} else {
+				fmt.Printf("  "+cRed+"Telegram: %s\n"+cReset, friendlyError(bs.TelegramErr))
 			}
 		}
 		if stack.cfg.Discord.Enabled {
-			dcBot, err := chat.NewDiscordBot(stack.cfg.Discord, stack.handler)
-			if err != nil {
-				fmt.Printf("  "+cRed+"Discord: %s\n"+cReset, friendlyError(err))
-			} else {
-				go func() {
-					if err := dcBot.Start(ctx); err != nil {
-						klog.Error("discord error", "error", err)
-					}
-				}()
+			if bs.DiscordOK {
 				fmt.Println("  " + cGreen + "Discord:  swimming" + cReset)
+			} else {
+				fmt.Printf("  "+cRed+"Discord: %s\n"+cReset, friendlyError(bs.DiscordErr))
 			}
 		}
 		if reminderStore, err := newReminderStore(); err == nil {
@@ -442,6 +448,61 @@ var surfaceCmd = &cobra.Command{
 	},
 }
 
+// botStatus holds the result of starting chat bots.
+type botStatus struct {
+	TelegramOK bool
+	TelegramErr error
+	DiscordOK  bool
+	DiscordErr error
+}
+
+// startBots launches Telegram and Discord bots in the background when enabled.
+// Bots are tied to ctx and will shut down when the context is cancelled.
+func startBots(ctx context.Context, stack *krillStack) botStatus {
+	var s botStatus
+	if stack.cfg.Telegram.Enabled {
+		tgBot, err := chat.NewTelegramBot(stack.cfg.Telegram, stack.handler)
+		if err != nil {
+			s.TelegramErr = err
+			klog.Warn("telegram bot failed to start", "error", err)
+		} else {
+			tgBot.SetProviderManager(stack.llm)
+			tgBot.SetLearnFunc(func(ctx context.Context, key, value string) error {
+				return stack.brain.Memory().Store(ctx, core.MemoryEntry{
+					Key:        key,
+					Value:      value,
+					Tags:       []string{"group-learned", "telegram"},
+					CreatedAt:  time.Now(),
+					AccessedAt: time.Now(),
+				})
+			})
+			go func() {
+				if err := tgBot.Start(ctx); err != nil {
+					klog.Error("telegram error", "error", err)
+				}
+			}()
+			s.TelegramOK = true
+			klog.Info("telegram bot started")
+		}
+	}
+	if stack.cfg.Discord.Enabled {
+		dcBot, err := chat.NewDiscordBot(stack.cfg.Discord, stack.handler)
+		if err != nil {
+			s.DiscordErr = err
+			klog.Warn("discord bot failed to start", "error", err)
+		} else {
+			go func() {
+				if err := dcBot.Start(ctx); err != nil {
+					klog.Error("discord error", "error", err)
+				}
+			}()
+			s.DiscordOK = true
+			klog.Info("discord bot started")
+		}
+	}
+	return s
+}
+
 // ---------------------------------------------------------------------------
 // chat command
 // ---------------------------------------------------------------------------
@@ -459,6 +520,8 @@ var chatCmd = &cobra.Command{
 		defer cancel()
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
+
+		startBots(ctx, stack)
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, core.Version, stack.cfg.Log.File)
 		app.SetInitialTab(tui.TabChat)
@@ -483,6 +546,8 @@ var tuiCmd = &cobra.Command{
 		defer cancel()
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
+
+		startBots(ctx, stack)
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, core.Version, stack.cfg.Log.File)
 		return app.Run()

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -186,7 +186,7 @@ var initCmd = &cobra.Command{
 		}
 
 		fmt.Println()
-		// Telegram setup - preserve existing token if user skips
+		// Telegram setup - preserve existing token and enabled state if user skips
 		if cfg.Telegram.Token != "" {
 			fmt.Println(cDim + "  Telegram bot token already configured." + cReset)
 			if ans := ask(scanner, cCyan+"  Replace Telegram token? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
@@ -194,9 +194,9 @@ var initCmd = &cobra.Command{
 				token := ask(scanner, cCyan+"  Bot token: "+cReset)
 				if token != "" {
 					cfg.Telegram.Token = token
+					cfg.Telegram.Enabled = true
 				}
 			}
-			cfg.Telegram.Enabled = true
 		} else if ans := ask(scanner, cCyan+"  Enable Telegram bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
 			fmt.Println(cDim + "  To get a bot token, message @BotFather on Telegram → /newbot → follow the prompts." + cReset)
 			cfg.Telegram.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
@@ -206,7 +206,7 @@ var initCmd = &cobra.Command{
 			fmt.Println(cDim + "  Telegram bot saved! Run " + cReset + "minikrill dive" + cDim + " to start it, then send " + cReset + "/start" + cDim + " to your bot on Telegram." + cReset)
 		}
 
-		// Discord setup - preserve existing token if user skips
+		// Discord setup - preserve existing token and enabled state if user skips
 		if cfg.Discord.Token != "" {
 			fmt.Println(cDim + "  Discord bot token already configured." + cReset)
 			if ans := ask(scanner, cCyan+"  Replace Discord token? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
@@ -214,9 +214,9 @@ var initCmd = &cobra.Command{
 				token := ask(scanner, cCyan+"  Bot token: "+cReset)
 				if token != "" {
 					cfg.Discord.Token = token
+					cfg.Discord.Enabled = true
 				}
 			}
-			cfg.Discord.Enabled = true
 		} else if ans := ask(scanner, cCyan+"  Enable Discord bot? "+cDim+"[y/N]"+cReset+" "); strings.HasPrefix(strings.ToLower(ans), "y") {
 			fmt.Println(cDim + "  Create a bot at https://discord.com/developers/applications → Bot → Copy token." + cReset)
 			cfg.Discord.Token = ask(scanner, cCyan+"  Bot token: "+cReset)
@@ -450,10 +450,10 @@ var surfaceCmd = &cobra.Command{
 
 // botStatus holds the result of starting chat bots.
 type botStatus struct {
-	TelegramOK bool
+	TelegramOK  bool
 	TelegramErr error
-	DiscordOK  bool
-	DiscordErr error
+	DiscordOK   bool
+	DiscordErr  error
 }
 
 // startBots launches Telegram and Discord bots in the background when enabled.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -117,6 +117,9 @@ func (a *App) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if a.quitting {
 			return a, tea.Quit
 		}
+		// handleKey already forwards unhandled keys to updateActiveView,
+		// so return here to avoid processing the same key twice.
+		return a, tea.Batch(cmds...)
 
 	case tickMsg:
 		a.onTick()

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -91,6 +91,25 @@ func TestEscBlursChatInput(t *testing.T) {
 	}
 }
 
+// TestUpdateKeyMsgNotDoubleDispatched verifies that App.Update returns after
+// handleKey without forwarding the same KeyMsg to updateActiveView a second
+// time. This is a regression test for the double-character-input bug.
+func TestUpdateKeyMsgNotDoubleDispatched(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Focus()
+	// Resize so the chat view is ready
+	app.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	// Type a character via Update (not handleKey) to exercise the full path.
+	app.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+
+	got := app.chat.input.Value()
+	if got != "a" {
+		t.Errorf("expected input value %q after one keypress, got %q (double dispatch?)", "a", got)
+	}
+}
+
 func TestEscDoesNotForwardWhenNotInChat(t *testing.T) {
 	app := newSizedApp()
 	app.activeTab = TabDashboard

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -257,11 +257,14 @@ func (c *ChatView) Update(msg tea.Msg) tea.Cmd {
 	c.viewport, cmd = c.viewport.Update(msg)
 	cmds = append(cmds, cmd)
 
-	// Animate spinner while waiting for response
+	// Animate spinner while waiting for response — only refresh viewport on
+	// spinner ticks to avoid rebuilding chat content on every message.
 	if c.waiting {
-		c.spinner, cmd = c.spinner.Update(msg)
-		cmds = append(cmds, cmd)
-		c.refreshViewport()
+		if _, ok := msg.(spinner.TickMsg); ok {
+			c.spinner, cmd = c.spinner.Update(msg)
+			cmds = append(cmds, cmd)
+			c.refreshViewport()
+		}
 	}
 
 	return tea.Batch(cmds...)

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textinput"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
@@ -126,6 +127,7 @@ type ChatView struct {
 	messages []chatEntry
 	input    textinput.Model
 	viewport viewport.Model
+	spinner  spinner.Model
 	width    int
 	height   int
 	agent    core.Agent
@@ -148,6 +150,10 @@ func NewChatView(agent core.Agent) ChatView {
 	vp := viewport.New(80, 20)
 	vp.Style = lipgloss.NewStyle().Foreground(ColorWhite)
 
+	sp := spinner.New()
+	sp.Spinner = spinner.Dot
+	sp.Style = lipgloss.NewStyle().Foreground(ColorCyan)
+
 	greeting := chatEntry{
 		sender: "krill",
 		text:   "Hey there! I'm Mini Krill, your crustaceous AI buddy. I live in the deep ocean of your terminal. Ask me anything - I might be small, but I'm part of the largest biomass on Earth!",
@@ -158,6 +164,7 @@ func NewChatView(agent core.Agent) ChatView {
 		messages: []chatEntry{greeting},
 		input:    ti,
 		viewport: vp,
+		spinner:  sp,
 		agent:    agent,
 	}
 }
@@ -223,8 +230,8 @@ func (c *ChatView) Update(msg tea.Msg) tea.Cmd {
 			c.waiting = true
 			c.refreshViewport()
 
-			// Send to agent in goroutine
-			return c.sendChat(text)
+			// Send to agent in goroutine; start spinner alongside
+			return tea.Batch(c.sendChat(text), c.spinner.Tick)
 		}
 	case chatResponseMsg:
 		c.waiting = false
@@ -249,6 +256,13 @@ func (c *ChatView) Update(msg tea.Msg) tea.Cmd {
 
 	c.viewport, cmd = c.viewport.Update(msg)
 	cmds = append(cmds, cmd)
+
+	// Animate spinner while waiting for response
+	if c.waiting {
+		c.spinner, cmd = c.spinner.Update(msg)
+		cmds = append(cmds, cmd)
+		c.refreshViewport()
+	}
 
 	return tea.Batch(cmds...)
 }
@@ -301,10 +315,10 @@ func (c *ChatView) refreshViewport() {
 		}
 	}
 
-	// Waiting indicator
+	// Animated waiting indicator
 	if c.waiting {
-		spinner := AccentStyle.Render("  ~ Krill is diving deep... ~")
-		lines = append(lines, spinner)
+		thinking := fmt.Sprintf("  %s Krill is thinking...", c.spinner.View())
+		lines = append(lines, AccentStyle.Render(thinking))
 	}
 
 	content := strings.Join(lines, "\n")


### PR DESCRIPTION
## Summary

- **Fix double character input in TUI chat** — `App.Update()` forwarded every `KeyMsg` to `updateActiveView` twice (once inside `handleKey()`, once after the switch block), causing each keystroke to register two characters
- **Start Telegram/Discord bots from `chat` and `tui` commands** — previously only `dive` launched bots, so tokens configured during setup had no effect when using the TUI. Extracted shared `startBots()` helper used by all three commands
- **Preserve bot tokens on re-init** — `minikrill init` used to start from `DefaultConfig()`, silently wiping existing tokens if the user skipped the prompts. Now loads existing config first and only overwrites tokens on explicit replace
- **Animated thinking spinner** — replaced static "diving deep" text with a `bubbles/spinner` that animates while waiting for LLM response

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 12 packages)
- [ ] Run `minikrill chat`, type in the input — each character should appear once
- [ ] Run `minikrill chat` with Telegram enabled — bot should respond to messages
- [ ] Run `minikrill init` with existing tokens — should show "already configured" and preserve on skip
- [ ] Send a message in chat — animated spinner should appear until response arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)