### PR TITLE
Fix Telegram polling conflict in chat/tui commands

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -367,17 +367,31 @@ var diveCmd = &cobra.Command{
 }
 
 // diveDaemon re-execs the dive command as a detached background process.
+// daemonRunning returns true if a dive daemon is already running.
+func daemonRunning() bool {
+	pidFile := filepath.Join(config.DataDir(), "krill.pid")
+	data, err := os.ReadFile(pidFile)
+	if err != nil {
+		return false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return processRunning(proc)
+}
+
 func diveDaemon() error {
 	// Check if a daemon is already running
-	pidFile := filepath.Join(config.DataDir(), "krill.pid")
-	if data, err := os.ReadFile(pidFile); err == nil {
-		if pid, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
-			if proc, err := os.FindProcess(pid); err == nil {
-				if processRunning(proc) {
-					return fmt.Errorf("Mini Krill is already diving (PID %d). Run 'minikrill surface' first", pid)
-				}
-			}
-		}
+	if daemonRunning() {
+		pidFile := filepath.Join(config.DataDir(), "krill.pid")
+		data, _ := os.ReadFile(pidFile)
+		pid, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+		return fmt.Errorf("Mini Krill is already diving (PID %d). Run 'minikrill surface' first", pid)
 	}
 
 	exe, err := os.Executable()
@@ -413,6 +427,7 @@ func diveDaemon() error {
 	// Detach - the parent does not wait for the child.
 	_ = child.Process.Release()
 
+	pidFile := filepath.Join(config.DataDir(), "krill.pid")
 	_ = os.WriteFile(pidFile, []byte(strconv.Itoa(child.Process.Pid)), 0644)
 
 	printBanner()
@@ -527,7 +542,9 @@ var chatCmd = &cobra.Command{
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
 
-		startBots(ctx, stack)
+		if !daemonRunning() {
+			startBots(ctx, stack)
+		}
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, stack.skills, stack.mcp, core.Version, stack.cfg.Log.File)
 		app.SetInitialTab(tui.TabChat)
@@ -553,9 +570,11 @@ var tuiCmd = &cobra.Command{
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
 
-		bs := startBots(ctx, stack)
-		if stack.cfg.Telegram.Enabled && bs.TelegramErr != nil {
-			klog.Error("telegram bot failed in TUI mode", "error", bs.TelegramErr)
+		if !daemonRunning() {
+			bs := startBots(ctx, stack)
+			if stack.cfg.Telegram.Enabled && bs.TelegramErr != nil {
+				klog.Error("telegram bot failed in TUI mode", "error", bs.TelegramErr)
+			}
 		}
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, stack.skills, stack.mcp, core.Version, stack.cfg.Log.File)

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -366,31 +366,31 @@ var diveCmd = &cobra.Command{
 	},
 }
 
-// diveDaemon re-execs the dive command as a detached background process.
-// daemonRunning returns true if a dive daemon is already running.
-func daemonRunning() bool {
+// daemonPID returns the PID of a running dive daemon, or 0 if none.
+func daemonPID() int {
 	pidFile := filepath.Join(config.DataDir(), "krill.pid")
 	data, err := os.ReadFile(pidFile)
 	if err != nil {
-		return false
+		return 0
 	}
 	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
 	if err != nil {
-		return false
+		return 0
 	}
 	proc, err := os.FindProcess(pid)
 	if err != nil {
-		return false
+		return 0
 	}
-	return processRunning(proc)
+	if !processRunning(proc) {
+		return 0
+	}
+	return pid
 }
 
+// diveDaemon re-execs the dive command as a detached background process.
 func diveDaemon() error {
 	// Check if a daemon is already running
-	if daemonRunning() {
-		pidFile := filepath.Join(config.DataDir(), "krill.pid")
-		data, _ := os.ReadFile(pidFile)
-		pid, _ := strconv.Atoi(strings.TrimSpace(string(data)))
+	if pid := daemonPID(); pid != 0 {
 		return fmt.Errorf("Mini Krill is already diving (PID %d). Run 'minikrill surface' first", pid)
 	}
 
@@ -447,14 +447,9 @@ var surfaceCmd = &cobra.Command{
 	Use:   "surface",
 	Short: "Stop a running Mini Krill instance",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		pidFile := filepath.Join(config.DataDir(), "krill.pid")
-		data, err := os.ReadFile(pidFile)
-		if err != nil {
-			return fmt.Errorf("Mini Krill is not diving (no PID file)")
-		}
-		pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
-		if err != nil {
-			return fmt.Errorf("corrupt PID file")
+		pid := daemonPID()
+		if pid == 0 {
+			return fmt.Errorf("Mini Krill is not diving (no running daemon found)")
 		}
 		proc, err := os.FindProcess(pid)
 		if err != nil {
@@ -463,7 +458,7 @@ var surfaceCmd = &cobra.Command{
 		if err := terminateProcess(proc); err != nil {
 			_ = proc.Kill()
 		}
-		_ = os.Remove(pidFile)
+		_ = os.Remove(filepath.Join(config.DataDir(), "krill.pid"))
 		fmt.Println(cCyan + "Mini Krill is surfacing..." + cReset)
 		return nil
 	},
@@ -542,8 +537,13 @@ var chatCmd = &cobra.Command{
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
 
-		if !daemonRunning() {
-			startBots(ctx, stack)
+		if daemonPID() == 0 {
+			bs := startBots(ctx, stack)
+			if stack.cfg.Telegram.Enabled && bs.TelegramErr != nil {
+				klog.Warn("telegram bot failed to start", "error", bs.TelegramErr)
+			}
+		} else {
+			klog.Debug("skipping bot startup, dive daemon is running")
 		}
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, stack.skills, stack.mcp, core.Version, stack.cfg.Log.File)
@@ -570,11 +570,13 @@ var tuiCmd = &cobra.Command{
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
 
-		if !daemonRunning() {
+		if daemonPID() == 0 {
 			bs := startBots(ctx, stack)
 			if stack.cfg.Telegram.Enabled && bs.TelegramErr != nil {
 				klog.Error("telegram bot failed in TUI mode", "error", bs.TelegramErr)
 			}
+		} else {
+			klog.Debug("skipping bot startup, dive daemon is running")
 		}
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, stack.skills, stack.mcp, core.Version, stack.cfg.Log.File)


### PR DESCRIPTION
## Summary
- `chat` and `tui` commands both called `startBots()` which starts a Telegram `getUpdates` poller — when a `dive` daemon was already running, this created two pollers on the same bot token causing a Telegram API conflict: `"Conflict: terminated by other getUpdates request"`
- Extracted `daemonRunning()` helper from `diveDaemon()` to check if a dive daemon is already active via the PID file
- `chat` and `tui` now skip `startBots()` when a daemon is already running, avoiding the duplicate poller

## Test plan
- [ ] Run `minikrill dive` to start the daemon, then `minikrill chat` — verify no Telegram conflict error
- [ ] Run `minikrill chat` standalone (no daemon) — verify Telegram bot still starts normally
- [ ] Run `minikrill tui` standalone — verify Telegram bot still starts normally
- [ ] Run `minikrill dive` twice — verify it still rejects with "already diving" error