### PR TITLE
Promote CLI features to chat skills with TLDR capabilities

### DIFF
--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -166,11 +166,18 @@ func initStack(quiet bool) (*krillStack, error) {
 		DataDir:   config.DataDir(),
 	})
 
+	// Register feature skills (YouTube, reminders, web, research, notify)
+	reminderStore, _ := reminder.NewStore(filepath.Join(config.DataDir(), "reminders.jsonl"))
+	skillReg.RegisterFeatureSkills(plugin.FeatureContext{
+		Config:    cfg,
+		LLM:       providerMgr,
+		Reminders: reminderStore,
+	})
+
 	// Pass recovery config from brain to agent for cold-start continuity
 	cfg.Agent.RecoveryTurns = cfg.Brain.RecoveryTurns
 
 	krillAgent := agent.New(cfg.Agent, providerMgr, krillBrain, skillReg, mcpReg)
-	reminderStore, _ := reminder.NewStore(filepath.Join(config.DataDir(), "reminders.jsonl"))
 	chatHandler := chat.NewHandler(krillAgent, reminderStore)
 
 	return &krillStack{

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -167,10 +167,12 @@ func initStack(quiet bool) (*krillStack, error) {
 	})
 
 	// Register feature skills (YouTube, reminders, web, research, notify)
-	reminderStore, _ := reminder.NewStore(filepath.Join(config.DataDir(), "reminders.jsonl"))
+	reminderStore, err := reminder.NewStore(filepath.Join(config.DataDir(), "reminders.jsonl"))
+	if err != nil {
+		klog.Warn("reminder store init failed, remind skill will not be available", "error", err)
+	}
 	skillReg.RegisterFeatureSkills(plugin.FeatureContext{
 		Config:    cfg,
-		LLM:       providerMgr,
 		Reminders: reminderStore,
 	})
 

--- a/internal/plugin/builtins.go
+++ b/internal/plugin/builtins.go
@@ -52,7 +52,7 @@ func (r *SkillRegistryImpl) RegisterFeatureSkills(fc FeatureContext) {
 		if err := r.Register(s); err != nil {
 			log.Warn("failed to register feature skill", "name", s.Name(), "error", err)
 		} else {
-			r.categories[s.Name()] = "Built-in"
+			r.categories[s.Name()] = "Feature"
 		}
 	}
 	log.Debug("feature skills registered", "count", len(features))

--- a/internal/plugin/builtins.go
+++ b/internal/plugin/builtins.go
@@ -44,6 +44,20 @@ func (r *SkillRegistryImpl) RegisterSelfSkills(sc SelfContext) {
 	log.Debug("self-awareness skills registered", "count", len(selfSkills))
 }
 
+// RegisterFeatureSkills registers chat skills wrapping CLI-only features
+// (YouTube, reminders, web research, notifications).
+func (r *SkillRegistryImpl) RegisterFeatureSkills(fc FeatureContext) {
+	features := NewFeatureSkills(fc)
+	for _, s := range features {
+		if err := r.Register(s); err != nil {
+			log.Warn("failed to register feature skill", "name", s.Name(), "error", err)
+		} else {
+			r.categories[s.Name()] = "Built-in"
+		}
+	}
+	log.Debug("feature skills registered", "count", len(features))
+}
+
 // ---------------------------------------------------------------------------
 // recall skill
 // ---------------------------------------------------------------------------

