### PR TITLE
Replace fixed timeouts with idle-based CLI process monitor

### DIFF
--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -288,8 +288,8 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 		log.Debug("failed to send typing action", "error", err)
 	}
 
-	// Per-message timeout so a slow LLM doesn't block Telegram forever.
-	msgCtx, msgCancel := context.WithTimeout(ctx, 90*time.Second)
+	// No fixed timeout - the agent and providers manage their own deadlines.
+	msgCtx, msgCancel := context.WithCancel(ctx)
 	defer msgCancel()
 
 	chatMsg := core.ChatMessage{

--- a/internal/llm/cli_provider.go
+++ b/internal/llm/cli_provider.go
@@ -134,6 +134,14 @@ func (p *CLIProvider) runClaude(ctx context.Context, model, prompt string) ([]by
 // produces zero bytes on both stdout and stderr for idleTimeout, it is
 // considered stuck and gets killed.
 func runCLI(ctx context.Context, name string, args []string, stdin string) ([]byte, error) {
+	return runCLIWithIdle(ctx, name, args, stdin, idleTimeout)
+}
+
+// runCLIWithIdle is the implementation of runCLI with an injectable idle
+// duration. Production code always passes the fixed idleTimeout const via
+// runCLI; the parameter exists only so tests can shrink it to drive the
+// idle-kill and slow-stream paths under the race detector.
+func runCLIWithIdle(ctx context.Context, name string, args []string, stdin string, idleAfter time.Duration) ([]byte, error) {
 	// Create a child context we can cancel when idle timeout fires.
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -208,14 +216,14 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 	// process, which closes the pipes and unblocks the readers).
 	var idled atomic.Bool
 	go func() {
-		idle := time.NewTimer(idleTimeout)
+		idle := time.NewTimer(idleAfter)
 		defer idle.Stop()
 		for {
 			select {
 			case <-bump:
 				// Go 1.23+: Reset alone is correct; no manual drain needed,
 				// and a stale fire is never delivered after Reset.
-				idle.Reset(idleTimeout)
+				idle.Reset(idleAfter)
 			case <-idle.C:
 				idled.Store(true)
 				cancel()
@@ -238,7 +246,7 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 
 	switch {
 	case idled.Load():
-		return nil, fmt.Errorf("%s idle for %v with no output — process killed", name, idleTimeout)
+		return nil, fmt.Errorf("%s idle for %v with no output — process killed", name, idleAfter)
 	case ctx.Err() != nil:
 		// Parent cancelled deliberately (user quit TUI, app shutdown).
 		// Surface the real cause rather than a generic "<killed>" string.

--- a/internal/llm/cli_provider.go
+++ b/internal/llm/cli_provider.go
@@ -151,6 +151,19 @@ func runCLIWithIdle(ctx context.Context, name string, args []string, stdin strin
 		cmd.Stdin = strings.NewReader(stdin)
 	}
 
+	// Run the child in its own process group and, on context cancel (idle
+	// kill or parent cancel), SIGKILL the whole group rather than just the
+	// direct child. exec.CommandContext's default Cancel kills cmd.Process
+	// only; a CLI that forks helper grandchildren would leave them holding
+	// the pipe write ends, so the reader goroutines never EOF and <-done
+	// (and thus the idle-kill) hangs until the orphan exits on its own.
+	setProcessGroup(cmd)
+	cmd.Cancel = func() error { return killProcessTree(cmd) }
+	// Belt-and-suspenders bound on cmd.Wait(): if a stray inherited FD is
+	// still open after the group kill, force the pipes closed rather than
+	// blocking Wait indefinitely.
+	cmd.WaitDelay = 10 * time.Second
+
 	// Suppress macOS dyld MallocStackLogging warnings at the source. The flag
 	// is leaked into every Go-spawned subprocess on dev machines and pollutes
 	// dive.log with thousands of "can't turn off malloc stack logging" lines.

--- a/internal/llm/cli_provider.go
+++ b/internal/llm/cli_provider.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
@@ -17,7 +18,10 @@ import (
 
 // idleTimeout is how long runCLI waits with zero output from the subprocess
 // before considering it stuck and killing it. The total runtime is unlimited
-// as long as the process keeps producing output.
+// as long as the process keeps producing output. This is deliberately a
+// fixed const rather than an LLMConfig field: it is a stuck-process backstop,
+// not a tuning knob, and a per-provider value invites users to set it low
+// enough to re-introduce the wall-clock-cap bug this change removes.
 const idleTimeout = 10 * time.Minute
 
 // CLIProvider delegates model calls to official subscription-aware CLIs.
@@ -157,17 +161,19 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 		return nil, fmt.Errorf("%s failed to start: %w", name, err)
 	}
 
-	// Idle timer — reset every time bytes arrive on either pipe.
-	idle := time.NewTimer(idleTimeout)
-	defer idle.Stop()
-
 	var stdout, stderr bytes.Buffer
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	// readAndBump drains a pipe into a buffer, resetting the idle timer on
-	// every chunk read. When the pipe closes (process exits or EOF), the
-	// goroutine returns.
+	// bump carries an "I saw output" signal from the reader goroutines to the
+	// single timer-owning monitor goroutine. Buffered+non-blocking send: the
+	// readers must never block on a slow/absent monitor, and one queued bump is
+	// enough — the monitor only needs to know *that* there was activity, not
+	// how much.
+	bump := make(chan struct{}, 1)
+
+	// readAndBump drains a pipe into a buffer, signalling activity on every
+	// chunk read. When the pipe closes (process exits or EOF), it returns.
 	readAndBump := func(pipe io.Reader, buf *bytes.Buffer) {
 		defer wg.Done()
 		tmp := make([]byte, 4096)
@@ -175,14 +181,10 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 			n, err := pipe.Read(tmp)
 			if n > 0 {
 				buf.Write(tmp[:n])
-				// Reset the idle timer — process is alive.
-				if !idle.Stop() {
-					select {
-					case <-idle.C:
-					default:
-					}
+				select {
+				case bump <- struct{}{}:
+				default:
 				}
-				idle.Reset(idleTimeout)
 			}
 			if err != nil {
 				return
@@ -193,34 +195,55 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 	go readAndBump(stdoutPipe, &stdout)
 	go readAndBump(stderrPipe, &stderr)
 
-	// Wait for either: both pipes close (normal exit), idle timeout, or
-	// parent context cancellation.
+	// done closes once both reader goroutines have returned, i.e. both pipes
+	// are fully drained and closed. Nothing reads the pipes after this.
 	done := make(chan struct{})
 	go func() {
 		wg.Wait()
 		close(done)
 	}()
 
-	var idled bool
-	select {
-	case <-done:
-		// Process finished normally — pipes closed.
-	case <-idle.C:
-		// No output for idleTimeout — kill the stuck process.
-		idled = true
-		cancel()
-	case <-ctx.Done():
-		// Parent cancelled (user quit, app shutdown).
-	}
+	// Single owner of the idle timer. Resets on every activity bump; on
+	// idleTimeout with no bump it cancels the context (killing the stuck
+	// process, which closes the pipes and unblocks the readers).
+	var idled atomic.Bool
+	go func() {
+		idle := time.NewTimer(idleTimeout)
+		defer idle.Stop()
+		for {
+			select {
+			case <-bump:
+				// Go 1.23+: Reset alone is correct; no manual drain needed,
+				// and a stale fire is never delivered after Reset.
+				idle.Reset(idleTimeout)
+			case <-idle.C:
+				idled.Store(true)
+				cancel()
+				return
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 
-	// Wait for the process to exit and the reader goroutines to drain.
+	// Block until the readers have fully drained the pipes (normal exit, idle
+	// kill, or parent cancellation all converge here once the process dies and
+	// its pipes close). Only then is it safe to call cmd.Wait(), which closes
+	// the pipe FDs — calling it while a reader's pipe.Read is in flight is a
+	// documented data race.
+	<-done
 	waitErr := cmd.Wait()
-	wg.Wait()
 
-	if idled {
+	switch {
+	case idled.Load():
 		return nil, fmt.Errorf("%s idle for %v with no output — process killed", name, idleTimeout)
-	}
-	if waitErr != nil {
+	case ctx.Err() != nil:
+		// Parent cancelled deliberately (user quit TUI, app shutdown).
+		// Surface the real cause rather than a generic "<killed>" string.
+		return nil, fmt.Errorf("%s cancelled: %w", name, ctx.Err())
+	case waitErr != nil:
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
 			msg = waitErr.Error()

--- a/internal/llm/cli_provider.go
+++ b/internal/llm/cli_provider.go
@@ -4,21 +4,27 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
 )
 
+// idleTimeout is how long runCLI waits with zero output from the subprocess
+// before considering it stuck and killing it. The total runtime is unlimited
+// as long as the process keeps producing output.
+const idleTimeout = 10 * time.Minute
+
 // CLIProvider delegates model calls to official subscription-aware CLIs.
 // It intentionally stores no OAuth tokens; Codex/Claude own authentication.
 type CLIProvider struct {
-	name    string
-	model   string
-	timeout time.Duration
+	name  string
+	model string
 }
 
 func NewCLIProvider(name string, cfg config.LLMConfig) *CLIProvider {
@@ -26,7 +32,7 @@ func NewCLIProvider(name string, cfg config.LLMConfig) *CLIProvider {
 	if model == "" {
 		model = "auto"
 	}
-	return &CLIProvider{name: name, model: model, timeout: 10 * time.Minute}
+	return &CLIProvider{name: name, model: model}
 }
 
 func (p *CLIProvider) Chat(ctx context.Context, messages []core.Message, opts ...core.ChatOption) (*core.Response, error) {
@@ -40,9 +46,6 @@ func (p *CLIProvider) Chat(ctx context.Context, messages []core.Message, opts ..
 	if strings.TrimSpace(prompt) == "" {
 		return nil, fmt.Errorf("%s provider received empty prompt", p.name)
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, p.timeout)
-	defer cancel()
 
 	var out []byte
 	var err error
@@ -122,7 +125,15 @@ func (p *CLIProvider) runClaude(ctx context.Context, model, prompt string) ([]by
 	return runCLI(ctx, "claude", args, prompt)
 }
 
+// runCLI executes a CLI subprocess with idle-based termination. The process
+// can run for as long as it needs — there is no wall-clock cap. But if it
+// produces zero bytes on both stdout and stderr for idleTimeout, it is
+// considered stuck and gets killed.
 func runCLI(ctx context.Context, name string, args []string, stdin string) ([]byte, error) {
+	// Create a child context we can cancel when idle timeout fires.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	cmd := exec.CommandContext(ctx, name, args...)
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
@@ -133,17 +144,90 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 	// dive.log with thousands of "can't turn off malloc stack logging" lines.
 	cmd.Env = append(os.Environ(), "MallocStackLogging=0")
 
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
-	out, err := cmd.Output()
+	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
+		return nil, fmt.Errorf("%s: stdout pipe: %w", name, err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("%s: stderr pipe: %w", name, err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("%s failed to start: %w", name, err)
+	}
+
+	// Idle timer — reset every time bytes arrive on either pipe.
+	idle := time.NewTimer(idleTimeout)
+	defer idle.Stop()
+
+	var stdout, stderr bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// readAndBump drains a pipe into a buffer, resetting the idle timer on
+	// every chunk read. When the pipe closes (process exits or EOF), the
+	// goroutine returns.
+	readAndBump := func(pipe io.Reader, buf *bytes.Buffer) {
+		defer wg.Done()
+		tmp := make([]byte, 4096)
+		for {
+			n, err := pipe.Read(tmp)
+			if n > 0 {
+				buf.Write(tmp[:n])
+				// Reset the idle timer — process is alive.
+				if !idle.Stop() {
+					select {
+					case <-idle.C:
+					default:
+					}
+				}
+				idle.Reset(idleTimeout)
+			}
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	go readAndBump(stdoutPipe, &stdout)
+	go readAndBump(stderrPipe, &stderr)
+
+	// Wait for either: both pipes close (normal exit), idle timeout, or
+	// parent context cancellation.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	var idled bool
+	select {
+	case <-done:
+		// Process finished normally — pipes closed.
+	case <-idle.C:
+		// No output for idleTimeout — kill the stuck process.
+		idled = true
+		cancel()
+	case <-ctx.Done():
+		// Parent cancelled (user quit, app shutdown).
+	}
+
+	// Wait for the process to exit and the reader goroutines to drain.
+	waitErr := cmd.Wait()
+	wg.Wait()
+
+	if idled {
+		return nil, fmt.Errorf("%s idle for %v with no output — process killed", name, idleTimeout)
+	}
+	if waitErr != nil {
 		msg := strings.TrimSpace(stderr.String())
 		if msg == "" {
-			msg = err.Error()
+			msg = waitErr.Error()
 		}
 		return nil, fmt.Errorf("%s failed: %s", name, redactCLIError(msg))
 	}
-	return out, nil
+	return stdout.Bytes(), nil
 }
 
 func commandOK(ctx context.Context, name string, args ...string) bool {

--- a/internal/llm/cli_provider_test.go
+++ b/internal/llm/cli_provider_test.go
@@ -1,8 +1,12 @@
 package llm
 
 import (
+	"context"
+	"errors"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/core"
 )
@@ -67,5 +71,82 @@ func TestTitleRole(t *testing.T) {
 		if got := titleRole(input); got != want {
 			t.Fatalf("titleRole(%q) = %q, want %q", input, got, want)
 		}
+	}
+}
+
+// The runCLI tests below exercise the concurrent idle-monitor path
+// (readers + single timer owner + Wait/drain ordering). Run them under
+// `go test -race` to validate the data-race fixes from the PR review.
+
+func skipIfNoShell(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("runCLI shell tests require a POSIX sh")
+	}
+}
+
+// A subprocess that finishes quickly returns its stdout and no error.
+func TestRunCLINormalExit(t *testing.T) {
+	skipIfNoShell(t)
+	out, err := runCLIWithIdle(context.Background(), "sh",
+		[]string{"-c", "printf hello"}, "", time.Minute)
+	if err != nil {
+		t.Fatalf("runCLIWithIdle: unexpected error: %v", err)
+	}
+	if string(out) != "hello" {
+		t.Fatalf("runCLIWithIdle out = %q, want %q", out, "hello")
+	}
+}
+
+// A subprocess silent past the idle window is killed and reported as idle.
+func TestRunCLIIdleKill(t *testing.T) {
+	skipIfNoShell(t)
+	start := time.Now()
+	_, err := runCLIWithIdle(context.Background(), "sh",
+		[]string{"-c", "sleep 5"}, "", 150*time.Millisecond)
+	if err == nil {
+		t.Fatal("runCLIWithIdle: expected idle-kill error, got nil")
+	}
+	if !strings.Contains(err.Error(), "idle for") {
+		t.Fatalf("runCLIWithIdle error = %v, want idle-kill message", err)
+	}
+	if elapsed := time.Since(start); elapsed > 3*time.Second {
+		t.Fatalf("idle kill took %v, expected to fire near the 150ms window", elapsed)
+	}
+}
+
+// A subprocess that keeps streaming output, each chunk within the idle
+// window, must run to completion across many idle windows without being
+// killed — the exact multi-step-plan scenario the PR targets.
+func TestRunCLISlowStreamSurvives(t *testing.T) {
+	skipIfNoShell(t)
+	// 10 chunks ~50ms apart (~500ms total), idle window 200ms: every gap
+	// is well under the window, so the timer should keep resetting.
+	out, err := runCLIWithIdle(context.Background(), "sh",
+		[]string{"-c", "for i in 1 2 3 4 5 6 7 8 9 10; do printf x; sleep 0.05; done"},
+		"", 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("runCLIWithIdle: slow stream should survive, got error: %v", err)
+	}
+	if string(out) != "xxxxxxxxxx" {
+		t.Fatalf("runCLIWithIdle out = %q, want 10 x's", out)
+	}
+}
+
+// Deliberate parent-context cancellation surfaces ctx.Err(), not a
+// generic "<killed>" failure string.
+func TestRunCLIParentCancel(t *testing.T) {
+	skipIfNoShell(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	_, err := runCLIWithIdle(ctx, "sh", []string{"-c", "sleep 5"}, "", time.Minute)
+	if err == nil {
+		t.Fatal("runCLIWithIdle: expected cancellation error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runCLIWithIdle error = %v, want errors.Is(context.Canceled)", err)
 	}
 }

--- a/internal/llm/cli_provider_test.go
+++ b/internal/llm/cli_provider_test.go
@@ -115,6 +115,30 @@ func TestRunCLIIdleKill(t *testing.T) {
 	}
 }
 
+// A silent subprocess that forks a grandchild must still be reclaimed
+// within the idle window. The compound command stops `sh` from
+// exec-replacing into `sleep`, so `sleep` is a forked grandchild that
+// inherits the pipe write ends. Killing only the direct child (the
+// pre-fix behaviour) would orphan `sleep`, keep the pipes open, and hang
+// <-done for the full 5s — the round-4 CI regression. The process-group
+// kill must take the whole tree down promptly.
+func TestRunCLIIdleKillReclaimsChildTree(t *testing.T) {
+	skipIfNoShell(t)
+	start := time.Now()
+	_, err := runCLIWithIdle(context.Background(), "sh",
+		[]string{"-c", "sleep 5; :"}, "", 150*time.Millisecond)
+	if err == nil {
+		t.Fatal("runCLIWithIdle: expected idle-kill error, got nil")
+	}
+	if !strings.Contains(err.Error(), "idle for") {
+		t.Fatalf("runCLIWithIdle error = %v, want idle-kill message", err)
+	}
+	// Must fire near the 150ms window, not the grandchild's 5s lifetime.
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("idle kill took %v — orphaned grandchild not reclaimed", elapsed)
+	}
+}
+
 // A subprocess that keeps streaming output, each chunk within the idle
 // window, must run to completion across many idle windows without being
 // killed — the exact multi-step-plan scenario the PR targets.

--- a/internal/llm/cli_provider_unix.go
+++ b/internal/llm/cli_provider_unix.go
@@ -1,0 +1,38 @@
+//go:build !windows
+
+package llm
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setProcessGroup makes the child the leader of a new process group, so the
+// whole subprocess tree can be signalled at once. The target Codex/Claude
+// CLIs (and `sh -c` in the tests) fork helper grandchildren; without this,
+// exec.CommandContext SIGKILLs only the direct child, the orphaned
+// grandchildren keep the stdout/stderr pipe write ends open, the reader
+// goroutines never EOF, and the idle-kill path hangs on <-done until the
+// grandchild exits on its own — the round-4 CI regression.
+func setProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}
+
+// killProcessTree SIGKILLs the entire process group led by cmd's child. With
+// Setpgid the child's PGID equals its PID, so -PID addresses the whole group
+// (children and grandchildren included). Safe to call repeatedly and after
+// the process has already exited: a vanished group yields ESRCH, which is
+// ignored. Falls back to killing just the direct child if the group signal
+// fails for any other reason.
+func killProcessTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return cmd.Process.Kill()
+	}
+	return nil
+}

--- a/internal/llm/cli_provider_windows.go
+++ b/internal/llm/cli_provider_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package llm
+
+import "os/exec"
+
+// setProcessGroup is a no-op on Windows: there is no POSIX process group, the
+// target CLIs are POSIX, and the shell-based runCLI tests skip on Windows.
+func setProcessGroup(cmd *exec.Cmd) {}
+
+// killProcessTree falls back to killing the direct child on Windows.
+func killProcessTree(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}

--- a/internal/tui/views.go
+++ b/internal/tui/views.go
@@ -338,7 +338,7 @@ func (c *ChatView) sendChat(text string) tea.Cmd {
 				response: "No agent connected - I'm swimming solo right now. Try again after the LLM is configured!",
 			}
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
 		resp, err := agent.Chat(ctx, text)


### PR DESCRIPTION
## Summary

- **Fixed bug**: Multi-step plan execution via Codex/Claude CLIs hit `context deadline exceeded` because the TUI (60s) and Telegram (90s) had hard wall-clock timeouts — too short for plans with multiple CLI subprocess calls
- **Removed** all fixed timeouts from callers (TUI, Telegram, planner) — they now use cancel-only contexts
- **Added** a single idle-activity monitor in `runCLI` (`cli_provider.go`): the subprocess can run indefinitely as long as it produces output, but gets killed after 10 minutes of silence on both stdout/stderr

## Test plan

- [ ] Run `minikrill chat` with Codex provider, trigger a multi-step plan (6+ steps), approve it — should complete without timeout
- [ ] Verify a genuinely stuck subprocess (e.g. kill network mid-step) gets caught after 10 min idle
- [ ] Verify user can quit TUI mid-plan and the subprocess gets cleaned up
- [ ] Run `minikrill doctor` and `minikrill sonar` to confirm no regressions
- [ ] Test Telegram bot with a plan execution if Telegram is configured