### PR TITLE
Fix TUI layout, model pull, and LLM status reporting

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -135,15 +135,15 @@ var initCmd = &cobra.Command{
 			cfg.Ollama.DefaultModel = selectedModel
 
 			if !localSet[selectedModel] {
-				fmt.Printf(cDim+"  Pulling %s in background..."+cReset+"\n", selectedModel)
-				fmt.Println(cDim + "  Run " + cReset + "minikrill doctor" + cDim + " to check pull status." + cReset)
-				ctx := cmd.Context()
-				go func(model string) {
-					if err := mgr.EnsureRunning(ctx); err != nil {
-						return
-					}
-					_ = mgr.Pull(ctx, model)
-				}(selectedModel)
+				fmt.Println()
+				pullCtx := context.Background()
+				if err := mgr.EnsureRunning(pullCtx); err != nil {
+					fmt.Printf(cYellow+"  Could not start Ollama: %v\n"+cReset, err)
+					fmt.Println(cDim + "  You can pull the model later with: ollama pull " + selectedModel + cReset)
+				} else if err := mgr.PullWithProgress(pullCtx, selectedModel, os.Stdout); err != nil {
+					fmt.Printf(cYellow+"  Pull failed: %v\n"+cReset, err)
+					fmt.Println(cDim + "  You can retry with: ollama pull " + selectedModel + cReset)
+				}
 			}
 		case 1: // Codex
 			cfg.LLM.Provider = "codex"

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -136,14 +136,20 @@ var initCmd = &cobra.Command{
 
 			if !localSet[selectedModel] {
 				fmt.Println()
-				pullCtx := context.Background()
+				pullCtx, pullStop := signal.NotifyContext(context.Background(), os.Interrupt)
+				defer pullStop()
 				if err := mgr.EnsureRunning(pullCtx); err != nil {
 					fmt.Printf(cYellow+"  Could not start Ollama: %v\n"+cReset, err)
 					fmt.Println(cDim + "  You can pull the model later with: ollama pull " + selectedModel + cReset)
 				} else if err := mgr.PullWithProgress(pullCtx, selectedModel, os.Stdout); err != nil {
-					fmt.Printf(cYellow+"  Pull failed: %v\n"+cReset, err)
+					if pullCtx.Err() != nil {
+						fmt.Println(cDim + "\n  Download interrupted." + cReset)
+					} else {
+						fmt.Printf(cYellow+"  Pull failed: %v\n"+cReset, err)
+					}
 					fmt.Println(cDim + "  You can retry with: ollama pull " + selectedModel + cReset)
 				}
+				pullStop()
 			}
 		case 1: // Codex
 			cfg.LLM.Provider = "codex"

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -13,6 +13,7 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
 	log "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/ollama"
 )
 
 // OllamaProvider talks to a local Ollama instance over its REST API.
@@ -265,24 +266,15 @@ func (o *OllamaProvider) Available(ctx context.Context) bool {
 		return false
 	}
 
-	target := normalizeModelName(o.model)
+	target := ollama.NormalizeModelName(o.model)
 	for _, m := range tags.Models {
-		if normalizeModelName(m.Name) == target {
+		if ollama.NormalizeModelName(m.Name) == target {
 			return true
 		}
 	}
 
 	log.Debug("ollama model not found locally", "model", o.model, "available", len(tags.Models))
 	return false
-}
-
-// normalizeModelName lowercases and appends ":latest" if no tag is specified.
-func normalizeModelName(name string) string {
-	name = strings.ToLower(name)
-	if !strings.Contains(name, ":") {
-		name += ":latest"
-	}
-	return name
 }
 
 func isConnectionRefused(err error) bool {

--- a/internal/llm/ollama.go
+++ b/internal/llm/ollama.go
@@ -74,6 +74,12 @@ type ollamaChatResponse struct {
 	PromptEvalCount int           `json:"prompt_eval_count"`
 }
 
+type ollamaTagsResponse struct {
+	Models []struct {
+		Name string `json:"name"`
+	} `json:"models"`
+}
+
 // ---------------------------------------------------------------------------
 // Shared helpers
 // ---------------------------------------------------------------------------
@@ -248,8 +254,35 @@ func (o *OllamaProvider) Available(ctx context.Context) bool {
 		return false
 	}
 	defer resp.Body.Close()
-	_, _ = io.Copy(io.Discard, resp.Body)
-	return resp.StatusCode == http.StatusOK
+
+	if resp.StatusCode != http.StatusOK {
+		return false
+	}
+
+	var tags ollamaTagsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tags); err != nil {
+		log.Debug("ollama tags decode failed", "error", err)
+		return false
+	}
+
+	target := normalizeModelName(o.model)
+	for _, m := range tags.Models {
+		if normalizeModelName(m.Name) == target {
+			return true
+		}
+	}
+
+	log.Debug("ollama model not found locally", "model", o.model, "available", len(tags.Models))
+	return false
+}
+
+// normalizeModelName lowercases and appends ":latest" if no tag is specified.
+func normalizeModelName(name string) string {
+	name = strings.ToLower(name)
+	if !strings.Contains(name, ":") {
+		name += ":latest"
+	}
+	return name
 }
 
 func isConnectionRefused(err error) bool {

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/ollama"
 )
 
 func newTestOllamaProvider(serverURL, model string) *OllamaProvider {
@@ -113,9 +114,9 @@ func TestNormalizeModelName(t *testing.T) {
 		{"model:latest", "model:latest"},
 	}
 	for _, tt := range tests {
-		got := normalizeModelName(tt.input)
+		got := ollama.NormalizeModelName(tt.input)
 		if got != tt.want {
-			t.Errorf("normalizeModelName(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("NormalizeModelName(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }

--- a/internal/llm/ollama_test.go
+++ b/internal/llm/ollama_test.go
@@ -1,0 +1,121 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+)
+
+func newTestOllamaProvider(serverURL, model string) *OllamaProvider {
+	return NewOllamaProvider(serverURL, model, config.LLMConfig{})
+}
+
+func TestAvailableModelPresent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ollamaTagsResponse{
+			Models: []struct {
+				Name string `json:"name"`
+			}{
+				{Name: "gemma3:4b"},
+				{Name: "llama3.2:3b"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := newTestOllamaProvider(srv.URL, "gemma3:4b")
+	if !p.Available(context.Background()) {
+		t.Error("expected Available=true when model is in the list")
+	}
+}
+
+func TestAvailableModelMissing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ollamaTagsResponse{
+			Models: []struct {
+				Name string `json:"name"`
+			}{
+				{Name: "llama3.2:3b"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	p := newTestOllamaProvider(srv.URL, "gemma3:4b")
+	if p.Available(context.Background()) {
+		t.Error("expected Available=false when model is not in the list")
+	}
+}
+
+func TestAvailableEmptyModelList(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ollamaTagsResponse{})
+	}))
+	defer srv.Close()
+
+	p := newTestOllamaProvider(srv.URL, "gemma3:4b")
+	if p.Available(context.Background()) {
+		t.Error("expected Available=false when model list is empty")
+	}
+}
+
+func TestAvailableServerDown(t *testing.T) {
+	p := newTestOllamaProvider("http://127.0.0.1:1", "gemma3:4b")
+	if p.Available(context.Background()) {
+		t.Error("expected Available=false when server is unreachable")
+	}
+}
+
+func TestAvailableServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := newTestOllamaProvider(srv.URL, "gemma3:4b")
+	if p.Available(context.Background()) {
+		t.Error("expected Available=false when server returns 500")
+	}
+}
+
+func TestAvailableNormalizesModelName(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(ollamaTagsResponse{
+			Models: []struct {
+				Name string `json:"name"`
+			}{
+				{Name: "gemma3:latest"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	// Config says "gemma3" (no tag), server has "gemma3:latest" - should match
+	p := newTestOllamaProvider(srv.URL, "gemma3")
+	if !p.Available(context.Background()) {
+		t.Error("expected Available=true: 'gemma3' should match 'gemma3:latest'")
+	}
+}
+
+func TestNormalizeModelName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"gemma3", "gemma3:latest"},
+		{"gemma3:4b", "gemma3:4b"},
+		{"Gemma3:4B", "gemma3:4b"},
+		{"LLAMA3.2:3B", "llama3.2:3b"},
+		{"model:latest", "model:latest"},
+	}
+	for _, tt := range tests {
+		got := normalizeModelName(tt.input)
+		if got != tt.want {
+			t.Errorf("normalizeModelName(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/ollama/manager.go
+++ b/internal/ollama/manager.go
@@ -232,9 +232,18 @@ func (m *OllamaManager) Stop() error {
 
 // Pull downloads a model from the Ollama registry. It reads the streaming
 // progress response and logs status updates.
-func (m *OllamaManager) Pull(ctx context.Context, model string) error {
-	log.Info("pulling ollama model", "model", model)
+// pullProgress holds a single progress event from the Ollama pull stream.
+type pullProgress struct {
+	Status    string `json:"status"`
+	Digest    string `json:"digest"`
+	Total     int64  `json:"total"`
+	Completed int64  `json:"completed"`
+	Error     string `json:"error"`
+}
 
+// pullStream sends a pull request and feeds each progress event to onProgress.
+// Shared by Pull (log-only) and PullWithProgress (interactive).
+func (m *OllamaManager) pullStream(ctx context.Context, model string, onProgress func(pullProgress)) error {
 	reqBody, err := json.Marshal(map[string]string{"name": model})
 	if err != nil {
 		return fmt.Errorf("marshal pull request: %w", err)
@@ -247,7 +256,6 @@ func (m *OllamaManager) Pull(ctx context.Context, model string) error {
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	// Use a client with no timeout since model downloads can take a long time
 	pullClient := &http.Client{}
 	resp, err := pullClient.Do(req)
 	if err != nil {
@@ -260,12 +268,9 @@ func (m *OllamaManager) Pull(ctx context.Context, model string) error {
 		return fmt.Errorf("pull returned status %d: %s", resp.StatusCode, string(errBody))
 	}
 
-	// Read streaming NDJSON progress
 	scanner := bufio.NewScanner(resp.Body)
-	// Allow large lines for download progress messages
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
-	var lastStatus string
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
@@ -278,31 +283,37 @@ func (m *OllamaManager) Pull(ctx context.Context, model string) error {
 			continue
 		}
 
-		var progress struct {
-			Status    string `json:"status"`
-			Digest    string `json:"digest"`
-			Total     int64  `json:"total"`
-			Completed int64  `json:"completed"`
-			Error     string `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &progress); err != nil {
-			// Skip malformed lines gracefully
+		var p pullProgress
+		if err := json.Unmarshal([]byte(line), &p); err != nil {
 			continue
 		}
 
-		if progress.Error != "" {
-			return fmt.Errorf("ollama pull error: %s", progress.Error)
+		if p.Error != "" {
+			return fmt.Errorf("ollama pull error: %s", p.Error)
 		}
 
-		// Log status changes (not every progress tick)
-		if progress.Status != lastStatus {
-			log.Info("pull progress", "model", model, "status", progress.Status)
-			lastStatus = progress.Status
-		}
+		onProgress(p)
 	}
 
 	if err := scanner.Err(); err != nil {
 		return fmt.Errorf("reading pull response: %w", err)
+	}
+
+	return nil
+}
+
+func (m *OllamaManager) Pull(ctx context.Context, model string) error {
+	log.Info("pulling ollama model", "model", model)
+
+	var lastStatus string
+	err := m.pullStream(ctx, model, func(p pullProgress) {
+		if p.Status != lastStatus {
+			log.Info("pull progress", "model", model, "status", p.Status)
+			lastStatus = p.Status
+		}
+	})
+	if err != nil {
+		return err
 	}
 
 	log.Info("model pulled successfully", "model", model)
@@ -310,87 +321,32 @@ func (m *OllamaManager) Pull(ctx context.Context, model string) error {
 }
 
 // PullWithProgress pulls a model and writes human-readable progress to w.
-// Unlike Pull, this is designed for interactive use (e.g. init wizard).
+// Designed for interactive use (e.g. init wizard).
 func (m *OllamaManager) PullWithProgress(ctx context.Context, model string, w io.Writer) error {
 	log.Info("pulling ollama model with progress", "model", model)
 
-	reqBody, err := json.Marshal(map[string]string{"name": model})
-	if err != nil {
-		return fmt.Errorf("marshal pull request: %w", err)
-	}
-
-	url := m.host + "/api/pull"
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(reqBody)))
-	if err != nil {
-		return fmt.Errorf("create pull request: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-
-	pullClient := &http.Client{}
-	resp, err := pullClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("pull request failed (is ollama running?): %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		errBody, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("pull returned status %d: %s", resp.StatusCode, string(errBody))
-	}
-
-	scanner := bufio.NewScanner(resp.Body)
-	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
-
-	for scanner.Scan() {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		var progress struct {
-			Status    string `json:"status"`
-			Digest    string `json:"digest"`
-			Total     int64  `json:"total"`
-			Completed int64  `json:"completed"`
-			Error     string `json:"error"`
-		}
-		if err := json.Unmarshal([]byte(line), &progress); err != nil {
-			continue
-		}
-
-		if progress.Error != "" {
-			fmt.Fprintf(w, "\n")
-			return fmt.Errorf("ollama pull error: %s", progress.Error)
-		}
-
-		if progress.Total > 0 {
-			pct := float64(progress.Completed) / float64(progress.Total) * 100
-			completedMB := float64(progress.Completed) / (1024 * 1024)
-			totalMB := float64(progress.Total) / (1024 * 1024)
+	err := m.pullStream(ctx, model, func(p pullProgress) {
+		if p.Total > 0 {
+			pct := float64(p.Completed) / float64(p.Total) * 100
+			completedMB := float64(p.Completed) / (1024 * 1024)
+			totalMB := float64(p.Total) / (1024 * 1024)
 			if totalMB >= 1024 {
-				fmt.Fprintf(w, "\r  Pulling %s... %.0f%% (%.1f GB / %.1f GB)   ",
+				fmt.Fprintf(w, "\r\033[2K  Pulling %s... %.0f%% (%.1f GB / %.1f GB)",
 					model, pct, completedMB/1024, totalMB/1024)
 			} else {
-				fmt.Fprintf(w, "\r  Pulling %s... %.0f%% (%.0f MB / %.0f MB)   ",
+				fmt.Fprintf(w, "\r\033[2K  Pulling %s... %.0f%% (%.0f MB / %.0f MB)",
 					model, pct, completedMB, totalMB)
 			}
-		} else if progress.Status != "" {
-			fmt.Fprintf(w, "\r  Pulling %s... %s   ", model, progress.Status)
+		} else if p.Status != "" {
+			fmt.Fprintf(w, "\r\033[2K  Pulling %s... %s", model, p.Status)
 		}
-	}
-
-	if err := scanner.Err(); err != nil {
+	})
+	if err != nil {
 		fmt.Fprintf(w, "\n")
-		return fmt.Errorf("reading pull response: %w", err)
+		return err
 	}
 
-	fmt.Fprintf(w, "\r  Pulled %s successfully.                              \n", model)
+	fmt.Fprintf(w, "\r\033[2K  Pulled %s successfully.\n", model)
 	log.Info("model pulled successfully (with progress)", "model", model)
 	return nil
 }
@@ -479,16 +435,9 @@ func (m *OllamaManager) HasModel(ctx context.Context, model string) bool {
 	if err != nil {
 		return false
 	}
-	normalize := func(s string) string {
-		s = strings.ToLower(s)
-		if !strings.Contains(s, ":") {
-			s += ":latest"
-		}
-		return s
-	}
-	target := normalize(model)
+	target := NormalizeModelName(model)
 	for _, mi := range models {
-		if normalize(mi.Name) == target {
+		if NormalizeModelName(mi.Name) == target {
 			return true
 		}
 	}
@@ -585,4 +534,14 @@ func (m *OllamaManager) healthMonitorLoop(ctx context.Context) {
 			backoff = backoffMax
 		}
 	}
+}
+
+// NormalizeModelName lowercases a model name and appends ":latest" if no tag
+// is specified, matching Ollama's own normalization rules.
+func NormalizeModelName(name string) string {
+	name = strings.ToLower(name)
+	if !strings.Contains(name, ":") {
+		name += ":latest"
+	}
+	return name
 }

--- a/internal/ollama/manager.go
+++ b/internal/ollama/manager.go
@@ -309,6 +309,92 @@ func (m *OllamaManager) Pull(ctx context.Context, model string) error {
 	return nil
 }
 
+// PullWithProgress pulls a model and writes human-readable progress to w.
+// Unlike Pull, this is designed for interactive use (e.g. init wizard).
+func (m *OllamaManager) PullWithProgress(ctx context.Context, model string, w io.Writer) error {
+	log.Info("pulling ollama model with progress", "model", model)
+
+	reqBody, err := json.Marshal(map[string]string{"name": model})
+	if err != nil {
+		return fmt.Errorf("marshal pull request: %w", err)
+	}
+
+	url := m.host + "/api/pull"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(string(reqBody)))
+	if err != nil {
+		return fmt.Errorf("create pull request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	pullClient := &http.Client{}
+	resp, err := pullClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("pull request failed (is ollama running?): %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		errBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("pull returned status %d: %s", resp.StatusCode, string(errBody))
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		line := scanner.Text()
+		if line == "" {
+			continue
+		}
+
+		var progress struct {
+			Status    string `json:"status"`
+			Digest    string `json:"digest"`
+			Total     int64  `json:"total"`
+			Completed int64  `json:"completed"`
+			Error     string `json:"error"`
+		}
+		if err := json.Unmarshal([]byte(line), &progress); err != nil {
+			continue
+		}
+
+		if progress.Error != "" {
+			fmt.Fprintf(w, "\n")
+			return fmt.Errorf("ollama pull error: %s", progress.Error)
+		}
+
+		if progress.Total > 0 {
+			pct := float64(progress.Completed) / float64(progress.Total) * 100
+			completedMB := float64(progress.Completed) / (1024 * 1024)
+			totalMB := float64(progress.Total) / (1024 * 1024)
+			if totalMB >= 1024 {
+				fmt.Fprintf(w, "\r  Pulling %s... %.0f%% (%.1f GB / %.1f GB)   ",
+					model, pct, completedMB/1024, totalMB/1024)
+			} else {
+				fmt.Fprintf(w, "\r  Pulling %s... %.0f%% (%.0f MB / %.0f MB)   ",
+					model, pct, completedMB, totalMB)
+			}
+		} else if progress.Status != "" {
+			fmt.Fprintf(w, "\r  Pulling %s... %s   ", model, progress.Status)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(w, "\n")
+		return fmt.Errorf("reading pull response: %w", err)
+	}
+
+	fmt.Fprintf(w, "\r  Pulled %s successfully.                              \n", model)
+	log.Info("model pulled successfully (with progress)", "model", model)
+	return nil
+}
+
 // ListModels queries the Ollama API for all locally available models.
 func (m *OllamaManager) ListModels(ctx context.Context) ([]ModelInfo, error) {
 	url := m.host + "/api/tags"

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -152,14 +152,8 @@ func (a *App) View() string {
 		return "\n  Waiting for terminal..."
 	}
 
-	// Chat tab gets a compact header for maximum chat space;
-	// other tabs keep the full ASCII art banner.
-	var header string
-	if a.activeTab == TabChat {
-		header = RenderCompactHeader(a.version, a.width)
-	} else {
-		header = RenderHeader(a.version, a.width)
-	}
+	// Compact header for all tabs to maximize body space.
+	header := RenderCompactHeader(a.version, a.width)
 	tabBar := a.renderTabBar()
 	body := a.renderBody()
 	footer := a.renderFooter()
@@ -231,18 +225,14 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 
 	case "right":
-		if !inChat {
-			a.activeTab = (a.activeTab + 1) % len(a.tabs)
-			a.onTabSwitch()
-			return nil
-		}
+		a.activeTab = (a.activeTab + 1) % len(a.tabs)
+		a.onTabSwitch()
+		return nil
 
 	case "left":
-		if !inChat {
-			a.activeTab = (a.activeTab - 1 + len(a.tabs)) % len(a.tabs)
-			a.onTabSwitch()
-			return nil
-		}
+		a.activeTab = (a.activeTab - 1 + len(a.tabs)) % len(a.tabs)
+		a.onTabSwitch()
+		return nil
 
 	case "1":
 		if !inChat {
@@ -341,12 +331,7 @@ func (a *App) resizeViews() {
 // bodyHeight computes the available vertical space for view content
 // by subtracting the actual rendered header, tab bar, and footer heights.
 func (a *App) bodyHeight() int {
-	var header string
-	if a.activeTab == TabChat {
-		header = RenderCompactHeader(a.version, a.width)
-	} else {
-		header = RenderHeader(a.version, a.width)
-	}
+	header := RenderCompactHeader(a.version, a.width)
 	tabBar := a.renderTabBar()
 	footer := a.renderFooter()
 

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -225,14 +225,18 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 		return nil
 
 	case "right":
-		a.activeTab = (a.activeTab + 1) % len(a.tabs)
-		a.onTabSwitch()
-		return nil
+		if !inChat {
+			a.activeTab = (a.activeTab + 1) % len(a.tabs)
+			a.onTabSwitch()
+			return nil
+		}
 
 	case "left":
-		a.activeTab = (a.activeTab - 1 + len(a.tabs)) % len(a.tabs)
-		a.onTabSwitch()
-		return nil
+		if !inChat {
+			a.activeTab = (a.activeTab - 1 + len(a.tabs)) % len(a.tabs)
+			a.onTabSwitch()
+			return nil
+		}
 
 	case "1":
 		if !inChat {
@@ -272,14 +276,11 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 }
 
 // onTabSwitch handles focus changes when switching tabs.
+// Chat input is NOT auto-focused on switch so that left/right arrows
+// remain available for tab navigation. Press Enter to focus the input.
 func (a *App) onTabSwitch() {
-	if a.activeTab == TabChat {
-		a.chat.Focus()
-	} else {
-		a.chat.Blur()
-	}
+	a.chat.Blur()
 
-	// Recalculate view sizes since chat tab uses a compact header.
 	a.resizeViews()
 
 	// Refresh logs when switching to logs tab

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -110,29 +110,66 @@ func TestUpdateKeyMsgNotDoubleDispatched(t *testing.T) {
 	}
 }
 
-func TestLeftRightAlwaysSwitchTabs(t *testing.T) {
+func TestLeftRightSwitchTabsWhenChatBlurred(t *testing.T) {
 	app := newSizedApp()
-	app.activeTab = TabChat
-	app.chat.Focus()
 
-	if !app.chat.Focused() {
-		t.Fatal("expected chat input to be focused")
+	// Navigate to chat tab - onTabSwitch does NOT auto-focus
+	app.activeTab = TabChat
+	app.onTabSwitch()
+
+	if app.chat.Focused() {
+		t.Fatal("expected chat input to be blurred after tab switch")
 	}
 
-	// Right should switch from Chat to Logs even when chat is focused
+	// Right should switch from Chat to Logs when input is blurred
 	app.handleKey(tea.KeyMsg{Type: tea.KeyRight})
 	if app.activeTab != TabLogs {
 		t.Errorf("expected Right to switch to TabLogs (%d), got %d", TabLogs, app.activeTab)
 	}
 
-	// Go back to Chat and re-focus
+	// Go back to Chat (blurred)
 	app.activeTab = TabChat
-	app.chat.Focus()
+	app.onTabSwitch()
 
-	// Left should switch from Chat to Dashboard
+	// Left should switch from Chat to Dashboard when blurred
 	app.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
 	if app.activeTab != TabDashboard {
 		t.Errorf("expected Left to switch to TabDashboard (%d), got %d", TabDashboard, app.activeTab)
+	}
+}
+
+func TestLeftRightGuardedWhenChatFocused(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Focus()
+
+	// Left/right should NOT switch tabs when chat input is focused
+	app.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	if app.activeTab != TabChat {
+		t.Errorf("expected Right to be guarded in focused chat, got tab %d", app.activeTab)
+	}
+
+	app.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
+	if app.activeTab != TabChat {
+		t.Errorf("expected Left to be guarded in focused chat, got tab %d", app.activeTab)
+	}
+}
+
+func TestEnterFocusesChatWhenBlurred(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Blur()
+	// Resize so chat view is ready
+	app.Update(tea.WindowSizeMsg{Width: 100, Height: 40})
+
+	if app.chat.Focused() {
+		t.Fatal("expected chat to be blurred before Enter")
+	}
+
+	// Enter should focus the chat input, not send
+	app.chat.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if !app.chat.Focused() {
+		t.Error("expected Enter to focus chat input when blurred")
 	}
 }
 

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -110,6 +110,50 @@ func TestUpdateKeyMsgNotDoubleDispatched(t *testing.T) {
 	}
 }
 
+func TestLeftRightAlwaysSwitchTabs(t *testing.T) {
+	app := newSizedApp()
+	app.activeTab = TabChat
+	app.chat.Focus()
+
+	if !app.chat.Focused() {
+		t.Fatal("expected chat input to be focused")
+	}
+
+	// Right should switch from Chat to Logs even when chat is focused
+	app.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	if app.activeTab != TabLogs {
+		t.Errorf("expected Right to switch to TabLogs (%d), got %d", TabLogs, app.activeTab)
+	}
+
+	// Go back to Chat and re-focus
+	app.activeTab = TabChat
+	app.chat.Focus()
+
+	// Left should switch from Chat to Dashboard
+	app.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
+	if app.activeTab != TabDashboard {
+		t.Errorf("expected Left to switch to TabDashboard (%d), got %d", TabDashboard, app.activeTab)
+	}
+}
+
+func TestLeftRightWrapAround(t *testing.T) {
+	app := newSizedApp()
+
+	// From Dashboard, Left should wrap to Help
+	app.activeTab = TabDashboard
+	app.handleKey(tea.KeyMsg{Type: tea.KeyLeft})
+	if app.activeTab != TabHelp {
+		t.Errorf("expected Left from Dashboard to wrap to TabHelp (%d), got %d", TabHelp, app.activeTab)
+	}
+
+	// From Help, Right should wrap to Dashboard
+	app.activeTab = TabHelp
+	app.handleKey(tea.KeyMsg{Type: tea.KeyRight})
+	if app.activeTab != TabDashboard {
+		t.Errorf("expected Right from Help to wrap to TabDashboard (%d), got %d", TabDashboard, app.activeTab)
+	}
+}
+
 func TestEscDoesNotForwardWhenNotInChat(t *testing.T) {
 	app := newSizedApp()
 	app.activeTab = TabDashboard

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -34,7 +34,7 @@ type chatEntry struct {
 // DashboardView
 // ---------------------------------------------------------------------------
 
-// DashboardView shows system status, active sub-krills, and a krill fact.
+// DashboardView shows system status and a krill fact.
 type DashboardView struct {
 	status  core.HealthStatus
 	fact    string
@@ -68,10 +68,9 @@ func (d *DashboardView) View() string {
 		return "Terminal too small..."
 	}
 
-	// Calculate panel widths - leave room for borders and padding
-	panelWidth := (d.width - 6) / 2
+	panelWidth := d.width - 4
 	if panelWidth < 20 {
-		panelWidth = d.width - 4
+		panelWidth = 20
 	}
 
 	// --- System Status panel ---
@@ -99,24 +98,12 @@ func (d *DashboardView) View() string {
 	statusContent := strings.Join(statusLines, "\n")
 	statusBox := RenderBox("  System Status", statusContent, panelWidth)
 
-	// --- Active Sub-Krills panel ---
-	subKrillContent := DimStyle.Render("No active sub-krills\nThe swarm is resting...")
-	subKrillBox := RenderBox("  Active Sub-Krills", subKrillContent, panelWidth)
-
 	// --- Krill Fact panel ---
 	factWrapped := wordWrap(d.fact, d.width-8)
 	factContent := AccentStyle.Render("  " + factWrapped)
-	factBox := RenderBox("  Did You Know?", factContent, d.width-4)
+	factBox := RenderBox("  Did You Know?", factContent, panelWidth)
 
-	// Layout: status + sub-krills side by side, fact below
-	if panelWidth < d.width-4 {
-		// Wide enough for side-by-side
-		topRow := lipgloss.JoinHorizontal(lipgloss.Top, statusBox, "  ", subKrillBox)
-		return lipgloss.JoinVertical(lipgloss.Left, topRow, "", factBox)
-	}
-
-	// Narrow: stack vertically
-	return lipgloss.JoinVertical(lipgloss.Left, statusBox, "", subKrillBox, "", factBox)
+	return lipgloss.JoinVertical(lipgloss.Left, statusBox, "", factBox)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -200,6 +200,11 @@ func (c *ChatView) Update(msg tea.Msg) tea.Cmd {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "enter":
+			// If input is blurred, focus it instead of sending.
+			if !c.input.Focused() {
+				c.input.Focus()
+				return nil
+			}
 			if c.waiting {
 				return nil
 			}


### PR DESCRIPTION
## Summary

- **Fix init model pull silently dying**: the background goroutine used `cmd.Context()` which was cancelled on process exit, so the download never completed. Replaced with blocking `PullWithProgress()` that shows live download percentage (`Pulling gemma3:4b... 47% (1.4 GB / 3.0 GB)`).
- **Fix dashboard clipping**: use compact header on all tabs (frees ~13 lines), remove always-empty "Active Sub-Krills" panel — the "Did You Know?" fact is now visible.
- **Fix left/right arrow tab switching**: was getting trapped at Chat tab because `onTabSwitch()` auto-focused the input, blocking further arrow navigation. Now matches Tab/Shift+Tab behavior.
- **Fix LLM showing [LIVE] when model not downloaded**: `Available()` only checked if the Ollama *server* was reachable, not if the configured model existed. Now parses `/api/tags` response and checks model presence with name normalization.

## Test plan

- [x] `go build ./cmd/minikrill` compiles clean
- [x] `go test ./...` all pass (19 new test cases for Available() + tab switching)
- [ ] Run `minikrill init`, select Ollama + unpulled model, verify progress bar shows and download completes
- [ ] Run `minikrill tui`, verify compact header, dashboard shows System Status + Did You Know? with fact visible
- [ ] Press left/right arrows across all tabs — no getting stuck at Chat
- [ ] With Ollama running but model not pulled, verify dashboard shows LLM `[DOWN]` not `[LIVE]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)