### PR TITLE
Add dedicated MCP tab to TUI

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -33,8 +33,9 @@ const (
 	TabDashboard = 0
 	TabChat      = 1
 	TabSkills    = 2
-	TabLogs      = 3
-	TabHelp      = 4
+	TabMCP       = 3
+	TabLogs      = 4
+	TabHelp      = 5
 
 	// layoutMargins is the vertical breathing room reserved between layout sections.
 	layoutMargins = 3
@@ -52,6 +53,7 @@ type App struct {
 	dashboard DashboardView
 	chat      ChatView
 	skills    SkillsView
+	mcp       MCPView
 	logs      LogsView
 	help      HelpView
 
@@ -69,11 +71,12 @@ type App struct {
 // NewApp creates a fully initialized App ready to run.
 func NewApp(agent core.Agent, brain core.Brain, heartbeat core.Heartbeat, skillReg core.SkillRegistry, mcpReg core.MCPRegistry, version, logFile string) *App {
 	return &App{
-		tabs:      []string{"Dashboard", "Chat", "Skills", "Logs", "Help"},
+		tabs:      []string{"Dashboard", "Chat", "Skills", "MCP", "Logs", "Help"},
 		activeTab: 0,
 		dashboard: NewDashboardView(version),
 		chat:      NewChatView(agent),
-		skills:    NewSkillsView(skillReg, mcpReg),
+		skills:    NewSkillsView(skillReg),
+		mcp:       NewMCPView(mcpReg),
 		logs:      NewLogsView(logFile),
 		help:      NewHelpView(),
 		agent:     agent,
@@ -261,11 +264,17 @@ func (a *App) handleKey(msg tea.KeyMsg) tea.Cmd {
 		}
 	case "4":
 		if !inChat {
-			a.activeTab = TabLogs
+			a.activeTab = TabMCP
 			a.onTabSwitch()
 			return nil
 		}
 	case "5":
+		if !inChat {
+			a.activeTab = TabLogs
+			a.onTabSwitch()
+			return nil
+		}
+	case "6":
 		if !inChat {
 			a.activeTab = TabHelp
 			a.onTabSwitch()
@@ -295,6 +304,8 @@ func (a *App) onTabSwitch() {
 	switch a.activeTab {
 	case TabSkills:
 		a.skills.refreshContent()
+	case TabMCP:
+		a.mcp.refreshContent()
 	case TabLogs:
 		a.logs.RefreshLogs()
 	}
@@ -325,6 +336,8 @@ func (a *App) updateActiveView(msg tea.Msg) tea.Cmd {
 		return a.chat.Update(msg)
 	case TabSkills:
 		return a.skills.Update(msg)
+	case TabMCP:
+		return a.mcp.Update(msg)
 	case TabLogs:
 		return a.logs.Update(msg)
 	case TabHelp:
@@ -339,6 +352,7 @@ func (a *App) resizeViews() {
 	a.dashboard.SetSize(a.width, h)
 	a.chat.SetSize(a.width, h)
 	a.skills.SetSize(a.width, h)
+	a.mcp.SetSize(a.width, h)
 	a.logs.SetSize(a.width, h)
 	a.help.SetSize(a.width, h)
 }
@@ -400,6 +414,8 @@ func (a *App) renderBody() string {
 		return a.chat.View()
 	case TabSkills:
 		return a.skills.View()
+	case TabMCP:
+		return a.mcp.View()
 	case TabLogs:
 		return a.logs.View()
 	case TabHelp:

--- a/internal/tui/app_test.go
+++ b/internal/tui/app_test.go
@@ -33,7 +33,7 @@ func TestSetInitialTab(t *testing.T) {
 	}
 
 	// Set to each valid tab
-	for _, tab := range []int{TabDashboard, TabChat, TabSkills, TabLogs, TabHelp} {
+	for _, tab := range []int{TabDashboard, TabChat, TabSkills, TabMCP, TabLogs, TabHelp} {
 		app.SetInitialTab(tab)
 		if app.activeTab != tab {
 			t.Errorf("expected tab %d, got %d", tab, app.activeTab)

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -755,7 +755,7 @@ func (s *SkillsView) refreshContent() {
 		HelpKeyStyle.Render("j/k") + DimStyle.Render(" navigate  ") +
 		HelpKeyStyle.Render("g/G") + DimStyle.Render(" top/bottom  ") +
 		HelpKeyStyle.Render("Enter/Space") + DimStyle.Render(" toggle  ") +
-		DimStyle.Render("(changes reset on restart)")
+		DimStyle.Render("(runtime only)")
 
 	// Compose final view
 	body := lipgloss.JoinVertical(lipgloss.Left,
@@ -913,7 +913,7 @@ func (m *MCPView) refreshContent() {
 		DimStyle.Render(fmt.Sprintf("  %d servers registered", len(m.items)))
 
 	if len(m.items) == 0 {
-		empty := DimStyle.Render("  No MCP servers configured.\n  Add servers in config/default.yaml under mcp.servers.")
+		empty := DimStyle.Render("  No MCP servers configured.\n  Add servers in your krill config under mcp.servers.")
 		nav := DimStyle.Render("  Configure MCP servers to extend your agent's capabilities.")
 
 		body := lipgloss.JoinVertical(lipgloss.Left,
@@ -943,7 +943,11 @@ func (m *MCPView) refreshContent() {
 			connText = fmt.Sprintf("connected, %d tools", item.toolCount)
 		}
 
-		nameDisplay := fmt.Sprintf("%-20s", item.name)
+		name := item.name
+		if len(name) > 20 {
+			name = name[:17] + "..."
+		}
+		nameDisplay := fmt.Sprintf("%-20s", name)
 
 		if i == m.cursor {
 			line := lipgloss.NewStyle().
@@ -988,7 +992,7 @@ func (m *MCPView) refreshContent() {
 		HelpKeyStyle.Render("j/k") + DimStyle.Render(" navigate  ") +
 		HelpKeyStyle.Render("g/G") + DimStyle.Render(" top/bottom  ") +
 		HelpKeyStyle.Render("Enter/Space") + DimStyle.Render(" toggle  ") +
-		DimStyle.Render("(changes reset on restart)")
+		DimStyle.Render("(runtime only)")
 
 	// Compose final view
 	body := lipgloss.JoinVertical(lipgloss.Left,
@@ -1044,8 +1048,8 @@ func (h *HelpView) View() string {
 		{"1 2 3 4 5 6", "Jump directly to tab"},
 		{"Right / Left", "Next / previous tab"},
 		{"Esc", "Unfocus chat input"},
-		{"j / k", "Scroll down / up (skills, logs)"},
-		{"g / G", "Jump to top / bottom (skills)"},
+		{"j / k", "Scroll down / up (skills, mcp, logs)"},
+		{"g / G", "Jump to top / bottom (skills, mcp)"},
 		{"c", "Copy logs to clipboard (logs)"},
 		{"Enter", "Send message (chat)"},
 		{"q / Ctrl+C", "Quit (not in chat input)"},

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -504,20 +504,18 @@ func colorizeLogLine(line string) string {
 // SkillsView
 // ---------------------------------------------------------------------------
 
-// registryItem is a unified entry for both skills and MCP servers.
+// registryItem is an entry for a skill in the registry.
 type registryItem struct {
 	name        string
 	description string
 	enabled     bool
-	category    string // "Built-in", "Self-Awareness", "Custom / YAML", "MCP Servers"
-	isMCP       bool
-	locked      bool // true for self:* skills — cannot be toggled
+	category    string // "Built-in", "Self-Awareness", "Custom / YAML"
+	locked      bool   // true for self:* skills — cannot be toggled
 }
 
-// SkillsView displays skills and MCP servers with enable/disable toggle.
+// SkillsView displays skills with enable/disable toggle.
 type SkillsView struct {
 	registry  core.SkillRegistry
-	mcpReg    core.MCPRegistry
 	viewport  viewport.Model
 	items     []registryItem
 	catCounts map[string]int // pre-computed category counts
@@ -528,10 +526,9 @@ type SkillsView struct {
 }
 
 // NewSkillsView creates a skills registry view.
-func NewSkillsView(registry core.SkillRegistry, mcpReg core.MCPRegistry) SkillsView {
+func NewSkillsView(registry core.SkillRegistry) SkillsView {
 	return SkillsView{
 		registry: registry,
-		mcpReg:   mcpReg,
 	}
 }
 
@@ -584,17 +581,9 @@ func (s *SkillsView) Update(msg tea.Msg) tea.Cmd {
 					return nil // self-skills cannot be toggled
 				}
 				newEnabled := !item.enabled
-				if item.isMCP {
-					if s.mcpReg != nil {
-						if err := s.mcpReg.SetEnabled(item.name, newEnabled); err != nil {
-							log.Debug("toggle MCP server failed", "name", item.name, "error", err)
-						}
-					}
-				} else {
-					if s.registry != nil {
-						if err := s.registry.SetEnabled(item.name, newEnabled); err != nil {
-							log.Debug("toggle skill failed", "name", item.name, "error", err)
-						}
+				if s.registry != nil {
+					if err := s.registry.SetEnabled(item.name, newEnabled); err != nil {
+						log.Debug("toggle skill failed", "name", item.name, "error", err)
 					}
 				}
 				s.refreshContent()
@@ -647,30 +636,11 @@ func (s *SkillsView) buildItems() {
 		}
 	}
 
-	// MCP servers
-	var mcpItems []registryItem
-	if s.mcpReg != nil {
-		for _, srv := range s.mcpReg.List() {
-			connLabel := "disconnected"
-			if srv.Connected {
-				connLabel = fmt.Sprintf("connected, %d tools", srv.ToolCount)
-			}
-			mcpItems = append(mcpItems, registryItem{
-				name:        srv.Name,
-				description: connLabel,
-				enabled:     srv.Enabled,
-				category:    "MCP Servers",
-				isMCP:       true,
-			})
-		}
-	}
-
 	// Assemble in display order
 	s.items = append(s.items, builtin...)
 	s.items = append(s.items, feature...)
 	s.items = append(s.items, selfAware...)
 	s.items = append(s.items, custom...)
-	s.items = append(s.items, mcpItems...)
 
 	// Pre-compute category counts
 	s.catCounts = make(map[string]int)
@@ -700,24 +670,9 @@ func (s *SkillsView) refreshContent() {
 		panelWidth = 30
 	}
 
-	// Count skills vs MCP
-	skillCount := 0
-	mcpCount := 0
-	for _, item := range s.items {
-		if item.isMCP {
-			mcpCount++
-		} else {
-			skillCount++
-		}
-	}
-
 	// Header summary
-	header := TitleStyle.Render("  Skill Registry  ")
-	if mcpCount > 0 {
-		header += DimStyle.Render(fmt.Sprintf("  %d skills, %d MCP servers", skillCount, mcpCount))
-	} else {
-		header += DimStyle.Render(fmt.Sprintf("  %d skills registered", skillCount))
-	}
+	header := TitleStyle.Render("  Skill Registry  ") +
+		DimStyle.Render(fmt.Sprintf("  %d skills registered", len(s.items)))
 
 	// Build rows grouped by category
 	var sections []string
@@ -792,11 +747,7 @@ func (s *SkillsView) refreshContent() {
 			LabelStyle.Render("Description:"),
 			ValueStyle.Render("  " + wordWrap(selected.description, panelWidth-8)),
 		}
-		boxTitle := "  Skill Details"
-		if selected.isMCP {
-			boxTitle = "  MCP Server Details"
-		}
-		detailBox = RenderBox(boxTitle, strings.Join(detailLines, "\n"), panelWidth)
+		detailBox = RenderBox("  Skill Details", strings.Join(detailLines, "\n"), panelWidth)
 	}
 
 	// Navigation hints
@@ -819,6 +770,239 @@ func (s *SkillsView) refreshContent() {
 	)
 
 	s.viewport.SetContent(body)
+}
+
+// ---------------------------------------------------------------------------
+// MCPView
+// ---------------------------------------------------------------------------
+
+// mcpItem represents a single MCP server entry.
+type mcpItem struct {
+	name      string
+	enabled   bool
+	connected bool
+	toolCount int
+}
+
+// MCPView displays MCP servers with connection status and enable/disable toggle.
+type MCPView struct {
+	mcpReg   core.MCPRegistry
+	viewport viewport.Model
+	items    []mcpItem
+	cursor   int
+	ready    bool
+	width    int
+	height   int
+}
+
+// NewMCPView creates a new MCP server management view.
+func NewMCPView(mcpReg core.MCPRegistry) MCPView {
+	return MCPView{
+		mcpReg: mcpReg,
+	}
+}
+
+// SetSize updates the MCP view dimensions.
+func (m *MCPView) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+	if !m.ready {
+		m.viewport = viewport.New(w, h)
+		m.ready = true
+	} else {
+		m.viewport.Width = w
+		m.viewport.Height = h
+	}
+	m.refreshContent()
+}
+
+// Update handles keyboard navigation and toggle for the MCP server list.
+func (m *MCPView) Update(msg tea.Msg) tea.Cmd {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		total := len(m.items)
+		switch msg.String() {
+		case "j", "down":
+			if m.cursor < total-1 {
+				m.cursor++
+				m.refreshContent()
+			}
+			return nil
+		case "k", "up":
+			if m.cursor > 0 {
+				m.cursor--
+				m.refreshContent()
+			}
+			return nil
+		case "g":
+			m.cursor = 0
+			m.refreshContent()
+			return nil
+		case "G":
+			if total > 0 {
+				m.cursor = total - 1
+				m.refreshContent()
+			}
+			return nil
+		case "enter", " ":
+			if m.cursor < total {
+				item := m.items[m.cursor]
+				newEnabled := !item.enabled
+				if m.mcpReg != nil {
+					if err := m.mcpReg.SetEnabled(item.name, newEnabled); err != nil {
+						log.Debug("toggle MCP server failed", "name", item.name, "error", err)
+					}
+				}
+				m.refreshContent()
+			}
+			return nil
+		}
+	}
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return cmd
+}
+
+// View renders the MCP server tab.
+func (m *MCPView) View() string {
+	if !m.ready {
+		return "Loading MCP servers..."
+	}
+	return m.viewport.View()
+}
+
+// buildItems constructs the item list from the MCP registry.
+func (m *MCPView) buildItems() {
+	m.items = nil
+	if m.mcpReg == nil {
+		return
+	}
+	for _, srv := range m.mcpReg.List() {
+		m.items = append(m.items, mcpItem{
+			name:      srv.Name,
+			enabled:   srv.Enabled,
+			connected: srv.Connected,
+			toolCount: srv.ToolCount,
+		})
+	}
+}
+
+// refreshContent rebuilds the viewport content from the current item list.
+func (m *MCPView) refreshContent() {
+	if !m.ready {
+		return
+	}
+
+	m.buildItems()
+
+	// Clamp cursor
+	if m.cursor >= len(m.items) {
+		m.cursor = len(m.items) - 1
+	}
+	if m.cursor < 0 {
+		m.cursor = 0
+	}
+
+	panelWidth := m.width - 4
+	if panelWidth < 30 {
+		panelWidth = 30
+	}
+
+	// Header
+	header := TitleStyle.Render("  MCP Servers  ") +
+		DimStyle.Render(fmt.Sprintf("  %d servers registered", len(m.items)))
+
+	if len(m.items) == 0 {
+		empty := DimStyle.Render("  No MCP servers configured.\n  Add servers in config/default.yaml under mcp.servers.")
+		nav := DimStyle.Render("  Configure MCP servers to extend your agent's capabilities.")
+
+		body := lipgloss.JoinVertical(lipgloss.Left,
+			"",
+			header,
+			"",
+			empty,
+			"",
+			nav,
+		)
+		m.viewport.SetContent(body)
+		return
+	}
+
+	// Build rows
+	var rows []string
+	for i, item := range m.items {
+		// Status badge
+		status := StatusOK.Render("[on] ")
+		if !item.enabled {
+			status = StatusFail.Render("[off]")
+		}
+
+		// Connection indicator
+		connText := "disconnected"
+		if item.connected {
+			connText = fmt.Sprintf("connected, %d tools", item.toolCount)
+		}
+
+		nameDisplay := fmt.Sprintf("%-20s", item.name)
+
+		if i == m.cursor {
+			line := lipgloss.NewStyle().
+				Foreground(ColorCyan).
+				Bold(true).
+				Render(fmt.Sprintf("▸ %s %s %s", status, nameDisplay, connText))
+			rows = append(rows, line)
+		} else {
+			line := fmt.Sprintf("  %s %s %s", status, nameDisplay, DimStyle.Render(connText))
+			rows = append(rows, line)
+		}
+	}
+
+	// Detail panel for selected server
+	var detailBox string
+	if m.cursor >= 0 && m.cursor < len(m.items) {
+		selected := m.items[m.cursor]
+
+		statusLabel := AccentStyle.Render("enabled")
+		if !selected.enabled {
+			statusLabel = ErrorStyle.Render("disabled")
+		}
+
+		var connStatus string
+		if selected.connected {
+			connStatus = AccentStyle.Render(fmt.Sprintf("connected (%d tools)", selected.toolCount))
+		} else {
+			connStatus = ErrorStyle.Render("disconnected")
+		}
+
+		detailLines := []string{
+			RenderKeyValue("Name", selected.name),
+			RenderKeyValue("Status", statusLabel),
+			RenderKeyValue("Connection", connStatus),
+			RenderKeyValue("Tools", fmt.Sprintf("%d", selected.toolCount)),
+		}
+		detailBox = RenderBox("  MCP Server Details", strings.Join(detailLines, "\n"), panelWidth)
+	}
+
+	// Navigation hints
+	nav := DimStyle.Render("  ") +
+		HelpKeyStyle.Render("j/k") + DimStyle.Render(" navigate  ") +
+		HelpKeyStyle.Render("g/G") + DimStyle.Render(" top/bottom  ") +
+		HelpKeyStyle.Render("Enter/Space") + DimStyle.Render(" toggle  ") +
+		DimStyle.Render("(changes reset on restart)")
+
+	// Compose final view
+	body := lipgloss.JoinVertical(lipgloss.Left,
+		"",
+		header,
+		"",
+		strings.Join(rows, "\n"),
+		"",
+		detailBox,
+		"",
+		nav,
+	)
+
+	m.viewport.SetContent(body)
 }
 
 // ---------------------------------------------------------------------------
@@ -857,7 +1041,7 @@ func (h *HelpView) View() string {
 	// --- Keyboard Shortcuts ---
 	shortcuts := []struct{ key, desc string }{
 		{"Tab / Shift+Tab", "Switch between tabs (always works)"},
-		{"1 2 3 4 5", "Jump directly to tab"},
+		{"1 2 3 4 5 6", "Jump directly to tab"},
 		{"Right / Left", "Next / previous tab"},
 		{"Esc", "Unfocus chat input"},
 		{"j / k", "Scroll down / up (skills, logs)"},

--- a/internal/tui/views_test.go
+++ b/internal/tui/views_test.go
@@ -1,6 +1,43 @@
 package tui
 
-import "testing"
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// ---------------------------------------------------------------------------
+// Mock MCP Registry for view tests
+// ---------------------------------------------------------------------------
+
+type mockMCPRegistry struct {
+	servers  []core.MCPServerInfo
+	toggled  map[string]bool // tracks SetEnabled calls
+	toggleFn func(name string, enabled bool) error
+}
+
+func newMockMCPRegistry(servers ...core.MCPServerInfo) *mockMCPRegistry {
+	return &mockMCPRegistry{
+		servers: servers,
+		toggled: make(map[string]bool),
+	}
+}
+
+func (r *mockMCPRegistry) Register(_ string, _ core.MCPServer) error { return nil }
+func (r *mockMCPRegistry) Get(_ string) (core.MCPServer, bool)       { return nil, false }
+func (r *mockMCPRegistry) List() []core.MCPServerInfo                { return r.servers }
+func (r *mockMCPRegistry) AllTools() []core.MCPTool                  { return nil }
+func (r *mockMCPRegistry) Close() error                              { return nil }
+func (r *mockMCPRegistry) IsEnabled(_ string) bool                   { return true }
+func (r *mockMCPRegistry) SetEnabled(name string, enabled bool) error {
+	r.toggled[name] = enabled
+	if r.toggleFn != nil {
+		return r.toggleFn(name, enabled)
+	}
+	return nil
+}
 
 func TestWordWrap(t *testing.T) {
 	tests := []struct {
@@ -85,4 +122,128 @@ func TestWordWrap(t *testing.T) {
 			}
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// MCPView tests
+// ---------------------------------------------------------------------------
+
+// newReadyMCPView creates an MCPView with dimensions set so it's ready for use.
+func newReadyMCPView(reg core.MCPRegistry) MCPView {
+	v := NewMCPView(reg)
+	v.SetSize(100, 40)
+	return v
+}
+
+func TestMCPViewCursorClampEmpty(t *testing.T) {
+	v := newReadyMCPView(newMockMCPRegistry())
+
+	// Cursor should be 0 on empty list
+	if v.cursor != 0 {
+		t.Errorf("expected cursor 0 on empty list, got %d", v.cursor)
+	}
+
+	// Navigation on empty list should not panic
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	v.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	if v.cursor != 0 {
+		t.Errorf("expected cursor to stay 0 after nav on empty list, got %d", v.cursor)
+	}
+}
+
+func TestMCPViewCursorNavigation(t *testing.T) {
+	reg := newMockMCPRegistry(
+		core.MCPServerInfo{Name: "alpha", Connected: true, ToolCount: 3, Enabled: true},
+		core.MCPServerInfo{Name: "beta", Connected: false, ToolCount: 0, Enabled: true},
+		core.MCPServerInfo{Name: "gamma", Connected: true, ToolCount: 5, Enabled: false},
+	)
+	v := newReadyMCPView(reg)
+
+	// Start at 0
+	if v.cursor != 0 {
+		t.Fatalf("expected initial cursor 0, got %d", v.cursor)
+	}
+
+	// j moves down
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if v.cursor != 1 {
+		t.Errorf("expected cursor 1 after j, got %d", v.cursor)
+	}
+
+	// k moves back up
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if v.cursor != 0 {
+		t.Errorf("expected cursor 0 after k, got %d", v.cursor)
+	}
+
+	// k at top stays at 0
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'k'}})
+	if v.cursor != 0 {
+		t.Errorf("expected cursor to stay 0 at top, got %d", v.cursor)
+	}
+
+	// G jumps to bottom
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'G'}})
+	if v.cursor != 2 {
+		t.Errorf("expected cursor 2 after G, got %d", v.cursor)
+	}
+
+	// j at bottom stays at bottom
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	if v.cursor != 2 {
+		t.Errorf("expected cursor to stay 2 at bottom, got %d", v.cursor)
+	}
+
+	// g jumps to top
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'g'}})
+	if v.cursor != 0 {
+		t.Errorf("expected cursor 0 after g, got %d", v.cursor)
+	}
+}
+
+func TestMCPViewToggleDispatchesSetEnabled(t *testing.T) {
+	reg := newMockMCPRegistry(
+		core.MCPServerInfo{Name: "server-a", Connected: true, ToolCount: 2, Enabled: true},
+		core.MCPServerInfo{Name: "server-b", Connected: false, ToolCount: 0, Enabled: false},
+	)
+	v := newReadyMCPView(reg)
+
+	// Toggle first item (enabled -> disabled)
+	v.Update(tea.KeyMsg{Type: tea.KeyEnter})
+
+	enabled, ok := reg.toggled["server-a"]
+	if !ok {
+		t.Fatal("expected SetEnabled to be called for server-a")
+	}
+	if enabled != false {
+		t.Errorf("expected server-a toggled to false, got %v", enabled)
+	}
+
+	// Move to second item and toggle (disabled -> enabled)
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}})
+	v.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{' '}})
+
+	enabled, ok = reg.toggled["server-b"]
+	if !ok {
+		t.Fatal("expected SetEnabled to be called for server-b")
+	}
+	if enabled != true {
+		t.Errorf("expected server-b toggled to true, got %v", enabled)
+	}
+}
+
+func TestMCPViewNilRegistry(t *testing.T) {
+	v := newReadyMCPView(nil)
+
+	// Should not panic with nil registry
+	if len(v.items) != 0 {
+		t.Errorf("expected 0 items with nil registry, got %d", len(v.items))
+	}
+
+	// Toggle on nil registry should not panic
+	v.Update(tea.KeyMsg{Type: tea.KeyEnter})
 }


### PR DESCRIPTION
## Summary
- Extract MCP server management from the Skills tab into a dedicated **MCP** tab (tab position 4)
- MCP tab shows server connection status, tool counts, and supports enable/disable toggling with a detail panel
- Skills tab now focuses purely on skill registry — all MCP-specific code (`isMCP`, `mcpReg`) removed
- Tab bar updated to 6 tabs: Dashboard, Chat, Skills, **MCP**, Logs, Help (keys 1-6)

## Test plan
- [ ] `go build ./...` compiles cleanly
- [ ] Run `krill tui` — verify 6 tabs visible in the tab bar
- [ ] Press `4` to jump to MCP tab — shows server list (or empty state if none configured)
- [ ] Press `3` to jump to Skills tab — no MCP servers listed
- [ ] Tab/Shift+Tab wraps through all 6 tabs correctly
- [ ] Configure an MCP server in `config/default.yaml` and verify it appears in the MCP tab with connection status
- [ ] Toggle enable/disable on an MCP server with Enter/Space