### PR TITLE
Add YouTube video summarization and transcript extraction

### DIFF
--- a/cmd/minikrill/cmd_content.go
+++ b/cmd/minikrill/cmd_content.go
@@ -12,10 +12,12 @@ import (
 )
 
 var (
-	summarizeTimeout    time.Duration
-	webReadTimeout      time.Duration
-	webSummarizeTimeout time.Duration
-	researchTimeout     time.Duration
+	summarizeTimeout         time.Duration
+	webReadTimeout           time.Duration
+	webSummarizeTimeout      time.Duration
+	researchTimeout          time.Duration
+	youtubeTimeout           time.Duration
+	youtubeSummarizeTimeout  time.Duration
 )
 
 var summarizeCmd = &cobra.Command{
@@ -110,10 +112,70 @@ var researchCmd = &cobra.Command{
 	},
 }
 
+// ---------------------------------------------------------------------------
+// youtube commands
+// ---------------------------------------------------------------------------
+
+var youtubeCmd = &cobra.Command{
+	Use:   "youtube [url]",
+	Short: "Extract transcript from a YouTube video",
+	Long: `Extract the transcript/captions from a YouTube video.
+
+Supports standard URLs, short links, embeds, and Shorts:
+  minikrill youtube https://www.youtube.com/watch?v=dQw4w9WgXcQ
+  minikrill youtube https://youtu.be/dQw4w9WgXcQ
+
+Use 'youtube summarize' to get an AI-generated summary with key takeaways.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), youtubeTimeout)
+		defer cancel()
+		doc, err := content.ReadYouTube(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		fmt.Println(doc.Text)
+		return nil
+	},
+}
+
+var youtubeSummarizeCmd = &cobra.Command{
+	Use:   "summarize [url]",
+	Short: "Summarize a YouTube video with key takeaways",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		stack, err := initStack(true)
+		if err != nil {
+			return err
+		}
+		defer stack.brain.Close()
+		ctx, cancel := context.WithTimeout(context.Background(), youtubeSummarizeTimeout)
+		defer cancel()
+		doc, err := content.ReadYouTube(ctx, args[0])
+		if err != nil {
+			return err
+		}
+		instruction := "Summarize this YouTube video transcript. Provide:\n" +
+			"1. A brief overview (2-3 sentences)\n" +
+			"2. Key takeaways (bulleted list)\n" +
+			"3. Notable quotes or points (if any)\n" +
+			"Keep the summary concise and actionable."
+		out, err := content.Summarize(ctx, stack.llm, []content.Document{doc}, instruction)
+		if err != nil {
+			return err
+		}
+		fmt.Println(out)
+		return nil
+	},
+}
+
 func init() {
 	summarizeCmd.Flags().DurationVar(&summarizeTimeout, "timeout", 2*time.Minute, "max time for fetch and summary")
 	webReadCmd.Flags().DurationVar(&webReadTimeout, "timeout", 2*time.Minute, "max time for fetch")
 	webSummarizeCmd.Flags().DurationVar(&webSummarizeTimeout, "timeout", 2*time.Minute, "max time for fetch and summary")
 	researchCmd.Flags().DurationVar(&researchTimeout, "timeout", 2*time.Minute, "max time for research")
+	youtubeCmd.Flags().DurationVar(&youtubeTimeout, "timeout", 2*time.Minute, "max time for transcript fetch")
+	youtubeSummarizeCmd.Flags().DurationVar(&youtubeSummarizeTimeout, "timeout", 3*time.Minute, "max time for fetch and summary")
 	webCmd.AddCommand(webReadCmd, webSummarizeCmd)
+	youtubeCmd.AddCommand(youtubeSummarizeCmd)
 }

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -92,7 +92,7 @@ func init() {
 
 	rootCmd.AddCommand(initCmd, diveCmd, surfaceCmd, chatCmd, tuiCmd,
 		doctorCmd, sonarCmd, versionCmd, ollamaCmd, skillCmd, brainCmd, personalityCmd,
-		runCmd, notifyCmd, remindCmd, remindersCmd, summarizeCmd, webCmd, researchCmd)
+		runCmd, notifyCmd, remindCmd, remindersCmd, summarizeCmd, webCmd, researchCmd, youtubeCmd)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/content/content.go
+++ b/internal/content/content.go
@@ -31,6 +31,14 @@ type SearchResult struct {
 
 func ReadTarget(ctx context.Context, target string) ([]Document, error) {
 	if strings.HasPrefix(target, "http://") || strings.HasPrefix(target, "https://") {
+		// Route YouTube URLs through the transcript extractor.
+		if IsYouTubeURL(target) {
+			doc, err := ReadYouTube(ctx, target)
+			if err != nil {
+				return nil, err
+			}
+			return []Document{doc}, nil
+		}
 		doc, err := ReadURL(ctx, target)
 		if err != nil {
 			return nil, err

--- a/internal/content/youtube.go
+++ b/internal/content/youtube.go
@@ -1,0 +1,244 @@
+package content
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// youtubeIDPatterns matches the common YouTube URL formats and extracts the video ID.
+var youtubeIDPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?:youtube\.com/watch\?.*v=|youtu\.be/|youtube\.com/embed/|youtube\.com/v/|youtube\.com/shorts/)([a-zA-Z0-9_-]{11})`),
+}
+
+// IsYouTubeURL returns true if the URL points to a YouTube video.
+func IsYouTubeURL(rawURL string) bool {
+	return extractVideoID(rawURL) != ""
+}
+
+// extractVideoID pulls the 11-character video ID from a YouTube URL.
+func extractVideoID(rawURL string) string {
+	for _, pat := range youtubeIDPatterns {
+		if m := pat.FindStringSubmatch(rawURL); len(m) >= 2 {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// ReadYouTube fetches the transcript/captions for a YouTube video and returns
+// it as a Document. It works without an API key by scraping the video page for
+// caption track metadata, then fetching the timed-text XML.
+func ReadYouTube(ctx context.Context, rawURL string) (Document, error) {
+	videoID := extractVideoID(rawURL)
+	if videoID == "" {
+		return Document{}, fmt.Errorf("could not extract YouTube video ID from %q", rawURL)
+	}
+
+	pageURL := "https://www.youtube.com/watch?v=" + videoID
+
+	// Fetch the video page to extract caption tracks and title.
+	client := newSafeHTTPClient(20 * time.Second)
+	req, err := http.NewRequestWithContext(ctx, "GET", pageURL, nil)
+	if err != nil {
+		return Document{}, err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; MiniKrill/0.1)")
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Document{}, fmt.Errorf("fetch YouTube page: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return Document{}, fmt.Errorf("YouTube returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return Document{}, fmt.Errorf("read YouTube page: %w", err)
+	}
+	page := string(body)
+
+	title := extractVideoTitle(page)
+	captionURL := extractCaptionURL(page)
+	if captionURL == "" {
+		// No captions available - fall back to page metadata summary.
+		desc := extractVideoDescription(page)
+		if desc == "" && title == "" {
+			return Document{}, fmt.Errorf("no captions or metadata found for video %s", videoID)
+		}
+		text := formatVideoMeta(title, desc, videoID)
+		return Document{Source: pageURL, Text: text}, nil
+	}
+
+	// Fetch the caption XML.
+	transcript, err := fetchCaptionXML(ctx, client, captionURL)
+	if err != nil {
+		return Document{}, fmt.Errorf("fetch captions: %w", err)
+	}
+
+	var b strings.Builder
+	if title != "" {
+		b.WriteString("Video: " + title + "\n")
+		b.WriteString("URL: " + pageURL + "\n\n")
+	}
+	b.WriteString("Transcript:\n")
+	b.WriteString(transcript)
+
+	return Document{Source: pageURL, Text: b.String()}, nil
+}
+
+// captionURLRe extracts the first captionTrack baseUrl from the player response JSON
+// embedded in the YouTube page. We look for English captions first, then fall back to any.
+var captionURLRe = regexp.MustCompile(`"captionTracks"\s*:\s*\[([^\]]+)\]`)
+var baseURLRe = regexp.MustCompile(`"baseUrl"\s*:\s*"([^"]+)"`)
+var langRe = regexp.MustCompile(`"languageCode"\s*:\s*"([^"]+)"`)
+
+func extractCaptionURL(page string) string {
+	m := captionURLRe.FindStringSubmatch(page)
+	if len(m) < 2 {
+		return ""
+	}
+	tracks := m[1]
+
+	// Split into individual track objects (heuristic: split on },{)
+	parts := strings.Split(tracks, "},{")
+
+	// First pass: look for English.
+	for _, part := range parts {
+		if lm := langRe.FindStringSubmatch(part); len(lm) >= 2 {
+			lang := lm[1]
+			if strings.HasPrefix(lang, "en") {
+				if bm := baseURLRe.FindStringSubmatch(part); len(bm) >= 2 {
+					return unescapeJSON(bm[1])
+				}
+			}
+		}
+	}
+
+	// Second pass: take the first available track.
+	if bm := baseURLRe.FindStringSubmatch(tracks); len(bm) >= 2 {
+		return unescapeJSON(bm[1])
+	}
+	return ""
+}
+
+var titleRe = regexp.MustCompile(`<title>([^<]+)</title>`)
+var metaTitleRe = regexp.MustCompile(`"title"\s*:\s*"([^"]*)"`)
+
+func extractVideoTitle(page string) string {
+	// Try og:title or <title> tag first.
+	if m := titleRe.FindStringSubmatch(page); len(m) >= 2 {
+		t := strings.TrimSuffix(m[1], " - YouTube")
+		return strings.TrimSpace(t)
+	}
+	if m := metaTitleRe.FindStringSubmatch(page); len(m) >= 2 {
+		return unescapeJSON(m[1])
+	}
+	return ""
+}
+
+var descRe = regexp.MustCompile(`"shortDescription"\s*:\s*"([^"]*(?:\\.[^"]*)*)"`)
+
+func extractVideoDescription(page string) string {
+	if m := descRe.FindStringSubmatch(page); len(m) >= 2 {
+		return unescapeJSON(m[1])
+	}
+	return ""
+}
+
+func formatVideoMeta(title, desc, videoID string) string {
+	var b strings.Builder
+	if title != "" {
+		b.WriteString("Video: " + title + "\n")
+	}
+	b.WriteString("URL: https://www.youtube.com/watch?v=" + videoID + "\n\n")
+	b.WriteString("Note: No captions/transcript available for this video.\n\n")
+	if desc != "" {
+		b.WriteString("Description:\n" + desc + "\n")
+	}
+	return b.String()
+}
+
+// unescapeJSON handles the common JSON string escapes found in YouTube's inline JS.
+func unescapeJSON(s string) string {
+	s = strings.ReplaceAll(s, `\\`, `\`)
+	s = strings.ReplaceAll(s, `\"`, `"`)
+	s = strings.ReplaceAll(s, `\/`, `/`)
+	s = strings.ReplaceAll(s, `\n`, "\n")
+	s = strings.ReplaceAll(s, `\t`, "\t")
+	s = strings.ReplaceAll(s, `\u0026`, "&")
+	return s
+}
+
+// timedText is the XML structure YouTube returns for captions.
+type timedText struct {
+	XMLName xml.Name   `xml:"transcript"`
+	Texts   []textNode `xml:"text"`
+}
+
+type textNode struct {
+	Start string `xml:"start,attr"`
+	Dur   string `xml:"dur,attr"`
+	Text  string `xml:",chardata"`
+}
+
+func fetchCaptionXML(ctx context.Context, client *http.Client, captionURL string) (string, error) {
+	// Ensure we request XML format (fmt=3 is timed text XML).
+	u, err := url.Parse(captionURL)
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("fmt", "3")
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (compatible; MiniKrill/0.1)")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("caption fetch returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
+	if err != nil {
+		return "", err
+	}
+
+	var tt timedText
+	if err := xml.Unmarshal(body, &tt); err != nil {
+		// If XML parsing fails, return raw text extraction as fallback.
+		return ExtractText(string(body)), nil
+	}
+
+	var b strings.Builder
+	for _, t := range tt.Texts {
+		line := strings.TrimSpace(t.Text)
+		if line == "" {
+			continue
+		}
+		// Unescape HTML entities in caption text.
+		line = ExtractText(line)
+		b.WriteString(line)
+		b.WriteString(" ")
+	}
+	return strings.TrimSpace(b.String()), nil
+}

--- a/internal/content/youtube.go
+++ b/internal/content/youtube.go
@@ -2,6 +2,7 @@ package content
 
 import (
 	"context"
+	"encoding/json"
 	"encoding/xml"
 	"fmt"
 	"io"
@@ -12,10 +13,8 @@ import (
 	"time"
 )
 
-// youtubeIDPatterns matches the common YouTube URL formats and extracts the video ID.
-var youtubeIDPatterns = []*regexp.Regexp{
-	regexp.MustCompile(`(?:youtube\.com/watch\?.*v=|youtu\.be/|youtube\.com/embed/|youtube\.com/v/|youtube\.com/shorts/)([a-zA-Z0-9_-]{11})`),
-}
+// youtubeIDPattern matches the common YouTube URL formats and extracts the video ID.
+var youtubeIDPattern = regexp.MustCompile(`(?:youtube\.com/watch\?.*v=|youtu\.be/|youtube\.com/embed/|youtube\.com/v/|youtube\.com/shorts/)([a-zA-Z0-9_-]{11})`)
 
 // IsYouTubeURL returns true if the URL points to a YouTube video.
 func IsYouTubeURL(rawURL string) bool {
@@ -24,10 +23,8 @@ func IsYouTubeURL(rawURL string) bool {
 
 // extractVideoID pulls the 11-character video ID from a YouTube URL.
 func extractVideoID(rawURL string) string {
-	for _, pat := range youtubeIDPatterns {
-		if m := pat.FindStringSubmatch(rawURL); len(m) >= 2 {
-			return m[1]
-		}
+	if m := youtubeIDPattern.FindStringSubmatch(rawURL); len(m) >= 2 {
+		return m[1]
 	}
 	return ""
 }
@@ -110,7 +107,10 @@ func extractCaptionURL(page string) string {
 	}
 	tracks := m[1]
 
-	// Split into individual track objects (heuristic: split on },{)
+	// Split into individual track objects. This is a heuristic: it assumes
+	// },{ never appears inside a JSON string value. In practice YouTube's
+	// caption track objects contain only simple key-value pairs, so this
+	// holds for real-world responses.
 	parts := strings.Split(tracks, "},{")
 
 	// First pass: look for English.
@@ -169,15 +169,15 @@ func formatVideoMeta(title, desc, videoID string) string {
 	return b.String()
 }
 
-// unescapeJSON handles the common JSON string escapes found in YouTube's inline JS.
+// unescapeJSON decodes a JSON-encoded string value. The input is expected to be
+// the content between quotes (not including the quotes themselves) from YouTube's
+// inline player response JSON.
 func unescapeJSON(s string) string {
-	s = strings.ReplaceAll(s, `\\`, `\`)
-	s = strings.ReplaceAll(s, `\"`, `"`)
-	s = strings.ReplaceAll(s, `\/`, `/`)
-	s = strings.ReplaceAll(s, `\n`, "\n")
-	s = strings.ReplaceAll(s, `\t`, "\t")
-	s = strings.ReplaceAll(s, `\u0026`, "&")
-	return s
+	var out string
+	if err := json.Unmarshal([]byte(`"`+s+`"`), &out); err != nil {
+		return s
+	}
+	return out
 }
 
 // timedText is the XML structure YouTube returns for captions.

--- a/internal/content/youtube_test.go
+++ b/internal/content/youtube_test.go
@@ -1,6 +1,10 @@
 package content
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -54,7 +58,7 @@ func TestExtractCaptionURL(t *testing.T) {
 	if got == "" {
 		t.Fatal("expected a caption URL, got empty string")
 	}
-	if !containsStr(got, "lang=en") {
+	if !strings.Contains(got, "lang=en") {
 		t.Errorf("expected English caption URL, got %q", got)
 	}
 }
@@ -67,7 +71,7 @@ func TestExtractCaptionURL_FallbackToFirst(t *testing.T) {
 	if got == "" {
 		t.Fatal("expected fallback caption URL, got empty string")
 	}
-	if !containsStr(got, "lang=ja") {
+	if !strings.Contains(got, "lang=ja") {
 		t.Errorf("expected Japanese caption URL, got %q", got)
 	}
 }
@@ -106,15 +110,67 @@ func TestUnescapeJSON(t *testing.T) {
 	}
 }
 
-func containsStr(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstring(s, sub))
-}
+func TestReadYouTube_Integration(t *testing.T) {
+	// Fake caption XML served by the test server.
+	captionXML := `<?xml version="1.0" encoding="utf-8"?>
+<transcript>
+  <text start="0.0" dur="2.5">Hello and welcome</text>
+  <text start="2.5" dur="3.0">to this test video</text>
+  <text start="5.5" dur="2.0">about krill facts</text>
+</transcript>`
 
-func containsSubstring(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
+	// Build a fake YouTube page with embedded player response.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/watch", func(w http.ResponseWriter, r *http.Request) {
+		// The caption URL points back to our test server.
+		captionBase := "http://" + r.Host + "/api/timedtext?v=abc123\\u0026lang=en"
+		page := `<html><head><title>Krill Facts 101 - YouTube</title></head><body>
+		<script>var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{
+		"captionTracks":[{"baseUrl":"` + captionBase + `","name":{"simpleText":"English"},"languageCode":"en"}]
+		}}};</script></body></html>`
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(page))
+	})
+	mux.HandleFunc("/api/timedtext", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/xml")
+		w.Write([]byte(captionXML))
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// ReadYouTube constructs its own URL from the video ID, so we can't
+	// directly point it at our test server. Instead, test the internal
+	// functions that do the heavy lifting.
+
+	// 1. Test caption URL extraction from the fake page.
+	captionBaseExpected := srv.URL + "/api/timedtext?v=abc123&lang=en"
+	fakePage := `<html><head><title>Krill Facts 101 - YouTube</title></head><body>
+	<script>var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{
+	"captionTracks":[{"baseUrl":"` + srv.URL + `/api/timedtext?v=abc123\u0026lang=en","name":{"simpleText":"English"},"languageCode":"en"}]
+	}}};</script></body></html>`
+
+	captionURL := extractCaptionURL(fakePage)
+	if captionURL != captionBaseExpected {
+		t.Fatalf("extractCaptionURL = %q, want %q", captionURL, captionBaseExpected)
 	}
-	return false
+
+	// 2. Test title extraction.
+	title := extractVideoTitle(fakePage)
+	if title != "Krill Facts 101" {
+		t.Errorf("extractVideoTitle = %q, want %q", title, "Krill Facts 101")
+	}
+
+	// 3. Test caption XML fetching and parsing.
+	client := &http.Client{}
+	transcript, err := fetchCaptionXML(context.Background(), client, captionURL)
+	if err != nil {
+		t.Fatalf("fetchCaptionXML error: %v", err)
+	}
+	if !strings.Contains(transcript, "Hello and welcome") {
+		t.Errorf("transcript missing expected text, got: %q", transcript)
+	}
+	if !strings.Contains(transcript, "krill facts") {
+		t.Errorf("transcript missing 'krill facts', got: %q", transcript)
+	}
 }

--- a/internal/content/youtube_test.go
+++ b/internal/content/youtube_test.go
@@ -1,0 +1,120 @@
+package content
+
+import (
+	"testing"
+)
+
+func TestExtractVideoID(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{"standard watch", "https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"short link", "https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"embed", "https://www.youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"shorts", "https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"with params", "https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=42s", "dQw4w9WgXcQ"},
+		{"http", "http://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"no www", "https://youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"v path", "https://www.youtube.com/v/dQw4w9WgXcQ", "dQw4w9WgXcQ"},
+		{"not youtube", "https://example.com/watch?v=dQw4w9WgXcQ", ""},
+		{"empty", "", ""},
+		{"no video id", "https://www.youtube.com/", ""},
+		{"playlist only", "https://www.youtube.com/playlist?list=PLrAXtmErZgOeiKm4sgNOknGvNjby9efdf", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractVideoID(tt.url)
+			if got != tt.want {
+				t.Errorf("extractVideoID(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsYouTubeURL(t *testing.T) {
+	if !IsYouTubeURL("https://www.youtube.com/watch?v=dQw4w9WgXcQ") {
+		t.Error("expected true for standard YouTube URL")
+	}
+	if !IsYouTubeURL("https://youtu.be/dQw4w9WgXcQ") {
+		t.Error("expected true for short YouTube URL")
+	}
+	if IsYouTubeURL("https://example.com/page") {
+		t.Error("expected false for non-YouTube URL")
+	}
+}
+
+func TestExtractCaptionURL(t *testing.T) {
+	// Simulated player response snippet with caption tracks.
+	page := `var ytInitialPlayerResponse = {"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"https:\/\/www.youtube.com\/api\/timedtext?v=abc\u0026lang=en","name":{"simpleText":"English"},"languageCode":"en"},{"baseUrl":"https:\/\/www.youtube.com\/api\/timedtext?v=abc\u0026lang=es","name":{"simpleText":"Spanish"},"languageCode":"es"}]}}};`
+
+	got := extractCaptionURL(page)
+	if got == "" {
+		t.Fatal("expected a caption URL, got empty string")
+	}
+	if !containsStr(got, "lang=en") {
+		t.Errorf("expected English caption URL, got %q", got)
+	}
+}
+
+func TestExtractCaptionURL_FallbackToFirst(t *testing.T) {
+	// Only non-English captions available.
+	page := `"captionTracks":[{"baseUrl":"https://example.com/timedtext?lang=ja","languageCode":"ja"}]`
+
+	got := extractCaptionURL(page)
+	if got == "" {
+		t.Fatal("expected fallback caption URL, got empty string")
+	}
+	if !containsStr(got, "lang=ja") {
+		t.Errorf("expected Japanese caption URL, got %q", got)
+	}
+}
+
+func TestExtractCaptionURL_NoCaptions(t *testing.T) {
+	page := `<html><body>no captions here</body></html>`
+	got := extractCaptionURL(page)
+	if got != "" {
+		t.Errorf("expected empty string for page without captions, got %q", got)
+	}
+}
+
+func TestExtractVideoTitle(t *testing.T) {
+	page := `<html><head><title>My Cool Video - YouTube</title></head></html>`
+	got := extractVideoTitle(page)
+	if got != "My Cool Video" {
+		t.Errorf("extractVideoTitle = %q, want %q", got, "My Cool Video")
+	}
+}
+
+func TestUnescapeJSON(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{`hello\nworld`, "hello\nworld"},
+		{`foo\u0026bar`, "foo&bar"},
+		{`path\/to\/thing`, "path/to/thing"},
+		{`say \"hi\"`, `say "hi"`},
+	}
+	for _, tt := range tests {
+		got := unescapeJSON(tt.input)
+		if got != tt.want {
+			t.Errorf("unescapeJSON(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsSubstring(s, sub))
+}
+
+func containsSubstring(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Add `minikrill youtube <url>` command to extract raw transcripts from YouTube videos
- Add `minikrill youtube summarize <url>` command for AI-generated summaries with key takeaways (overview, bullet points, notable quotes)
- Auto-detect YouTube URLs in the existing `minikrill summarize <url>` command so it routes through the transcript extractor instead of HTML scraping
- Support all YouTube URL formats: standard watch, youtu.be short links, embeds, /v/, and Shorts
- No API key required — extracts captions from the video page's embedded player response
- Prefers English captions, falls back to any available language, and gracefully degrades to video metadata when no captions exist
- 16 unit tests covering video ID extraction, caption URL parsing, title extraction, and JSON unescaping

## New commands
| Command | Description |
|---|---|
| `minikrill youtube <url>` | Extract and print the raw transcript |
| `minikrill youtube summarize <url>` | AI summary with key takeaways |
| `minikrill summarize <youtube-url>` | Also works (auto-detected) |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 16 new tests green, no regressions)
- [ ] Manual test: `minikrill youtube <real-url>` prints transcript
- [ ] Manual test: `minikrill youtube summarize <real-url>` returns structured summary
- [ ] Manual test: `minikrill summarize <youtube-url>` auto-detects and uses transcript
- [ ] Test with video that has no captions (should fall back to metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)