### PR TITLE
Fix Telegram token silently lost during init

### DIFF
--- a/cmd/minikrill/prompt.go
+++ b/cmd/minikrill/prompt.go
@@ -83,7 +83,7 @@ func (m selectModel) View() string {
 // Returns the chosen index, or -1 if cancelled with Ctrl+C.
 func promptSelect(items []selectItem) (int, error) {
 	m := selectModel{items: items, chosen: -1}
-	p := tea.NewProgram(m)
+	p := tea.NewProgram(m, tea.WithInputTTY())
 	result, err := p.Run()
 	if err != nil {
 		return -1, err


### PR DESCRIPTION
## Summary

- **Bug**: `minikrill init` silently skips Telegram setup even when the user provides a token. The saved config ends up with `token: ""` and `enabled: false`.
- **Root cause**: `promptSelect()` uses `tea.NewProgram(m)` which reads from `os.Stdin` in raw mode. When Bubble Tea exits, a stale newline is left in stdin. The `bufio.Scanner` used by `ask()` reads this as empty → "Enable Telegram bot? [y/N]" defaults to No → entire Telegram setup skipped.
- **Fix**: Use `tea.WithInputTTY()` so Bubble Tea reads from `/dev/tty` instead, keeping `os.Stdin` clean for the scanner. Also fixes the same silent-skip issue for Discord setup.

## Test plan

- [ ] `go build ./cmd/minikrill` compiles cleanly
- [ ] `go test ./...` passes
- [ ] Run `minikrill init`, select a provider, answer "y" to Telegram, provide a token → verify `~/.mini-krill/config.yaml` has the token and `enabled: true`
- [ ] Run `minikrill init` again → verify "Telegram bot token already configured" prompt appears (token survived)
- [ ] Run `minikrill dive --fg` → verify Telegram bot starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)