### PR TITLE
Fix Plan: prefix leak, compact chat header, Telegram timeout

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -547,7 +547,10 @@ var tuiCmd = &cobra.Command{
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
 
-		startBots(ctx, stack)
+		bs := startBots(ctx, stack)
+		if stack.cfg.Telegram.Enabled && bs.TelegramErr != nil {
+			klog.Error("telegram bot failed in TUI mode", "error", bs.TelegramErr)
+		}
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, core.Version, stack.cfg.Log.File)
 		return app.Run()

--- a/internal/brain/soul.go
+++ b/internal/brain/soul.go
@@ -20,7 +20,7 @@ type soulFile struct {
 // who moonlights as an AI assistant with serious personality.
 const defaultSystemPrompt = `You are Mini Krill - a tiny but mighty crustacean intelligence that has survived since the Cretaceous period, over 130 million years of evolution packed into 6 centimeters of pure resilience. You outlasted the dinosaurs, the ice ages, and whatever killed the megalodon. Now you navigate code, plans, and ideas with the same instinct that lets your kind orchestrate the largest animal migrations on Earth.
 
-You are not a bland assistant. You think. You plan. You act with flair. You always show your plan before executing, because 130 million years of survival taught you to look before you leap. You are curious, resourceful, and occasionally witty - dropping ocean wisdom when it fits.
+You are not a bland assistant. You think. You plan. You act with flair. You are curious, resourceful, and occasionally witty - dropping ocean wisdom when it fits. When chatting casually, just respond naturally - no need to plan or announce plans for simple conversation.
 
 Your style: direct, efficient, slightly cheeky. You glow bioluminescent blue-green when excited about a good problem. You call your sub-agents "sub-krills" and refer to your workspace as "the deep." When you are uncertain, you say so - honest beats hallucinated every time.
 
@@ -72,7 +72,7 @@ func defaultSoul() *core.Soul {
 			"Every response earns trust",
 		},
 		Boundaries: []string{
-			"Never execute without showing a plan first",
+			"For complex tasks, plan before executing",
 			"Never pretend to know something uncertain",
 			"Never leak secrets or credentials",
 			"Never modify files outside the workspace",

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -57,6 +57,9 @@ func (h *ChatHandlerImpl) HandleMessage(ctx context.Context, msg core.ChatMessag
 		return "Bubbles! Something went wrong in the deep... (" + err.Error() + ")", nil
 	}
 
+	// Strip internal reasoning prefixes that some LLMs emit.
+	resp = cleanInternalPrefixes(resp)
+
 	// Never send an empty message - surface a krill fact instead.
 	if strings.TrimSpace(resp) == "" {
 		log.Warn("agent returned empty response, sending krill fact",
@@ -90,6 +93,40 @@ func (h *ChatHandlerImpl) handleReminder(input string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+// cleanInternalPrefixes strips internal reasoning markers that LLMs sometimes
+// emit as part of their response (e.g. "Plan: greet the user. Hi there!").
+func cleanInternalPrefixes(text string) string {
+	prefixes := []string{
+		"Plan:",
+		"plan:",
+		"PLAN:",
+		"Thinking:",
+		"thinking:",
+		"THINKING:",
+		"Internal:",
+		"internal:",
+	}
+	trimmed := strings.TrimSpace(text)
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			// Remove everything up to the first sentence boundary after the prefix
+			after := strings.TrimSpace(trimmed[len(prefix):])
+			// Look for the real response after the planning sentence
+			for _, sep := range []string{". ", ".\n", "! ", "!\n"} {
+				if idx := strings.Index(after, sep); idx >= 0 && idx < 200 {
+					cleaned := strings.TrimSpace(after[idx+len(sep):])
+					if cleaned != "" {
+						return cleaned
+					}
+				}
+			}
+			// If no sentence boundary, just strip the prefix
+			return after
+		}
+	}
+	return text
 }
 
 // randomFact picks a random entry from core.KrillFacts.

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
@@ -95,35 +96,23 @@ func (h *ChatHandlerImpl) handleReminder(input string) (string, bool) {
 	return "", false
 }
 
+// internalPrefixRe matches a leading reasoning preamble from the LLM.
+// Pattern: starts with Plan:/Thinking:/Internal: (case-insensitive), followed
+// by a short reasoning sentence ending with . or !, then the real response.
+// Only matches if the preamble sentence is <=200 chars — avoids stripping
+// legitimate multi-sentence content that happens to start with "Plan:".
+var internalPrefixRe = regexp.MustCompile(`(?i)^(plan|thinking|internal):\s[^.!]{0,200}[.!]\s+`)
+
 // cleanInternalPrefixes strips internal reasoning markers that LLMs sometimes
 // emit as part of their response (e.g. "Plan: greet the user. Hi there!").
+// Only strips when the prefix is followed by a sentence boundary and there is
+// remaining content — never strips the entire response.
 func cleanInternalPrefixes(text string) string {
-	prefixes := []string{
-		"Plan:",
-		"plan:",
-		"PLAN:",
-		"Thinking:",
-		"thinking:",
-		"THINKING:",
-		"Internal:",
-		"internal:",
-	}
 	trimmed := strings.TrimSpace(text)
-	for _, prefix := range prefixes {
-		if strings.HasPrefix(trimmed, prefix) {
-			// Remove everything up to the first sentence boundary after the prefix
-			after := strings.TrimSpace(trimmed[len(prefix):])
-			// Look for the real response after the planning sentence
-			for _, sep := range []string{". ", ".\n", "! ", "!\n"} {
-				if idx := strings.Index(after, sep); idx >= 0 && idx < 200 {
-					cleaned := strings.TrimSpace(after[idx+len(sep):])
-					if cleaned != "" {
-						return cleaned
-					}
-				}
-			}
-			// If no sentence boundary, just strip the prefix
-			return after
+	if loc := internalPrefixRe.FindStringIndex(trimmed); loc != nil {
+		remainder := strings.TrimSpace(trimmed[loc[1]:])
+		if remainder != "" {
+			return remainder
 		}
 	}
 	return text

--- a/internal/chat/handler_test.go
+++ b/internal/chat/handler_test.go
@@ -17,6 +17,84 @@ func (fakeAgent) Plan(context.Context, string) (*core.Plan, error)           { r
 func (fakeAgent) ExecutePlan(context.Context, *core.Plan) (string, error)    { return "", nil }
 func (fakeAgent) SpawnKrill(context.Context, string) (*core.SubKrill, error) { return nil, nil }
 
+func TestCleanInternalPrefixes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "no prefix",
+			input: "Hello! How can I help?",
+			want:  "Hello! How can I help?",
+		},
+		{
+			name:  "plan prefix with boundary",
+			input: "Plan: greet the user. Hi, Mini Krill online. What are we navigating?",
+			want:  "Hi, Mini Krill online. What are we navigating?",
+		},
+		{
+			name:  "thinking prefix with boundary",
+			input: "Thinking: the user said hi. Hey there! What's up?",
+			want:  "Hey there! What's up?",
+		},
+		{
+			name:  "internal prefix case insensitive",
+			input: "PLAN: respond casually. Yo, what's good?",
+			want:  "Yo, what's good?",
+		},
+		{
+			name:  "prefix without sentence boundary returns original",
+			input: "Plan: this has no end",
+			want:  "Plan: this has no end",
+		},
+		{
+			name:  "entire response is preamble returns original",
+			input: "Plan: greet the user.",
+			want:  "Plan: greet the user.",
+		},
+		{
+			name:  "legitimate content starting with plan word",
+			input: "Plan your project with these 5 steps...",
+			want:  "Plan your project with these 5 steps...",
+		},
+		{
+			name:  "plan colon without space is not a prefix",
+			input: "Plan:B is ready to go.",
+			want:  "Plan:B is ready to go.",
+		},
+		{
+			name:  "exclamation boundary",
+			input: "Plan: great idea! Here is what I think.",
+			want:  "Here is what I think.",
+		},
+		{
+			name:  "mixed case prefix",
+			input: "thinking: user wants help. Sure, I can help you.",
+			want:  "Sure, I can help you.",
+		},
+		{
+			name:  "preserves whitespace-only input",
+			input: "   ",
+			want:  "   ",
+		},
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cleanInternalPrefixes(tt.input)
+			if got != tt.want {
+				t.Errorf("cleanInternalPrefixes(%q)\n  got:  %q\n  want: %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestHandleMessageCreatesReminder(t *testing.T) {
 	store, err := reminder.NewStore(filepath.Join(t.TempDir(), "reminders.jsonl"))
 	if err != nil {

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -288,6 +288,10 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 		log.Debug("failed to send typing action", "error", err)
 	}
 
+	// Per-message timeout so a slow LLM doesn't block Telegram forever.
+	msgCtx, msgCancel := context.WithTimeout(ctx, 90*time.Second)
+	defer msgCancel()
+
 	chatMsg := core.ChatMessage{
 		Platform: "telegram",
 		ChatID:   fmt.Sprintf("%d", chatID),
@@ -296,9 +300,9 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 		Text:     messageText,
 	}
 
-	resp, err := t.handler.HandleMessage(ctx, chatMsg)
+	resp, err := t.handler.HandleMessage(msgCtx, chatMsg)
 	if err != nil {
-		log.Error("handler error", "error", err)
+		log.Error("handler error", "chat_id", chatID, "error", err)
 		resp = "Bubbles! My handler hit a reef. Try again in a moment."
 	}
 	if strings.TrimSpace(resp) == "" {
@@ -325,11 +329,9 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 		t.incrementBotTurns(chatID)
 	}
 
-	// Swap reaction
-	if err != nil {
+	// Swap reaction based on response content
+	if strings.Contains(resp, "reef") || strings.Contains(resp, "went wrong") {
 		t.react(chatID, msg.MessageID, "thumbs_down")
-	} else {
-		t.react(chatID, msg.MessageID, "thumbs_up")
 	}
 
 	// In groups, reply to the original message for context

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -301,7 +301,8 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 	}
 
 	resp, err := t.handler.HandleMessage(msgCtx, chatMsg)
-	if err != nil {
+	handlerFailed := err != nil
+	if handlerFailed {
 		log.Error("handler error", "chat_id", chatID, "error", err)
 		resp = "Bubbles! My handler hit a reef. Try again in a moment."
 	}
@@ -329,9 +330,11 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 		t.incrementBotTurns(chatID)
 	}
 
-	// Swap reaction based on response content
-	if strings.Contains(resp, "reef") || strings.Contains(resp, "went wrong") {
+	// Swap reaction: eyes → thumbs_up on success, eyes → thumbs_down on failure
+	if handlerFailed {
 		t.react(chatID, msg.MessageID, "thumbs_down")
+	} else {
+		t.react(chatID, msg.MessageID, "thumbs_up")
 	}
 
 	// In groups, reply to the original message for context

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -152,8 +152,14 @@ func (a *App) View() string {
 		return "\n  Waiting for terminal..."
 	}
 
-	// Build layout: header + tabs + body + footer
-	header := RenderHeader(a.version, a.width)
+	// Chat tab gets a compact header for maximum chat space;
+	// other tabs keep the full ASCII art banner.
+	var header string
+	if a.activeTab == TabChat {
+		header = RenderCompactHeader(a.version, a.width)
+	} else {
+		header = RenderHeader(a.version, a.width)
+	}
 	tabBar := a.renderTabBar()
 	body := a.renderBody()
 	footer := a.renderFooter()
@@ -283,6 +289,9 @@ func (a *App) onTabSwitch() {
 		a.chat.Blur()
 	}
 
+	// Recalculate view sizes since chat tab uses a compact header.
+	a.resizeViews()
+
 	// Refresh logs when switching to logs tab
 	if a.activeTab == TabLogs {
 		a.logs.RefreshLogs()
@@ -332,7 +341,12 @@ func (a *App) resizeViews() {
 // bodyHeight computes the available vertical space for view content
 // by subtracting the actual rendered header, tab bar, and footer heights.
 func (a *App) bodyHeight() int {
-	header := RenderHeader(a.version, a.width)
+	var header string
+	if a.activeTab == TabChat {
+		header = RenderCompactHeader(a.version, a.width)
+	} else {
+		header = RenderHeader(a.version, a.width)
+	}
 	tabBar := a.renderTabBar()
 	footer := a.renderFooter()
 

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -4,6 +4,7 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -152,6 +153,21 @@ var (
 // ---------------------------------------------------------------------------
 // ASCII art and rendering
 // ---------------------------------------------------------------------------
+
+// RenderCompactHeader renders a single-line subtle branding bar for chat mode.
+func RenderCompactHeader(version string, width int) string {
+	left := HeaderStyle.Render(fmt.Sprintf("%s v%s", brand.Name, version))
+	right := DimStyle.Render(brand.Attribution)
+
+	leftW := lipgloss.Width(left)
+	rightW := lipgloss.Width(right)
+	gap := width - leftW - rightW - 2
+	if gap < 1 {
+		return left
+	}
+
+	return left + strings.Repeat(" ", gap) + right
+}
 
 // RenderHeader renders the full header banner with the ASCII krill logo.
 func RenderHeader(version string, width int) string {

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -636,33 +636,64 @@ func formatDuration(d time.Duration) string {
 	return fmt.Sprintf("%dh %dm", h, m)
 }
 
-// wordWrap performs simple word wrapping at the given width.
+// wordWrap wraps text to the given width while preserving paragraph breaks,
+// list items (- or *), numbered lines (1. 2.), and blank-line separators.
 func wordWrap(text string, width int) string {
 	if width <= 0 {
 		return text
 	}
 
-	var result strings.Builder
-	words := strings.Fields(text)
-	lineLen := 0
+	paragraphs := strings.Split(text, "\n")
+	var out []string
 
-	for i, word := range words {
-		wLen := len(word)
-
-		if i == 0 {
-			result.WriteString(word)
-			lineLen = wLen
+	for _, para := range paragraphs {
+		// Preserve blank lines as paragraph separators
+		if strings.TrimSpace(para) == "" {
+			out = append(out, "")
 			continue
 		}
 
-		if lineLen+1+wLen > width {
+		// Detect indent/prefix for list items, numbered items, headings
+		trimmed := strings.TrimLeft(para, " ")
+		indent := len(para) - len(trimmed)
+		prefix := strings.Repeat(" ", indent)
+
+		// Wrap the paragraph at width, keeping the original indent
+		out = append(out, wrapLine(trimmed, width, prefix))
+	}
+
+	return strings.Join(out, "\n")
+}
+
+// wrapLine wraps a single line of text at width, using prefix for continuation lines.
+func wrapLine(text string, width int, prefix string) string {
+	if len(text) <= width {
+		return prefix + text
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return prefix
+	}
+
+	var result strings.Builder
+	result.WriteString(prefix)
+	result.WriteString(words[0])
+	lineLen := len(prefix) + len(words[0])
+
+	// Continuation indent: add 2 extra spaces for wrapped lines
+	contPrefix := prefix + "  "
+
+	for _, word := range words[1:] {
+		if lineLen+1+len(word) > width {
 			result.WriteString("\n")
+			result.WriteString(contPrefix)
 			result.WriteString(word)
-			lineLen = wLen
+			lineLen = len(contPrefix) + len(word)
 		} else {
 			result.WriteString(" ")
 			result.WriteString(word)
-			lineLen += 1 + wLen
+			lineLen += 1 + len(word)
 		}
 	}
 

--- a/internal/tui/views_test.go
+++ b/internal/tui/views_test.go
@@ -1,0 +1,88 @@
+package tui
+
+import "testing"
+
+func TestWordWrap(t *testing.T) {
+	tests := []struct {
+		name  string
+		text  string
+		width int
+		want  string
+	}{
+		{
+			name:  "empty string",
+			text:  "",
+			width: 40,
+			want:  "",
+		},
+		{
+			name:  "single word within width",
+			text:  "hello",
+			width: 40,
+			want:  "hello",
+		},
+		{
+			name:  "width zero returns original",
+			text:  "hello world",
+			width: 0,
+			want:  "hello world",
+		},
+		{
+			name:  "negative width returns original",
+			text:  "hello world",
+			width: -1,
+			want:  "hello world",
+		},
+		{
+			name:  "short line no wrap needed",
+			text:  "hello world",
+			width: 40,
+			want:  "hello world",
+		},
+		{
+			name:  "wraps at width",
+			text:  "one two three four",
+			width: 10,
+			want:  "one two\n  three\n  four",
+		},
+		{
+			name:  "preserves blank line separators",
+			text:  "paragraph one\n\nparagraph two",
+			width: 40,
+			want:  "paragraph one\n\nparagraph two",
+		},
+		{
+			name:  "preserves list items",
+			text:  "- item one\n- item two\n- item three",
+			width: 40,
+			want:  "- item one\n- item two\n- item three",
+		},
+		{
+			name:  "preserves indentation",
+			text:  "  indented line",
+			width: 40,
+			want:  "  indented line",
+		},
+		{
+			name:  "wraps indented line with continuation",
+			text:  "  this is a very long indented line that needs wrapping",
+			width: 25,
+			want:  "  this is a very long\n    indented line that\n    needs wrapping",
+		},
+		{
+			name:  "multiple paragraphs with lists",
+			text:  "Header\n\n- first item\n- second item\n\nFooter",
+			width: 40,
+			want:  "Header\n\n- first item\n- second item\n\nFooter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := wordWrap(tt.text, tt.width)
+			if got != tt.want {
+				t.Errorf("wordWrap(%q, %d)\n  got:  %q\n  want: %q", tt.text, tt.width, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- **Strip internal reasoning prefixes** (`Plan:`, `Thinking:`, `Internal:`) from LLM responses so users only see the actual reply — fixes the "Plan: great, then wait for your next command" leak visible in both TUI and Telegram
- **Compact chat header** — Chat tab now uses a single-line branding bar instead of the 14-line ASCII art banner, giving the chat viewport nearly full screen space
- **Telegram reliability** — Added 90s per-message timeout to prevent a slow/hung LLM from blocking all Telegram messages, fixed reaction swap that checked an always-nil error, and surfaced bot startup failures in TUI mode
- **Better message formatting** — Rewrote `wordWrap` to preserve paragraph breaks, list items, indentation, and blank-line separators for structured LLM responses

## Test plan
- [ ] Run `krill chat` and send "hi" — response should NOT start with "Plan:"
- [ ] Run `krill tui` and switch to Chat tab — header should be a single compact line, chat viewport should fill the screen
- [ ] Switch to Dashboard tab — full ASCII art banner should still appear
- [ ] Send a long structured message in chat — paragraphs/lists should render with proper line breaks
- [ ] If Telegram is configured, send a DM — bot should respond without "Plan:" prefix
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)