### PR TITLE
Fix TUI header/tab bar visual duplication

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug Report
+about: Something isn't working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+**What happened?**
+A clear description of the bug.
+
+**Steps to reproduce**
+1. Run `minikrill ...`
+2. ...
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS: (e.g., macOS 15, Ubuntu 24.04, Windows 11)
+- Mini Krill version: (`minikrill version`)
+- LLM provider: (Ollama / Codex / Claude Code)
+- Model: (e.g., gemma3:4b)
+
+**Logs (if applicable)**
+Paste relevant output or attach `~/.mini-krill/logs/`.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest an idea or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**What would you like?**
+A clear description of the feature or improvement.
+
+**Why?**
+What problem does this solve or what workflow does it improve?
+
+**Alternatives considered**
+Any workarounds or alternative approaches you've thought about.

--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -8,6 +8,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/srvsngh99/mini-krill/internal/brand"
 	"github.com/srvsngh99/mini-krill/internal/core"
 	log "github.com/srvsngh99/mini-krill/internal/log"
 )
@@ -158,8 +159,6 @@ func (a *App) View() string {
 		return "\n  Waiting for terminal..."
 	}
 
-	// Compact header for all tabs to maximize body space.
-	header := RenderCompactHeader(a.version, a.width)
 	tabBar := a.renderTabBar()
 	body := a.renderBody()
 	footer := a.renderFooter()
@@ -175,7 +174,6 @@ func (a *App) View() string {
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,
-		header,
 		tabBar,
 		bodyStyled,
 		footer,
@@ -358,24 +356,23 @@ func (a *App) resizeViews() {
 }
 
 // bodyHeight computes the available vertical space for view content
-// by subtracting the actual rendered header, tab bar, and footer heights.
+// by subtracting the rendered tab bar and footer heights.
 func (a *App) bodyHeight() int {
-	header := RenderCompactHeader(a.version, a.width)
 	tabBar := a.renderTabBar()
 	footer := a.renderFooter()
 
-	headerLines := strings.Count(header, "\n") + 1
 	tabLines := strings.Count(tabBar, "\n") + 1
 	footerLines := strings.Count(footer, "\n") + 1
 
-	h := a.height - headerLines - tabLines - footerLines - layoutMargins
+	h := a.height - tabLines - footerLines - layoutMargins
 	if h < 5 {
 		h = 5
 	}
 	return h
 }
 
-// renderTabBar builds the horizontal tab bar with active highlighting.
+// renderTabBar builds the horizontal tab bar with active highlighting
+// and right-aligned version branding in the filler area.
 func (a *App) renderTabBar() string {
 	var tabs []string
 
@@ -392,13 +389,22 @@ func (a *App) renderTabBar() string {
 
 	row := lipgloss.JoinHorizontal(lipgloss.Bottom, tabs...)
 
-	// Fill the rest of the tab bar with a border line
+	// Fill the rest of the tab bar with a border line.
+	// Version branding is right-aligned in the filler area.
 	gap := a.width - lipgloss.Width(row)
 	if gap > 0 {
+		versionTag := fmt.Sprintf("%s v%s", brand.Name, a.version)
+		fillerContent := ""
+		if gap > len(versionTag)+4 {
+			padding := gap - len(versionTag) - 2
+			fillerContent = strings.Repeat(" ", padding) + DimStyle.Render(versionTag) + "  "
+		} else {
+			fillerContent = strings.Repeat(" ", gap)
+		}
 		filler := lipgloss.NewStyle().
 			Border(lipgloss.NormalBorder(), false, false, true, false).
 			BorderForeground(ColorDimBlue).
-			Render(strings.Repeat(" ", gap))
+			Render(fillerContent)
 		row = lipgloss.JoinHorizontal(lipgloss.Bottom, row, filler)
 	}
 


### PR DESCRIPTION
## Summary

- Remove the standalone compact header line that rendered in bold cyan (same style as active tab), eliminating the "double tab bar" effect
- Integrate version branding ("Mini Krill v0.1.0") into the tab bar's right-aligned filler area in dimmed style
- Reclaims one vertical row for body content

Cherry-picked from PR #24 which was merged into `feat/mcp-dedicated-tab` after that branch had already landed on `main` via PR #23.

## Test plan

- [ ] `go build ./...` compiles, `go test ./...` passes
- [ ] `minikrill tui` — single clean tab bar at the top, no duplicate header row
- [ ] Version branding visible right-aligned in the tab bar (dimmed)