--- a/internal/plugin/features.go
+++ b/internal/plugin/features.go
@@ -1,0 +1,340 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/content"
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/reminder"
+)
+
+// FeatureContext provides dependencies for feature skills that need
+// access to state beyond the standard Execute(ctx, input, llm) signature.
+type FeatureContext struct {
+	Config    *config.Config
+	LLM       core.LLMProvider
+	Reminders *reminder.Store
+}
+
+// NewFeatureSkills creates the feature skills from CLI capabilities.
+// Skills that need optional dependencies (reminders, notify) are only
+// included when their dependencies are available.
+func NewFeatureSkills(fc FeatureContext) []core.Skill {
+	skills := []core.Skill{
+		youtubeSkill(),
+		researchSkill(),
+		webSkill(),
+	}
+	if fc.Reminders != nil {
+		skills = append(skills, remindSkill(fc.Reminders))
+	}
+	// Notify requires Telegram token — check env or config
+	if telegramAvailable(fc.Config) {
+		skills = append(skills, notifySkill(fc.Config))
+	}
+	return skills
+}
+
+func telegramAvailable(cfg *config.Config) bool {
+	if os.Getenv("KRILL_TELEGRAM_TOKEN") != "" {
+		return true
+	}
+	return cfg != nil && cfg.Telegram.Token != ""
+}
+
+// ---------------------------------------------------------------------------
+// youtube skill
+// ---------------------------------------------------------------------------
+
+// urlPattern is a simple regex to extract a URL from user input.
+var urlPattern = regexp.MustCompile(`https?://[^\s<>"]+`)
+
+func youtubeSkill() core.Skill {
+	return &selfSkill{
+		name: "youtube",
+		desc: "Summarize or transcribe a YouTube video from its URL",
+		exec: func(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
+			// Extract URL from input
+			url := urlPattern.FindString(input)
+			if url == "" {
+				return "Please provide a YouTube URL. Example: youtube https://youtube.com/watch?v=...", nil
+			}
+			if !content.IsYouTubeURL(url) {
+				return fmt.Sprintf("%q does not look like a YouTube URL", url), nil
+			}
+
+			doc, err := content.ReadYouTube(ctx, url)
+			if err != nil {
+				return fmt.Sprintf("Could not read YouTube video: %v", err), nil
+			}
+
+			if doc.Text == "" {
+				return "No transcript or captions available for this video.", nil
+			}
+
+			// If LLM available, summarize; otherwise return raw transcript
+			if llm != nil {
+				summary, err := content.Summarize(ctx, llm, []content.Document{doc},
+					"Summarize this YouTube video transcript. Include:\n"+
+						"1. Brief overview (2-3 sentences)\n"+
+						"2. Key takeaways (bullet points)\n"+
+						"3. Notable quotes if any")
+				if err == nil && summary != "" {
+					return fmt.Sprintf("Video: %s\n\n%s", doc.Source, summary), nil
+				}
+			}
+
+			// Fallback: return raw transcript (truncated)
+			transcript := doc.Text
+			if len(transcript) > 3000 {
+				transcript = transcript[:3000] + "\n\n... [transcript truncated]"
+			}
+			return fmt.Sprintf("Video: %s\n\nTranscript:\n%s", doc.Source, transcript), nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// research skill
+// ---------------------------------------------------------------------------
+
+func researchSkill() core.Skill {
+	return &selfSkill{
+		name: "research",
+		desc: "Deep web research with sources and citations",
+		exec: func(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
+			if strings.TrimSpace(input) == "" {
+				return "What should I research? Example: research best Go testing frameworks", nil
+			}
+			if llm == nil {
+				return "Research requires an LLM provider to synthesize findings.", nil
+			}
+			result, err := content.Research(ctx, llm, input)
+			if err != nil {
+				return fmt.Sprintf("Research failed: %v", err), nil
+			}
+			return result, nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// web skill
+// ---------------------------------------------------------------------------
+
+func webSkill() core.Skill {
+	return &selfSkill{
+		name: "web",
+		desc: "Read and summarize any web page from its URL",
+		exec: func(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
+			url := urlPattern.FindString(input)
+			if url == "" {
+				return "Please provide a URL. Example: web https://example.com/article", nil
+			}
+
+			// If it's a YouTube URL, redirect to youtube skill
+			if content.IsYouTubeURL(url) {
+				return "This looks like a YouTube URL. Try: youtube " + url, nil
+			}
+
+			doc, err := content.ReadURL(ctx, url)
+			if err != nil {
+				return fmt.Sprintf("Could not read %s: %v", url, err), nil
+			}
+
+			if strings.TrimSpace(doc.Text) == "" {
+				return fmt.Sprintf("No readable text found at %s", url), nil
+			}
+
+			// If LLM available, summarize
+			if llm != nil {
+				summary, err := content.Summarize(ctx, llm, []content.Document{doc}, "")
+				if err == nil && summary != "" {
+					return fmt.Sprintf("Source: %s\n\n%s", url, summary), nil
+				}
+			}
+
+			// Fallback: return raw text (truncated)
+			text := doc.Text
+			if len(text) > 3000 {
+				text = text[:3000] + "\n\n... [content truncated]"
+			}
+			return fmt.Sprintf("Source: %s\n\n%s", url, text), nil
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// remind skill
+// ---------------------------------------------------------------------------
+
+func remindSkill(store *reminder.Store) core.Skill {
+	return &selfSkill{
+		name: "remind",
+		desc: "Set, list, and manage reminders with natural language timing",
+		exec: func(_ context.Context, input string, _ core.LLMProvider) (string, error) {
+			input = strings.TrimSpace(input)
+			if input == "" {
+				return "Usage:\n" +
+					"  remind <text> in <duration>  — set a reminder\n" +
+					"  remind list                  — show all reminders\n" +
+					"  remind due                   — show due reminders\n" +
+					"  remind done <id>             — mark as complete\n" +
+					"  remind delete <id>           — delete a reminder\n\n" +
+					"Examples:\n" +
+					"  remind check the build in 30 minutes\n" +
+					"  remind standup tomorrow 9am", nil
+			}
+
+			lower := strings.ToLower(input)
+
+			// Subcommand: list
+			if lower == "list" || lower == "list all" {
+				return formatReminderList(store)
+			}
+
+			// Subcommand: due
+			if lower == "due" {
+				return formatDueReminders(store)
+			}
+
+			// Subcommand: done <id>
+			if strings.HasPrefix(lower, "done ") {
+				id := strings.TrimSpace(input[5:])
+				if err := store.MarkDone(id); err != nil {
+					return fmt.Sprintf("Could not mark done: %v", err), nil
+				}
+				return fmt.Sprintf("Reminder %s marked as done.", id), nil
+			}
+
+			// Subcommand: delete <id>
+			if strings.HasPrefix(lower, "delete ") {
+				id := strings.TrimSpace(input[7:])
+				if err := store.Delete(id); err != nil {
+					return fmt.Sprintf("Could not delete: %v", err), nil
+				}
+				return fmt.Sprintf("Reminder %s deleted.", id), nil
+			}
+
+			// Default: create a new reminder
+			text, dueAt, err := reminder.Parse(input, "", time.Now())
+			if err != nil {
+				return fmt.Sprintf("Could not parse reminder: %v\n\nTry: \"remind check logs in 10 minutes\" or \"remind standup tomorrow 9am\"", err), nil
+			}
+
+			r, err := store.Add(text, dueAt)
+			if err != nil {
+				return fmt.Sprintf("Could not save reminder: %v", err), nil
+			}
+
+			return fmt.Sprintf("Reminder set!\n  ID: %s\n  Text: %s\n  Due: %s",
+				r.ID, r.Text, r.DueAt.Local().Format("2006-01-02 15:04")), nil
+		},
+	}
+}
+
+func formatReminderList(store *reminder.Store) (string, error) {
+	all, err := store.List()
+	if err != nil {
+		return fmt.Sprintf("Could not list reminders: %v", err), nil
+	}
+	if len(all) == 0 {
+		return "No reminders set.", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Reminders (%d):\n\n", len(all)))
+	for _, r := range all {
+		status := "pending"
+		if r.DoneAt != nil {
+			status = "done"
+		} else if r.FiredAt != nil {
+			status = "fired"
+		} else if !r.DueAt.After(time.Now().UTC()) {
+			status = "DUE"
+		}
+		sb.WriteString(fmt.Sprintf("  [%s] %s — %s (due %s)\n",
+			status, r.ID, r.Text, r.DueAt.Local().Format("Jan 2 15:04")))
+	}
+	return sb.String(), nil
+}
+
+func formatDueReminders(store *reminder.Store) (string, error) {
+	due, err := store.Due(time.Now())
+	if err != nil {
+		return fmt.Sprintf("Could not check due reminders: %v", err), nil
+	}
+	if len(due) == 0 {
+		return "No reminders are due right now.", nil
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Due reminders (%d):\n\n", len(due)))
+	for _, r := range due {
+		sb.WriteString(fmt.Sprintf("  %s — %s (was due %s)\n",
+			r.ID, r.Text, r.DueAt.Local().Format("Jan 2 15:04")))
+	}
+	sb.WriteString("\nUse 'remind done <id>' to mark complete.")
+	return sb.String(), nil
+}
+
+// ---------------------------------------------------------------------------
+// notify skill
+// ---------------------------------------------------------------------------
+
+func notifySkill(cfg *config.Config) core.Skill {
+	return &selfSkill{
+		name: "notify",
+		desc: "Send a message via Telegram bot",
+		exec: func(_ context.Context, input string, _ core.LLMProvider) (string, error) {
+			if strings.TrimSpace(input) == "" {
+				return "What message should I send? Example: notify deploy is complete", nil
+			}
+
+			token := os.Getenv("KRILL_TELEGRAM_TOKEN")
+			if token == "" && cfg != nil {
+				token = cfg.Telegram.Token
+			}
+			if token == "" {
+				return "Telegram not configured. Set KRILL_TELEGRAM_TOKEN environment variable.", nil
+			}
+
+			chatIDStr := os.Getenv("KRILL_TELEGRAM_CHAT_ID")
+			if chatIDStr == "" {
+				return "Telegram chat ID not configured. Set KRILL_TELEGRAM_CHAT_ID environment variable.", nil
+			}
+
+			chatID, err := strconv.ParseInt(strings.TrimSpace(chatIDStr), 10, 64)
+			if err != nil {
+				return fmt.Sprintf("Invalid KRILL_TELEGRAM_CHAT_ID: %v", err), nil
+			}
+
+			if len(input) > 4096 {
+				return fmt.Sprintf("Message too long (%d chars). Telegram limit is 4096.", len(input)), nil
+			}
+
+			bot, err := tgbotapi.NewBotAPI(token)
+			if err != nil {
+				return fmt.Sprintf("Could not connect to Telegram: %v", err), nil
+			}
+
+			msg := tgbotapi.NewMessage(chatID, input)
+			if _, err := bot.Send(msg); err != nil {
+				return fmt.Sprintf("Failed to send: %v", err), nil
+			}
+
+			log.Info("telegram notification sent", "chars", len(input))
+			return "Message sent to Telegram.", nil
+		},
+	}
+}

--- a/internal/plugin/features.go
+++ b/internal/plugin/features.go
@@ -22,7 +22,6 @@ import (
 // access to state beyond the standard Execute(ctx, input, llm) signature.
 type FeatureContext struct {
 	Config    *config.Config
-	LLM       core.LLMProvider
 	Reminders *reminder.Store
 }
 
@@ -46,10 +45,9 @@ func NewFeatureSkills(fc FeatureContext) []core.Skill {
 }
 
 func telegramAvailable(cfg *config.Config) bool {
-	if os.Getenv("KRILL_TELEGRAM_TOKEN") != "" {
-		return true
-	}
-	return cfg != nil && cfg.Telegram.Token != ""
+	hasToken := os.Getenv("KRILL_TELEGRAM_TOKEN") != "" || (cfg != nil && cfg.Telegram.Token != "")
+	hasChatID := os.Getenv("KRILL_TELEGRAM_CHAT_ID") != ""
+	return hasToken && hasChatID
 }
 
 // ---------------------------------------------------------------------------
@@ -57,7 +55,8 @@ func telegramAvailable(cfg *config.Config) bool {
 // ---------------------------------------------------------------------------
 
 // urlPattern is a simple regex to extract a URL from user input.
-var urlPattern = regexp.MustCompile(`https?://[^\s<>"]+`)
+// featureURLPattern extracts the first URL from user input for feature skills.
+var featureURLPattern = regexp.MustCompile(`https?://[^\s<>"]+`)
 
 func youtubeSkill() core.Skill {
 	return &selfSkill{
@@ -65,7 +64,7 @@ func youtubeSkill() core.Skill {
 		desc: "Summarize or transcribe a YouTube video from its URL",
 		exec: func(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
 			// Extract URL from input
-			url := urlPattern.FindString(input)
+			url := featureURLPattern.FindString(input)
 			if url == "" {
 				return "Please provide a YouTube URL. Example: youtube https://youtube.com/watch?v=...", nil
 			}
@@ -94,10 +93,10 @@ func youtubeSkill() core.Skill {
 				}
 			}
 
-			// Fallback: return raw transcript (truncated)
+			// Fallback: return raw transcript (rune-safe truncation)
 			transcript := doc.Text
-			if len(transcript) > 3000 {
-				transcript = transcript[:3000] + "\n\n... [transcript truncated]"
+			if len([]rune(transcript)) > 3000 {
+				transcript = string([]rune(transcript)[:3000]) + "\n\n... [transcript truncated]"
 			}
 			return fmt.Sprintf("Video: %s\n\nTranscript:\n%s", doc.Source, transcript), nil
 		},
@@ -137,14 +136,29 @@ func webSkill() core.Skill {
 		name: "web",
 		desc: "Read and summarize any web page from its URL",
 		exec: func(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
-			url := urlPattern.FindString(input)
+			url := featureURLPattern.FindString(input)
 			if url == "" {
 				return "Please provide a URL. Example: web https://example.com/article", nil
 			}
 
-			// If it's a YouTube URL, redirect to youtube skill
+			// If it's a YouTube URL, handle via ReadYouTube directly
 			if content.IsYouTubeURL(url) {
-				return "This looks like a YouTube URL. Try: youtube " + url, nil
+				doc, err := content.ReadYouTube(ctx, url)
+				if err != nil {
+					return fmt.Sprintf("Could not read YouTube video: %v", err), nil
+				}
+				if llm != nil {
+					summary, serr := content.Summarize(ctx, llm, []content.Document{doc},
+						"Summarize this YouTube video transcript concisely with key takeaways.")
+					if serr == nil && summary != "" {
+						return fmt.Sprintf("Video: %s\n\n%s", url, summary), nil
+					}
+				}
+				text := doc.Text
+				if len([]rune(text)) > 3000 {
+					text = string([]rune(text)[:3000]) + "\n\n... [transcript truncated]"
+				}
+				return fmt.Sprintf("Video: %s\n\nTranscript:\n%s", url, text), nil
 			}
 
 			doc, err := content.ReadURL(ctx, url)
@@ -164,10 +178,10 @@ func webSkill() core.Skill {
 				}
 			}
 
-			// Fallback: return raw text (truncated)
+			// Fallback: return raw text (rune-safe truncation)
 			text := doc.Text
-			if len(text) > 3000 {
-				text = text[:3000] + "\n\n... [content truncated]"
+			if len([]rune(text)) > 3000 {
+				text = string([]rune(text)[:3000]) + "\n\n... [content truncated]"
 			}
 			return fmt.Sprintf("Source: %s\n\n%s", url, text), nil
 		},

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -302,6 +302,37 @@ func TestSkillRegistryDisableUnknown(t *testing.T) {
 	}
 }
 
+func TestFeatureSkillsRegistration(t *testing.T) {
+	reg := NewRegistry()
+
+	// Register with nil reminders and no Telegram — should get youtube, research, web
+	reg.RegisterFeatureSkills(FeatureContext{})
+
+	expected := []string{"youtube", "research", "web"}
+	for _, name := range expected {
+		if _, ok := reg.Get(name); !ok {
+			t.Errorf("feature skill %q not registered", name)
+		}
+	}
+
+	// remind and notify should NOT be registered (nil store, no token)
+	if _, ok := reg.Get("remind"); ok {
+		t.Error("remind should not be registered without a Store")
+	}
+	if _, ok := reg.Get("notify"); ok {
+		t.Error("notify should not be registered without Telegram config")
+	}
+
+	// Verify categories are set to Built-in
+	for _, info := range reg.List() {
+		for _, name := range expected {
+			if info.Name == name && info.Category != "Built-in" {
+				t.Errorf("feature skill %q category = %q, want Built-in", name, info.Category)
+			}
+		}
+	}
+}
+
 func TestRecallSkill(t *testing.T) {
 	reg := NewRegistry()
 	reg.RegisterBuiltins()

--- a/internal/plugin/registry_test.go
+++ b/internal/plugin/registry_test.go
@@ -323,11 +323,11 @@ func TestFeatureSkillsRegistration(t *testing.T) {
 		t.Error("notify should not be registered without Telegram config")
 	}
 
-	// Verify categories are set to Built-in
+	// Verify categories are set to Feature
 	for _, info := range reg.List() {
 		for _, name := range expected {
-			if info.Name == name && info.Category != "Built-in" {
-				t.Errorf("feature skill %q category = %q, want Built-in", name, info.Category)
+			if info.Name == name && info.Category != "Feature" {
+				t.Errorf("feature skill %q category = %q, want Feature", name, info.Category)
 			}
 		}
 	}

--- a/internal/plugin/self.go
+++ b/internal/plugin/self.go
@@ -230,25 +230,51 @@ func selfMemory(sc SelfContext) core.Skill {
 	}
 }
 
+// capabilityLine maps a skill name to a user-friendly TLDR line.
+// Only skills that are actually registered appear in the TLDR.
+var capabilityLines = []struct {
+	skill string // skill name to check, or "" for always-shown
+	line  string
+}{
+	{"", "Chat & discuss any topic naturally"},
+	{"youtube", "Summarize YouTube videos — just paste a link"},
+	{"remind", "Set reminders — \"remind me in 30 min to check the build\""},
+	{"research", "Research the web — deep search with sources and citations"},
+	{"web", "Read & summarize web pages — paste any URL"},
+	{"summarize", "Summarize text and documents"},
+	{"explain-code", "Explain code with clear breakdowns"},
+	{"debug", "Debug errors and suggest fixes"},
+	{"brainstorm", "Brainstorm creative ideas"},
+	{"notify", "Send Telegram notifications"},
+	{"self:configure", "Manage my own personality, memory, and configuration"},
+	{"", "Plan and execute multi-step tasks"},
+}
+
 func selfSkills(sc SelfContext) core.Skill {
 	return &selfSkill{
 		name: "self:skills",
 		desc: "List all the krill's registered skills and capabilities",
 		exec: func(_ context.Context, _ string, _ core.LLMProvider) (string, error) {
 			skills := sc.Skills.List()
+
+			// Build a set of registered+enabled skill names
+			registered := make(map[string]bool, len(skills))
+			for _, s := range skills {
+				if s.Enabled {
+					registered[s.Name] = true
+				}
+			}
+
 			var sb strings.Builder
 
-			// TLDR — high-level capabilities summary shown first
+			// TLDR — built dynamically from what's actually registered
 			sb.WriteString("=== WHAT I CAN DO ===\n\n")
-			sb.WriteString("• Chat & discuss any topic naturally\n")
-			sb.WriteString("• Summarize YouTube videos — just paste a link\n")
-			sb.WriteString("• Set reminders — \"remind me in 30 min to check the build\"\n")
-			sb.WriteString("• Research the web — deep search with sources and citations\n")
-			sb.WriteString("• Read & summarize web pages — paste any URL\n")
-			sb.WriteString("• Summarize text, explain code, debug errors, brainstorm ideas\n")
-			sb.WriteString("• Send Telegram notifications\n")
-			sb.WriteString("• Manage my own personality, memory, and configuration\n")
-			sb.WriteString("• Plan and execute multi-step tasks\n\n")
+			for _, cap := range capabilityLines {
+				if cap.skill == "" || registered[cap.skill] {
+					sb.WriteString("• " + cap.line + "\n")
+				}
+			}
+			sb.WriteString("\n")
 
 			// Detailed skill list
 			sb.WriteString(fmt.Sprintf("=== REGISTERED SKILLS (%d) ===\n\n", len(skills)))

--- a/internal/plugin/self.go
+++ b/internal/plugin/self.go
@@ -237,7 +237,21 @@ func selfSkills(sc SelfContext) core.Skill {
 		exec: func(_ context.Context, _ string, _ core.LLMProvider) (string, error) {
 			skills := sc.Skills.List()
 			var sb strings.Builder
-			sb.WriteString(fmt.Sprintf("=== KRILL SKILLS (%d registered) ===\n\n", len(skills)))
+
+			// TLDR — high-level capabilities summary shown first
+			sb.WriteString("=== WHAT I CAN DO ===\n\n")
+			sb.WriteString("• Chat & discuss any topic naturally\n")
+			sb.WriteString("• Summarize YouTube videos — just paste a link\n")
+			sb.WriteString("• Set reminders — \"remind me in 30 min to check the build\"\n")
+			sb.WriteString("• Research the web — deep search with sources and citations\n")
+			sb.WriteString("• Read & summarize web pages — paste any URL\n")
+			sb.WriteString("• Summarize text, explain code, debug errors, brainstorm ideas\n")
+			sb.WriteString("• Send Telegram notifications\n")
+			sb.WriteString("• Manage my own personality, memory, and configuration\n")
+			sb.WriteString("• Plan and execute multi-step tasks\n\n")
+
+			// Detailed skill list
+			sb.WriteString(fmt.Sprintf("=== REGISTERED SKILLS (%d) ===\n\n", len(skills)))
 			for _, s := range skills {
 				status := "on"
 				if !s.Enabled {

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -620,7 +620,7 @@ func (s *SkillsView) buildItems() {
 	s.items = nil
 
 	// Group skills by category using the registry-provided Category field
-	var builtin, selfAware, custom []registryItem
+	var builtin, feature, selfAware, custom []registryItem
 	if s.registry != nil {
 		for _, sk := range s.registry.List() {
 			cat := sk.Category
@@ -637,6 +637,8 @@ func (s *SkillsView) buildItems() {
 			switch cat {
 			case "Built-in":
 				builtin = append(builtin, item)
+			case "Feature":
+				feature = append(feature, item)
 			case "Self-Awareness":
 				selfAware = append(selfAware, item)
 			default:
@@ -665,6 +667,7 @@ func (s *SkillsView) buildItems() {
 
 	// Assemble in display order
 	s.items = append(s.items, builtin...)
+	s.items = append(s.items, feature...)
 	s.items = append(s.items, selfAware...)
 	s.items = append(s.items, custom...)
 	s.items = append(s.items, mcpItems...)


### PR DESCRIPTION
## Summary

- **5 new chat skills** wrapping CLI-only features so they work from TUI/Chat:
  - `youtube` — paste a YouTube link, get a transcript or AI summary
  - `remind` — natural language reminders ("remind me in 30 min to check the build")
  - `research` — deep web research with sources and citations
  - `web` — read and summarize any web page
  - `notify` — send Telegram notifications from chat
- **TLDR in "what can you do"** — `self:skills` now leads with a plain-language capabilities summary (`=== WHAT I CAN DO ===`) before the detailed skill registry list
- **Conditional registration** — `remind` only registers when a reminder store is available; `notify` only when Telegram is configured

## How it works

All 5 skills reuse existing Go implementations (`internal/content/`, `internal/reminder/`) via thin wrappers. Skills needing state (reminder store, config) receive it through `FeatureContext` at registration time using the same closure pattern as self-skills.

## Files changed (5)

| File | Change |
|------|--------|
| `internal/plugin/features.go` | NEW — 5 feature skills with `FeatureContext` dependency injection |
| `internal/plugin/builtins.go` | `RegisterFeatureSkills()` method |
| `internal/plugin/self.go` | TLDR block prepended to `self:skills` output |
| `cmd/minikrill/main.go` | Wire `RegisterFeatureSkills()` in `initStack()` |
| `internal/plugin/registry_test.go` | `TestFeatureSkillsRegistration` — conditional registration |

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all tests pass
- [ ] TUI: type "what can you do" → verify TLDR appears first with all capabilities
- [ ] TUI: paste a YouTube URL → verify transcript/summary
- [ ] TUI: type "remind me in 5 minutes to stretch" → verify reminder created
- [ ] TUI: type "research best Go web frameworks" → verify research with sources
- [ ] TUI: type "read https://example.com" → verify page summary
- [ ] Skills tab: verify youtube, remind, research, web appear under "Built-in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)