### PR TITLE
Add smart intent router, real tool execution, and durable tasks

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -492,16 +492,22 @@ func startBots(ctx context.Context, stack *krillStack) botStatus {
 					AccessedAt: time.Now(),
 				})
 			})
-			// Wire durable task notifications back to Telegram
+			// Wire durable task notifications back to Telegram. RegisterNotifier
+			// scopes this to the "telegram" platform so other platforms (CLI,
+			// TUI, future Discord) don't accidentally receive Telegram-shaped
+			// callbacks.
 			if runner := stack.agent.TaskRunnerRef(); runner != nil {
 				localBot := tgBot // capture for closure
-				runner.SetNotifyFunc(func(platform, chatID, message string) {
-					if platform == "telegram" && chatID != "" {
-						id, err := strconv.ParseInt(chatID, 10, 64)
-						if err == nil {
-							localBot.SendToChat(id, message)
-						}
+				runner.RegisterNotifier("telegram", func(chatID, message string) {
+					if chatID == "" {
+						return
 					}
+					id, err := strconv.ParseInt(chatID, 10, 64)
+					if err != nil {
+						klog.Warn("telegram notify: invalid chat id", "chat_id", chatID, "error", err)
+						return
+					}
+					localBot.SendToChat(id, message)
 				})
 			}
 			go func() {

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -492,6 +492,18 @@ func startBots(ctx context.Context, stack *krillStack) botStatus {
 					AccessedAt: time.Now(),
 				})
 			})
+			// Wire durable task notifications back to Telegram
+			if runner := stack.agent.TaskRunnerRef(); runner != nil {
+				localBot := tgBot // capture for closure
+				runner.SetNotifyFunc(func(platform, chatID, message string) {
+					if platform == "telegram" && chatID != "" {
+						id, err := strconv.ParseInt(chatID, 10, 64)
+						if err == nil {
+							localBot.SendToChat(id, message)
+						}
+					}
+				})
+			}
 			go func() {
 				if err := tgBot.Start(ctx); err != nil {
 					klog.Error("telegram error", "error", err)

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -179,6 +179,7 @@ func initStack(quiet bool) (*krillStack, error) {
 	cfg.Agent.RecoveryTurns = cfg.Brain.RecoveryTurns
 
 	krillAgent := agent.New(cfg.Agent, providerMgr, krillBrain, skillReg, mcpReg)
+	krillAgent.InitTaskSystem(cfg.Brain.DataDir, 3)
 	chatHandler := chat.NewHandler(krillAgent, reminderStore)
 
 	return &krillStack{

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -179,7 +179,9 @@ func initStack(quiet bool) (*krillStack, error) {
 	cfg.Agent.RecoveryTurns = cfg.Brain.RecoveryTurns
 
 	krillAgent := agent.New(cfg.Agent, providerMgr, krillBrain, skillReg, mcpReg)
-	krillAgent.InitTaskSystem(cfg.Brain.DataDir, 3)
+	// Tasks are orchestration state, not memories — keep them out of the brain dir
+	// so clearing memory doesn't wipe in-flight task records.
+	krillAgent.InitTaskSystem(filepath.Join(config.DataDir(), "tasks"), 3)
 	chatHandler := chat.NewHandler(krillAgent, reminderStore)
 
 	return &krillStack{

--- a/docs/AUTONOMOUS_AGENT_HANDOFF.md
+++ b/docs/AUTONOMOUS_AGENT_HANDOFF.md
@@ -1,0 +1,353 @@
+# Mini Krill Autonomous Agent Handoff
+
+This document captures the current product gap and a practical execution brief
+for turning Mini Krill from a chat bot with planning into a smarter autonomous
+agent that learns, remembers, and improves with use.
+
+## Goal
+
+Mini Krill should feel like an agent that can:
+
+- understand when a user wants chat, advice, diagnosis, or action
+- inspect local repos and files when asked
+- run real tools and commands with progress updates
+- continue long-running work without Telegram or CLI timeouts killing the task
+- remember durable facts, preferences, projects, and outcomes
+- reflect on repeated feedback and adapt behavior automatically
+
+Today it has pieces of this system, but they are not connected into a real
+agent loop.
+
+## Observed Transcript Symptoms
+
+These behaviors came from real usage:
+
+- Ordinary questions like "why did I get this error?" triggered a full
+  `DIVE PLAN` instead of a direct clarifying answer.
+- Requests like "check the Medha repo in playground" became plans and then
+  failed with `context deadline exceeded`.
+- `/use codex` failed in Telegram even though the README documents `/use`.
+- Approved plans timed out after the user said "yes".
+- The bot sometimes answered with generic personality text instead of useful
+  stateful help.
+- It claimed it could learn and remember, but did not feel like it was evolving
+  from usage.
+
+## Root Causes
+
+### 1. Planner is overused
+
+Relevant file:
+
+- `internal/agent/agent.go`
+
+`classifyIntent` only chooses between `TASK` and `CHAT`. Many messages that
+should be handled as direct answers or lightweight diagnostics become `TASK`,
+which triggers a plan approval loop.
+
+Current issue:
+
+- "Can you check X?" becomes a plan instead of immediate repo inspection.
+- "Why did I get this error?" becomes a plan even when the bot already has
+  enough context to explain likely causes.
+- The user has to approve too many obvious actions.
+
+### 2. Plan execution is only LLM step narration
+
+Relevant file:
+
+- `internal/agent/planner.go`
+
+`ExecutePlanSteps` calls the LLM once per plan step with "Execute this step".
+It does not actually dispatch tools, inspect files, run tests, or persist
+intermediate state.
+
+Current issue:
+
+- A plan can describe useful work without doing useful work.
+- Each step consumes a model call.
+- Multi-step plans regularly exceed Telegram and CLI timeouts.
+
+### 3. Long-running tasks are tied to message timeouts
+
+Relevant files:
+
+- `internal/chat/telegram.go`
+- `cmd/minikrill/cmd_run.go`
+- `internal/llm/cli_provider.go`
+
+Telegram wraps every message in a 90 second context. CLI `run` defaults to 60
+seconds. The CLI provider itself defaults to 10 minutes, but the shorter
+upstream timeouts cancel work before the provider finishes. A multi-step plan
+through Codex or Claude can take longer than both the Telegram and CLI `run`
+limits.
+
+Current issue:
+
+- The user sees `context deadline exceeded`.
+- Work is lost because there is no durable task session.
+- The bot has no way to say "I started this, I will report back."
+
+### 4. Command naming is inconsistent across interfaces
+
+Relevant files:
+
+- `README.md`
+- `docs/INTERFACES.md`
+- `internal/chat/telegram.go`
+- `internal/agent/agent.go`
+
+Both `/use` and `/switch` work, but they are split across interfaces. The core
+agent handles `/use` while Telegram documents and handles `/switch`. Both
+interfaces also support natural language switching ("switch to X", "use X").
+The commands are not broken, but the inconsistent naming confuses users who
+read the README and then try `/use` in Telegram without realizing `/switch` is
+the equivalent there.
+
+Current issue:
+
+- Users may not discover the correct command for their interface on the first try.
+- Documentation should standardize on one name or explicitly list both.
+
+### 5. Memory exists but is not agentic
+
+Relevant files:
+
+- `internal/brain/memory.go`
+- `internal/brain/conversations.go`
+- `internal/agent/agent.go`
+- `internal/plugin/self.go`
+
+Mini Krill stores JSON memories and conversation turns, but memory retrieval is
+mostly substring search and recent-turn replay. Feedback is stored, but
+reflection is manual.
+
+Current issue:
+
+- It remembers raw snippets, not useful knowledge.
+- It does not consolidate repeated facts.
+- It does not automatically learn project context.
+- It does not automatically adapt from feedback.
+
+### 6. Unified conversation can blur context
+
+Relevant file:
+
+- `internal/agent/agent.go`
+
+`SetChannel` stores all turns under one unified channel. This helps continuity,
+but it can blur Telegram group chats, DMs, CLI, and TUI sessions.
+
+Current issue:
+
+- The agent can lose track of who said what.
+- Group memories and private memories need separate scopes.
+
+## Desired Architecture
+
+Build a small autonomous task layer between chat input and LLM/tool execution.
+
+Suggested packages:
+
+- `internal/agent/router.go`
+- `internal/agent/task.go`
+- `internal/agent/toolbox.go`
+- `internal/brain/learning.go`
+- `internal/brain/semantic_memory.go` if embeddings are added later
+
+Core loop:
+
+1. Route intent:
+   - `CHAT`
+   - `ANSWER`
+   - `DIAGNOSE`
+   - `REMEMBER`
+   - `TOOL_TASK`
+   - `LONG_TASK`
+2. For simple chat or answer, respond directly.
+3. For safe obvious tool tasks, execute directly with progress.
+4. For risky or destructive tasks, ask for approval.
+5. For long tasks, create a durable task record and return a task ID.
+6. Execute tools in a worker loop.
+7. Store findings and outcomes in memory.
+8. Periodically reflect and consolidate memories.
+
+## Implementation Plan
+
+### Phase 1: Fix routing and command mismatch
+
+Scope:
+
+- Add a deterministic pre-router before LLM classification.
+- Stop planning for simple questions, greetings, status checks, model switches,
+  and diagnostic questions.
+- Support `/use` and `/switch` consistently in Telegram.
+- Update help text and docs to show both commands or standardize on one.
+
+Acceptance criteria:
+
+- `/use codex` works in Telegram.
+- "why did I get this error?" does not produce a `DIVE PLAN`.
+- "are you okay?" maps to health or chat, not a generic plan.
+- "check repo X" is routed as an actionable tool task, not LLM-only plan text.
+
+### Phase 2: Add durable task sessions
+
+Scope:
+
+- Add a task store under the brain data directory, for example
+  `~/.mini-krill/brain/tasks.jsonl`.
+- Track task ID, status, input, owner/channel, steps, progress, result, error,
+  timestamps.
+- Let Telegram immediately acknowledge long tasks and continue execution in a
+  goroutine.
+- Add commands:
+  - `/tasks`
+  - `/task <id>`
+  - `/cancel <id>`
+
+Acceptance criteria:
+
+- A long repo inspection does not fail because of Telegram's 90 second timeout.
+- The user can ask for task status later.
+- Finished task summaries are saved and recallable.
+
+### Phase 3: Add real local tool execution
+
+Scope:
+
+- Implement a conservative toolbox for local workspace actions:
+  - list files
+  - read files
+  - grep with `rg`
+  - run approved test commands
+  - inspect git status
+- Wire tool execution into task plans.
+- Keep destructive operations blocked unless explicitly approved.
+
+Acceptance criteria:
+
+- "Check the Medha repo in playground" can list the folder, read README/config,
+  identify stack, and summarize next steps.
+- "Go through code and README" performs actual file reads.
+- Task output references real files inspected.
+
+### Phase 4: Improve memory and learning
+
+Scope:
+
+- Add memory scopes:
+  - user preference
+  - project memory
+  - group memory
+  - task outcome
+  - self feedback
+- Add memory consolidation:
+  - summarize raw conversation snippets
+  - merge duplicate preferences
+  - retain source and timestamp
+  - rank by recency and importance
+- Add automatic reflection after every N meaningful interactions or after a
+  completed task.
+
+Acceptance criteria:
+
+- "What do you remember about Medha?" returns project-specific facts from prior
+  task output.
+- Repeated feedback changes future tone or behavior without manual
+  `self:reflect`.
+- Group memories do not pollute private user preferences.
+
+### Phase 5: Make the agent feel alive but useful
+
+Scope:
+
+- Reduce forced personality flourishes in serious diagnostic paths.
+- Use personality mostly in short phrasing, not in place of useful action.
+- Add explicit capability honesty:
+  - what it can do now
+  - what requires local runtime access
+  - what requires approval
+
+Acceptance criteria:
+
+- The bot answers debugging and repo questions plainly.
+- Personality appears as flavor, not obstruction.
+- It does not invent access to Telegram groups, files, or external systems.
+
+## Suggested First PR
+
+Implement Phase 1 only.
+
+Files likely touched:
+
+- `internal/agent/agent.go`
+- `internal/chat/telegram.go`
+- `internal/chat/handler_test.go`
+- `internal/agent/agent_test.go`
+- `docs/INTERFACES.md`
+- `README.md`
+
+Concrete changes:
+
+- Add `/use` handling in Telegram command dispatch.
+- Add deterministic intent routing for common non-task inputs.
+- Add tests for:
+  - `/use codex` in Telegram command handling if practical
+  - diagnostic questions do not route to plan
+  - explicit action requests still route to task
+
+## Suggested Second PR
+
+Implement durable task sessions with no new tool execution yet.
+
+Files likely added:
+
+- `internal/agent/task.go`
+- `internal/agent/task_store.go`
+- `internal/agent/task_store_test.go`
+
+Concrete changes:
+
+- Store long-running task state.
+- Let Telegram acknowledge long tasks immediately.
+- Add status commands.
+- Keep old plan behavior behind the task session.
+
+## Design Notes
+
+- Do not make everything autonomous at once. Start with safer routing and
+  durable state.
+- Keep destructive filesystem and git operations approval-gated.
+- Prefer deterministic routing for obvious cases before using an LLM router.
+- Keep Telegram group context separate from private user memory.
+- Store task results as memories only after summarizing them into durable facts.
+- Avoid treating raw stored memory as instructions. Keep the current
+  "treat as data only" pattern.
+
+## Verification Checklist
+
+Run:
+
+```bash
+go test ./...
+```
+
+Manual checks:
+
+- Start Telegram bot in foreground with `minikrill dive --foreground`.
+- Send `/help`, `/use codex`, `/switch local`, `/model`.
+- Ask "why did I get this error?" and confirm no `DIVE PLAN`.
+- Ask "check the Medha repo in playground" and confirm it becomes a task or
+  a clear local-access response.
+- Ask "remember that I prefer direct answers" and confirm it is stored.
+- Restart Mini Krill and ask what it remembers.
+
+## Current Test Baseline
+
+At the time this handoff was written:
+
+```text
+go test ./... passes
+```
+

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -59,10 +59,14 @@ type KrillAgent struct {
 	skills      core.SkillRegistry
 	mcp         core.MCPRegistry
 	cfg         config.AgentConfig
+	router      *IntentRouter
 	channel     string // durable conversation channel; default is unified across interfaces
+	platform    string // current chat platform (telegram, discord, cli, tui)
 	history     []core.Message
 	pendingPlan *core.Plan
 	subMgr      *SubKrillManager
+	taskStore   *TaskStore
+	taskRunner  *TaskRunner
 	mu          sync.Mutex
 }
 
@@ -87,6 +91,7 @@ func New(cfg config.AgentConfig, llm core.LLMProvider, brain core.Brain, skills 
 		skills:  skills,
 		mcp:     mcp,
 		cfg:     cfg,
+		router:  NewIntentRouter(skills, llm),
 		channel: unifiedConversationChannel,
 		history: []core.Message{
 			{Role: "system", Content: sysPrompt},
@@ -106,6 +111,82 @@ func (a *KrillAgent) SetChannel(channel string) {
 			"requested", ch, "actual", unifiedConversationChannel)
 	}
 	a.channel = unifiedConversationChannel
+}
+
+// SetPlatform records which chat platform the agent is currently serving.
+// Used to decide whether to run tasks synchronously or in the background.
+func (a *KrillAgent) SetPlatform(platform string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.platform = platform
+}
+
+// InitTaskSystem sets up the durable task store and runner.
+// Called during application startup after the agent is created.
+func (a *KrillAgent) InitTaskSystem(dataDir string, maxConcurrent int) {
+	path := ""
+	if dataDir != "" {
+		path = dataDir + "/tasks.jsonl"
+	}
+	a.taskStore = NewTaskStore(path)
+	a.taskRunner = NewTaskRunner(a.taskStore, a, maxConcurrent)
+}
+
+// TaskStore returns the task store for external wiring (e.g. Telegram commands).
+func (a *KrillAgent) TaskStoreRef() *TaskStore {
+	return a.taskStore
+}
+
+// TaskRunnerRef returns the task runner for external wiring.
+func (a *KrillAgent) TaskRunnerRef() *TaskRunner {
+	return a.taskRunner
+}
+
+// SubmitTask creates and submits a background task. Implements core.TaskManager.
+func (a *KrillAgent) SubmitTask(_ context.Context, userID, platform, chatID, task string) (string, error) {
+	if a.taskStore == nil || a.taskRunner == nil {
+		return "", fmt.Errorf("task system not initialised")
+	}
+	dt := a.taskStore.Create(userID, platform, chatID, task)
+	if err := a.taskRunner.Submit(dt); err != nil {
+		a.taskStore.Update(dt.ID, "failed", "", err.Error())
+		return "", err
+	}
+	return dt.ID, nil
+}
+
+// ListTasks returns tasks for a user. Implements core.TaskManager.
+func (a *KrillAgent) ListTasks(userID string) []core.TaskInfo {
+	if a.taskStore == nil {
+		return nil
+	}
+	tasks := a.taskStore.List(userID)
+	infos := make([]core.TaskInfo, len(tasks))
+	for i, t := range tasks {
+		infos[i] = t.ToInfo()
+	}
+	return infos
+}
+
+// GetTask retrieves a task by ID. Implements core.TaskManager.
+func (a *KrillAgent) GetTask(id string) (*core.TaskInfo, bool) {
+	if a.taskStore == nil {
+		return nil, false
+	}
+	dt, ok := a.taskStore.Get(id)
+	if !ok {
+		return nil, false
+	}
+	info := dt.ToInfo()
+	return &info, true
+}
+
+// CancelTask cancels a running task. Implements core.TaskManager.
+func (a *KrillAgent) CancelTask(id string) error {
+	if a.taskStore == nil {
+		return fmt.Errorf("task system not initialised")
+	}
+	return a.taskStore.Cancel(id)
 }
 
 // Chat is the main entry point - every user message flows through here.
@@ -130,21 +211,33 @@ func (a *KrillAgent) Chat(ctx context.Context, input string) (string, error) {
 	a.saveTurn("user", input)
 	a.maybeStoreUserPreference(ctx, input)
 
-	// --- Phase 3: Classify intent ---
-	// Short-circuit: if the message matches a self-skill, it's always CHAT.
-	// This prevents the LLM classifier from routing self-referential questions
-	// (e.g. "what can you do") to the TASK/plan path.
-	intent := "CHAT"
-	if selfSkill, _ := a.detectSelfSkill(input); selfSkill == "" {
-		intent = a.classifyIntent(ctx, input)
-	}
-	log.Debug("intent classified", "input_preview", truncate(input, 50), "intent", intent)
+	// --- Phase 3: Classify intent via multi-intent router ---
+	route := a.router.Classify(ctx, input)
+	log.Debug("intent classified", "input_preview", truncate(input, 50), "intent", route.Intent)
 
 	// --- Phase 4: Route based on intent ---
 	var response string
 	var err error
-	switch intent {
-	case "TASK":
+	switch route.Intent {
+	case IntentCommand:
+		// Already handled by handleProviderCommand above; if we got here,
+		// it's a task-management command (/tasks, /task, /cancel).
+		if taskResp, handled := a.handleTaskCommand(input); handled {
+			response = taskResp
+		} else {
+			response, err = a.handleChat(ctx)
+		}
+	case IntentSelfSkill:
+		response, err = a.handleSelfSkill(ctx, route.SkillName, route.SkillInput)
+	case IntentRemember:
+		response, err = a.handleRemember(ctx, input, route.ToolName)
+	case IntentToolTask:
+		response, err = a.handleToolTask(ctx, input, route.ToolName)
+	case IntentDiagnose:
+		response, err = a.handleDiagnose(ctx)
+	case IntentAnswer:
+		response, err = a.handleAnswer(ctx)
+	case IntentLongTask:
 		response, err = a.handleTask(ctx, input)
 	default:
 		response, err = a.handleChat(ctx)
@@ -160,12 +253,12 @@ func (a *KrillAgent) Chat(ctx context.Context, input string) (string, error) {
 
 // Plan generates a plan for the given task. Delegates to the planner module.
 func (a *KrillAgent) Plan(ctx context.Context, task string) (*core.Plan, error) {
-	return GeneratePlan(ctx, task, a.llm, a.skills)
+	return GeneratePlan(ctx, task, a.llm, a.skills, a.mcp)
 }
 
-// ExecutePlan runs an approved plan through all its steps.
+// ExecutePlan runs an approved plan through all its steps with real tool dispatch.
 func (a *KrillAgent) ExecutePlan(ctx context.Context, plan *core.Plan) (string, error) {
-	return ExecutePlanSteps(ctx, plan, a.llm, a.brain, a.skills)
+	return ExecutePlanSteps(ctx, plan, a.llm, a.brain, a.skills, a.mcp)
 }
 
 // SpawnKrill launches a focused sub-agent for a specific task.
@@ -302,80 +395,163 @@ func (a *KrillAgent) handleTask(ctx context.Context, input string) (string, erro
 		return fmt.Sprintf("This krill's sonar is glitching - could not plan that task: %v", err), nil
 	}
 
-	// If auto-approve is enabled (plan_approval = false), execute immediately
-	if !a.cfg.PlanApproval {
-		log.Info("auto-approve enabled, executing plan immediately", "task", input)
-		plan.Approved = true
-		result, err := a.ExecutePlan(ctx, plan)
-		if err != nil {
-			return fmt.Sprintf("This krill hit a reef during auto-execution: %v", err), nil
-		}
-		a.appendMessage(core.Message{Role: "assistant", Content: result})
-		a.saveTurn("assistant", result)
-		return result, nil
+	if a.shouldRequireApproval(plan) {
+		// Store as pending and present for approval
+		a.pendingPlan = plan
+		formatted := FormatPlan(plan)
+		log.Info("plan generated, awaiting approval", "task", input, "steps", len(plan.Steps))
+		a.appendMessage(core.Message{Role: "assistant", Content: formatted})
+		a.saveTurn("assistant", formatted)
+		return formatted, nil
 	}
 
-	// Store as pending and present for approval
-	a.pendingPlan = plan
-	formatted := FormatPlan(plan)
-	log.Info("plan generated, awaiting approval", "task", input, "steps", len(plan.Steps))
+	// Auto-execute: intent is clear, plan is small and non-destructive
+	log.Info("auto-executing plan", "task", input, "steps", len(plan.Steps))
 
-	a.appendMessage(core.Message{Role: "assistant", Content: formatted})
-	a.saveTurn("assistant", formatted)
-	return formatted, nil
+	// On timeout-sensitive platforms, run in background if task has multiple steps
+	if a.shouldRunInBackground(plan) {
+		return a.submitBackgroundTask(input)
+	}
+
+	plan.Approved = true
+	result, err := a.ExecutePlan(ctx, plan)
+	if err != nil {
+		return fmt.Sprintf("This krill hit a reef during auto-execution: %v", err), nil
+	}
+	a.appendMessage(core.Message{Role: "assistant", Content: result})
+	a.saveTurn("assistant", result)
+	return result, nil
+}
+
+// shouldRunInBackground returns true when the task should be executed
+// asynchronously — on Telegram/Discord with multi-step plans.
+func (a *KrillAgent) shouldRunInBackground(plan *core.Plan) bool {
+	if a.taskStore == nil || a.taskRunner == nil {
+		return false
+	}
+	isTimeoutSensitive := a.platform == "telegram" || a.platform == "discord"
+	return isTimeoutSensitive && len(plan.Steps) >= 2
+}
+
+// submitBackgroundTask creates a durable task and returns an immediate ack.
+func (a *KrillAgent) submitBackgroundTask(input string) (string, error) {
+	taskID, err := a.SubmitTask(context.Background(), "", a.platform, "", input)
+	if err != nil {
+		log.Error("background task submission failed", "error", err)
+		return fmt.Sprintf("Could not start background task: %v", err), nil
+	}
+	ack := fmt.Sprintf("On it! I'll work on this in the background and message you when it's done.\nTrack progress: /task %s", taskID)
+	a.appendMessage(core.Message{Role: "assistant", Content: ack})
+	a.saveTurn("assistant", ack)
+	return ack, nil
+}
+
+// handleTaskCommand dispatches /tasks, /task <id>, and /cancel <id> commands.
+func (a *KrillAgent) handleTaskCommand(input string) (string, bool) {
+	lower := strings.ToLower(strings.TrimSpace(input))
+
+	if a.taskStore == nil {
+		if strings.HasPrefix(lower, "/task") || strings.HasPrefix(lower, "/cancel") {
+			return "Task system is not enabled.", true
+		}
+		return "", false
+	}
+
+	switch {
+	case lower == "/tasks":
+		tasks := a.ListTasks("")
+		if len(tasks) == 0 {
+			return "No tasks found.", true
+		}
+		var sb strings.Builder
+		sb.WriteString("=== TASKS ===\n\n")
+		for _, t := range tasks {
+			icon := "[ ]"
+			switch t.Status {
+			case "done":
+				icon = "[x]"
+			case "failed":
+				icon = "[!]"
+			case "running":
+				icon = "[~]"
+			case "cancelled":
+				icon = "[-]"
+			}
+			sb.WriteString(fmt.Sprintf("%s %s %s — %s\n", icon, t.ID, t.Status, truncate(t.Task, 50)))
+		}
+		return sb.String(), true
+
+	case strings.HasPrefix(lower, "/task "):
+		id := strings.TrimSpace(input[len("/task "):])
+		info, ok := a.GetTask(id)
+		if !ok {
+			return fmt.Sprintf("Task %q not found.", id), true
+		}
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("=== %s ===\n", info.ID))
+		sb.WriteString(fmt.Sprintf("Status: %s\n", info.Status))
+		sb.WriteString(fmt.Sprintf("Task: %s\n", info.Task))
+		sb.WriteString(fmt.Sprintf("Created: %s\n", info.CreatedAt.Local().Format("2006-01-02 15:04")))
+		if info.Result != "" {
+			sb.WriteString(fmt.Sprintf("\nResult:\n%s\n", truncate(info.Result, 3000)))
+		}
+		if info.Error != "" {
+			sb.WriteString(fmt.Sprintf("\nError: %s\n", info.Error))
+		}
+		return sb.String(), true
+
+	case strings.HasPrefix(lower, "/cancel "):
+		id := strings.TrimSpace(input[len("/cancel "):])
+		if err := a.CancelTask(id); err != nil {
+			return fmt.Sprintf("Cancel failed: %v", err), true
+		}
+		return fmt.Sprintf("Task %s cancelled.", id), true
+	}
+
+	return "", false
+}
+
+// shouldRequireApproval decides if a plan needs user approval before execution.
+// Uses a three-way config: "always", "never", or "auto" (smart default).
+func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
+	switch a.cfg.PlanApproval {
+	case "always":
+		return true
+	case "never":
+		return false
+	default: // "auto"
+		// Large plans (5+ steps) need approval
+		if len(plan.Steps) >= 5 {
+			return true
+		}
+		// Plans with destructive hints need approval
+		for _, step := range plan.Steps {
+			if step.NeedsApproval {
+				return true
+			}
+			lower := strings.ToLower(step.Description)
+			for _, danger := range []string{"delete", "remove", "deploy", "push", "install", "drop", "destroy", "reset"} {
+				if strings.Contains(lower, danger) {
+					return true
+				}
+			}
+		}
+		// Vague task descriptions need approval
+		lower := strings.ToLower(plan.Task)
+		vaguePatterns := []string{"everything", "all of", "entire", "whole project", "set up"}
+		for _, vague := range vaguePatterns {
+			if strings.Contains(lower, vague) {
+				return true
+			}
+		}
+		return false
+	}
 }
 
 // handleChat generates a conversational response using the LLM with brain enrichment.
 // If the user's question looks like it needs current information, the krill
 // automatically searches the web first and includes results in context.
 func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
-	// Check if the latest user message is about the krill itself
-	lastMsg := ""
-	if len(a.history) > 0 {
-		lastMsg = a.history[len(a.history)-1].Content
-	}
-
-	// Self-awareness: detect and invoke self-skills
-	if skillName, skillInput := a.detectSelfSkill(lastMsg); skillName != "" {
-		if skill, ok := a.skills.Get(skillName); ok {
-			log.Info("invoking self-skill", "skill", skillName)
-			result, err := skill.Execute(ctx, skillInput, a.llm)
-			if err != nil {
-				log.Error("self-skill failed", "skill", skillName, "error", err)
-			} else if result != "" {
-				// For write skills, return result directly (it's already the confirmation)
-				if strings.HasPrefix(skillName, "self:tune") ||
-					strings.HasPrefix(skillName, "self:configure") ||
-					strings.HasPrefix(skillName, "self:evolve") ||
-					strings.HasPrefix(skillName, "self:learn") ||
-					strings.HasPrefix(skillName, "self:add-skill") ||
-					strings.HasPrefix(skillName, "self:heal") ||
-					strings.HasPrefix(skillName, "self:reflect") {
-					a.appendMessage(core.Message{Role: "assistant", Content: result})
-					a.saveTurn("assistant", result)
-					return result, nil
-				}
-				// For read skills, inject into LLM context so the krill can discuss it naturally
-				enriched := a.brain.EnrichMessages(a.history)
-				selfCtx := core.Message{
-					Role:    "system",
-					Content: "Here is information about yourself that the user is asking about. Use it to respond naturally in first person:\n\n" + result,
-				}
-				enriched = append(enriched[:len(enriched)-1], selfCtx, enriched[len(enriched)-1])
-				resp, err := a.llm.Chat(ctx, enriched)
-				if err != nil {
-					// Fallback: return raw self-skill output
-					a.appendMessage(core.Message{Role: "assistant", Content: result})
-					a.saveTurn("assistant", result)
-					return result, nil
-				}
-				a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
-				a.saveTurn("assistant", resp.Content)
-				return resp.Content, nil
-			}
-		}
-	}
-
 	enriched := a.brain.EnrichMessages(a.history)
 
 	// Inject capability awareness so the LLM knows what it can and cannot do
@@ -396,39 +572,6 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 		enriched = append(enriched[:len(enriched)-1], memoryMsg, enriched[len(enriched)-1])
 	}
 
-	// If the question likely needs current info, search the web first
-	if a.shouldSearch(lastMsg) {
-		if searchSkill, ok := a.skills.Get("search"); ok {
-			log.Info("auto-searching web for context", "query", lastMsg)
-			searchResults, err := searchSkill.Execute(ctx, lastMsg, nil) // raw results, no LLM summary
-			if err == nil && searchResults != "" {
-				// Inject search results as context before the user message
-				searchCtx := core.Message{
-					Role:    "system",
-					Content: "Here are recent web search results relevant to the user's question. Use them to provide an informed answer:\n\n" + searchResults,
-				}
-				// Insert before the last user message
-				enriched = append(enriched[:len(enriched)-1], searchCtx, enriched[len(enriched)-1])
-			}
-		}
-	}
-
-	// If the user is asking about previous conversations, inject DM memories
-	if a.brain.Memory() != nil && looksLikeRecallRequest(lastMsg) {
-		entries, err := a.brain.Memory().Search(context.Background(), "dm_", 5)
-		if err == nil && len(entries) > 0 {
-			var contextParts []string
-			for _, e := range entries {
-				contextParts = append(contextParts, e.Value)
-			}
-			recallMsg := core.Message{
-				Role:    "system",
-				Content: "Here are your recent conversation memories. Use them if the user asks about past interactions:\n\n" + strings.Join(contextParts, "\n---\n"),
-			}
-			enriched = append(enriched[:len(enriched)-1], recallMsg, enriched[len(enriched)-1])
-		}
-	}
-
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
 		log.Error("LLM chat failed", "error", err)
@@ -443,6 +586,231 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 		"model", resp.Model,
 	)
 
+	return resp.Content, nil
+}
+
+// handleSelfSkill dispatches a self:* skill, either returning its result
+// directly (write skills) or injecting into LLM context for natural discussion (read skills).
+func (a *KrillAgent) handleSelfSkill(ctx context.Context, skillName, skillInput string) (string, error) {
+	skill, ok := a.skills.Get(skillName)
+	if !ok {
+		log.Warn("self-skill not found in registry", "skill", skillName)
+		return a.handleChat(ctx)
+	}
+
+	log.Info("invoking self-skill", "skill", skillName)
+	result, err := skill.Execute(ctx, skillInput, a.llm)
+	if err != nil {
+		log.Error("self-skill failed", "skill", skillName, "error", err)
+		return a.handleChat(ctx)
+	}
+	if result == "" {
+		return a.handleChat(ctx)
+	}
+
+	// Write skills return result directly
+	if strings.HasPrefix(skillName, "self:tune") ||
+		strings.HasPrefix(skillName, "self:configure") ||
+		strings.HasPrefix(skillName, "self:evolve") ||
+		strings.HasPrefix(skillName, "self:learn") ||
+		strings.HasPrefix(skillName, "self:add-skill") ||
+		strings.HasPrefix(skillName, "self:heal") ||
+		strings.HasPrefix(skillName, "self:reflect") {
+		a.appendMessage(core.Message{Role: "assistant", Content: result})
+		a.saveTurn("assistant", result)
+		return result, nil
+	}
+
+	// Read skills: inject into LLM context for natural first-person discussion
+	enriched := a.brain.EnrichMessages(a.history)
+	selfCtx := core.Message{
+		Role:    "system",
+		Content: "Here is information about yourself that the user is asking about. Use it to respond naturally in first person:\n\n" + result,
+	}
+	enriched = append(enriched[:len(enriched)-1], selfCtx, enriched[len(enriched)-1])
+	resp, err := a.llm.Chat(ctx, enriched)
+	if err != nil {
+		// Fallback: return raw self-skill output
+		a.appendMessage(core.Message{Role: "assistant", Content: result})
+		a.saveTurn("assistant", result)
+		return result, nil
+	}
+	a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
+	a.saveTurn("assistant", resp.Content)
+	return resp.Content, nil
+}
+
+// handleRemember handles memory store/recall/forget operations directly.
+func (a *KrillAgent) handleRemember(ctx context.Context, input, operation string) (string, error) {
+	// Delegate to self:learn for store, self:memory for recall
+	switch operation {
+	case "store":
+		if skill, ok := a.skills.Get("self:learn"); ok {
+			result, err := skill.Execute(ctx, input, a.llm)
+			if err == nil && result != "" {
+				a.appendMessage(core.Message{Role: "assistant", Content: result})
+				a.saveTurn("assistant", result)
+				return result, nil
+			}
+		}
+	case "forget":
+		mem := a.brain.Memory()
+		if mem != nil {
+			lower := strings.ToLower(input)
+			// Extract what to forget
+			for _, prefix := range []string{"forget that ", "forget about ", "delete memory ", "remove memory "} {
+				if idx := strings.Index(lower, prefix); idx >= 0 {
+					query := strings.TrimSpace(input[idx+len(prefix):])
+					if query != "" {
+						entries, err := mem.Search(ctx, query, 5)
+						if err == nil && len(entries) > 0 {
+							for _, e := range entries {
+								_ = mem.Forget(ctx, e.Key)
+							}
+							result := fmt.Sprintf("Forgotten %d memories related to %q.", len(entries), query)
+							a.appendMessage(core.Message{Role: "assistant", Content: result})
+							a.saveTurn("assistant", result)
+							return result, nil
+						}
+						result := fmt.Sprintf("No memories found matching %q.", query)
+						a.appendMessage(core.Message{Role: "assistant", Content: result})
+						a.saveTurn("assistant", result)
+						return result, nil
+					}
+				}
+			}
+		}
+	case "recall":
+		if skill, ok := a.skills.Get("self:memory"); ok {
+			result, err := skill.Execute(ctx, input, a.llm)
+			if err == nil && result != "" {
+				// Inject into LLM for natural response
+				enriched := a.brain.EnrichMessages(a.history)
+				recallCtx := core.Message{
+					Role:    "system",
+					Content: "Here are the krill's relevant memories. Respond naturally:\n\n" + result,
+				}
+				enriched = append(enriched[:len(enriched)-1], recallCtx, enriched[len(enriched)-1])
+				resp, err := a.llm.Chat(ctx, enriched)
+				if err != nil {
+					a.appendMessage(core.Message{Role: "assistant", Content: result})
+					a.saveTurn("assistant", result)
+					return result, nil
+				}
+				a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
+				a.saveTurn("assistant", resp.Content)
+				return resp.Content, nil
+			}
+		}
+	}
+
+	// Fallback to regular chat if specific handling didn't return
+	return a.handleChat(ctx)
+}
+
+// handleToolTask invokes a single skill directly and returns the result.
+func (a *KrillAgent) handleToolTask(ctx context.Context, input, toolName string) (string, error) {
+	if toolName == "" {
+		return a.handleChat(ctx)
+	}
+
+	skill, ok := a.skills.Get(toolName)
+	if !ok {
+		log.Warn("tool skill not found, falling back to chat", "tool", toolName)
+		return a.handleChat(ctx)
+	}
+
+	log.Info("direct tool invocation", "tool", toolName)
+	result, err := skill.Execute(ctx, input, a.llm)
+	if err != nil {
+		log.Error("tool execution failed", "tool", toolName, "error", err)
+		return a.handleChat(ctx)
+	}
+
+	if result == "" {
+		return a.handleChat(ctx)
+	}
+
+	// For simple data skills (time, sysinfo), return directly
+	if toolName == "time" || toolName == "sysinfo" {
+		a.appendMessage(core.Message{Role: "assistant", Content: result})
+		a.saveTurn("assistant", result)
+		return result, nil
+	}
+
+	// For content skills (search, web, youtube, research), wrap through LLM
+	enriched := a.brain.EnrichMessages(a.history)
+	toolCtx := core.Message{
+		Role:    "system",
+		Content: fmt.Sprintf("Here are the results from the %s tool. Use them to answer the user's question:\n\n%s", toolName, result),
+	}
+	enriched = append(enriched[:len(enriched)-1], toolCtx, enriched[len(enriched)-1])
+	resp, err := a.llm.Chat(ctx, enriched)
+	if err != nil {
+		// Fallback: return raw tool output
+		a.appendMessage(core.Message{Role: "assistant", Content: result})
+		a.saveTurn("assistant", result)
+		return result, nil
+	}
+	a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
+	a.saveTurn("assistant", resp.Content)
+	return resp.Content, nil
+}
+
+// handleDiagnose answers error/debugging questions directly with a diagnostic focus.
+func (a *KrillAgent) handleDiagnose(ctx context.Context) (string, error) {
+	enriched := a.brain.EnrichMessages(a.history)
+
+	// Add diagnostic system prompt
+	diagMsg := core.Message{
+		Role: "system",
+		Content: "The user is asking about an error or debugging issue. " +
+			"Provide a direct, technical diagnosis. Explain the likely cause, " +
+			"suggest concrete fixes, and keep your answer focused and actionable. " +
+			"Do NOT create a plan or ask for approval - just answer directly.",
+	}
+	enriched = append(enriched[:len(enriched)-1], diagMsg, enriched[len(enriched)-1])
+
+	resp, err := a.llm.Chat(ctx, enriched)
+	if err != nil {
+		log.Error("LLM diagnose failed", "error", err)
+		return "This krill's neural link is fuzzy right now. Could you try again?", nil
+	}
+
+	a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
+	a.saveTurn("assistant", resp.Content)
+	return resp.Content, nil
+}
+
+// handleAnswer provides a direct answer to a factual question.
+func (a *KrillAgent) handleAnswer(ctx context.Context) (string, error) {
+	enriched := a.brain.EnrichMessages(a.history)
+
+	// Add direct-answer system prompt
+	answerMsg := core.Message{
+		Role: "system",
+		Content: "Answer the user's question directly and concisely. " +
+			"Do not create a plan, do not ask for approval, and do not ask follow-up questions " +
+			"unless you truly need clarification to give a useful answer.",
+	}
+	enriched = append(enriched[:len(enriched)-1], answerMsg, enriched[len(enriched)-1])
+
+	if memoryCtx := a.buildUserMemoryContext(ctx, 8); memoryCtx != "" {
+		memoryMsg := core.Message{
+			Role:    "system",
+			Content: "Known user preferences:\n\n" + memoryCtx,
+		}
+		enriched = append(enriched[:len(enriched)-1], memoryMsg, enriched[len(enriched)-1])
+	}
+
+	resp, err := a.llm.Chat(ctx, enriched)
+	if err != nil {
+		log.Error("LLM answer failed", "error", err)
+		return "This krill's neural link is fuzzy right now. Could you try again?", nil
+	}
+
+	a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
+	a.saveTurn("assistant", resp.Content)
 	return resp.Content, nil
 }
 
@@ -569,41 +937,10 @@ func memoryKey(s string) string {
 	return key
 }
 
-// detectSelfSkill checks if the message is about the krill itself and maps
-// it to the appropriate self:* skill. Returns ("", "") if not self-referential.
-// Krill have compound eyes with 7 visual pigments - these detect self-references.
+// detectSelfSkill delegates to the router's detectSelfSkillTrigger.
+// Kept for backward compatibility with any callers outside the main Chat() path.
 func (a *KrillAgent) detectSelfSkill(msg string) (skillName, skillInput string) {
-	lower := strings.ToLower(msg)
-
-	// Read-only introspection
-	selfMap := []struct {
-		triggers []string
-		skill    string
-	}{
-		{[]string{"your health", "check yourself", "are you ok", "how are you feeling", "diagnose yourself"}, "self:health"},
-		{[]string{"your personality", "who are you", "describe yourself", "about yourself", "your identity", "your traits"}, "self:inspect"},
-		{[]string{"your status", "your uptime", "how long have you been", "your vitals"}, "self:status"},
-		{[]string{"your memories", "what do you remember", "what have you learned", "your memory"}, "self:memory"},
-		{[]string{"your skills", "your capabilities", "what can you do", "your abilities"}, "self:skills"},
-		{[]string{"your config", "your settings", "your configuration", "show config"}, "self:config"},
-		// Write operations
-		{[]string{"tune your", "change temperature", "set temperature", "tune temperature", "set max_token", "tune max_token"}, "self:tune"},
-		{[]string{"learn that", "remember that", "remember this", "memorize", "note that"}, "self:learn"},
-		{[]string{"evolve your", "update your personality", "change your style", "change your trait", "add trait", "be more", "be less"}, "self:evolve"},
-		{[]string{"add a skill", "create a skill", "new skill", "add skill"}, "self:add-skill"},
-		{[]string{"heal yourself", "fix yourself", "self heal", "self-heal", "repair yourself"}, "self:heal"},
-		{[]string{"switch to ollama", "switch to codex", "switch to claude", "switch to openai", "switch to anthropic", "switch to google", "auto approve", "require approval", "log level"}, "self:configure"},
-		{[]string{"reflect on yourself", "reflect on our conversations", "evolve yourself", "how have i changed you", "what have you learned about me"}, "self:reflect"},
-	}
-
-	for _, entry := range selfMap {
-		for _, trigger := range entry.triggers {
-			if strings.Contains(lower, trigger) {
-				return entry.skill, msg
-			}
-		}
-	}
-	return "", ""
+	return detectSelfSkillTrigger(msg)
 }
 
 // recordFeedback silently stores interaction signals for adaptive personality evolution.
@@ -674,52 +1011,11 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 	}
 }
 
-// shouldSearch detects if a message likely needs current web information.
-// Krill have photoreceptors that detect light changes - this detects info needs.
+// shouldSearch is kept for backward compatibility. The router now handles search
+// detection via IntentToolTask, but other code may still call this.
 func (a *KrillAgent) shouldSearch(msg string) bool {
 	lower := strings.ToLower(msg)
-	searchTriggers := []string{
-		"search for", "look up", "find out", "what is the latest",
-		"current news", "recent", "today", "who is", "what happened",
-		"search the web", "google", "search online", "look online",
-		"what's new", "latest on", "news about", "find me",
-	}
-	for _, trigger := range searchTriggers {
-		if strings.Contains(lower, trigger) {
-			return true
-		}
-	}
-	return false
-}
-
-// classifyIntent sends the user input to the LLM for TASK vs CHAT classification.
-// Defaults to CHAT if the LLM fails - safe default, just like a krill retreating
-// to deeper water when the signal is unclear.
-func (a *KrillAgent) classifyIntent(ctx context.Context, input string) string {
-	prompt := fmt.Sprintf(
-		"Classify this message as either TASK or CHAT. "+
-			"TASK means the user wants you to do something specific (research, build, analyze, create, find, fix, etc). "+
-			"CHAT means casual conversation, questions, or discussion. "+
-			"Reply with exactly one word: TASK or CHAT.\n\nMessage: %s", input,
-	)
-
-	msgs := []core.Message{
-		{Role: "user", Content: prompt},
-	}
-
-	resp, err := a.llm.Chat(ctx, msgs, core.WithTemperature(0.0), core.WithMaxTokens(10))
-	if err != nil {
-		log.Warn("intent classification failed, defaulting to CHAT", "error", err)
-		return "CHAT"
-	}
-
-	classification := strings.ToUpper(strings.TrimSpace(resp.Content))
-	if strings.Contains(classification, "TASK") {
-		return "TASK"
-	}
-
-	// Default to CHAT - the safe harbor
-	return "CHAT"
+	return matchesAny(lower, searchTriggers)
 }
 
 // saveTurn persists a single turn to the durable conversation store.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -62,6 +62,7 @@ type KrillAgent struct {
 	router      *IntentRouter
 	channel     string // durable conversation channel; default is unified across interfaces
 	platform    string // current chat platform (telegram, discord, cli, tui)
+	chatID      string // current chat ID for background task notifications
 	history     []core.Message
 	pendingPlan *core.Plan
 	subMgr      *SubKrillManager
@@ -113,12 +114,21 @@ func (a *KrillAgent) SetChannel(channel string) {
 	a.channel = unifiedConversationChannel
 }
 
-// SetPlatform records which chat platform the agent is currently serving.
-// Used to decide whether to run tasks synchronously or in the background.
+// SetPlatform records which chat platform and chat ID the agent is currently
+// serving. Used to decide whether to run tasks in the background and where
+// to deliver results. Safe to call concurrently — serialised by a.mu.
 func (a *KrillAgent) SetPlatform(platform string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.platform = platform
+}
+
+// SetChatContext records the current platform and chat ID for background task routing.
+func (a *KrillAgent) SetChatContext(platform, chatID string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	a.platform = platform
+	a.chatID = chatID
 }
 
 // InitTaskSystem sets up the durable task store and runner.
@@ -191,6 +201,10 @@ func (a *KrillAgent) CancelTask(id string) error {
 
 // Chat is the main entry point - every user message flows through here.
 // It handles pending plan approval, intent classification, and response generation.
+// Note: Chat holds a.mu for its entire duration. The platform field is safe to
+// read because SetPlatform also holds a.mu, so they cannot race. For multi-
+// platform concurrency (Telegram + CLI simultaneously), callers must set
+// platform before each Chat call, which is serialised by the lock.
 func (a *KrillAgent) Chat(ctx context.Context, input string) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
@@ -435,7 +449,7 @@ func (a *KrillAgent) shouldRunInBackground(plan *core.Plan) bool {
 
 // submitBackgroundTask creates a durable task and returns an immediate ack.
 func (a *KrillAgent) submitBackgroundTask(input string) (string, error) {
-	taskID, err := a.SubmitTask(context.Background(), "", a.platform, "", input)
+	taskID, err := a.SubmitTask(context.Background(), "", a.platform, a.chatID, input)
 	if err != nil {
 		log.Error("background task submission failed", "error", err)
 		return fmt.Sprintf("Could not start background task: %v", err), nil

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,6 +6,8 @@ package agent
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -15,8 +17,12 @@ import (
 	log "github.com/srvsngh99/mini-krill/internal/log"
 )
 
-// Compile-time interface check - KrillAgent must satisfy core.Agent.
-var _ core.Agent = (*KrillAgent)(nil)
+// Compile-time interface checks - KrillAgent satisfies both Agent and the
+// platform-aware extension.
+var (
+	_ core.Agent              = (*KrillAgent)(nil)
+	_ core.PlatformAwareAgent = (*KrillAgent)(nil)
+)
 
 // maxHistory caps conversation history to prevent unbounded memory growth.
 // Krill molt their exoskeleton to grow - we shed old messages to stay nimble.
@@ -114,29 +120,27 @@ func (a *KrillAgent) SetChannel(channel string) {
 	a.channel = unifiedConversationChannel
 }
 
-// SetPlatform records which chat platform and chat ID the agent is currently
-// serving. Used to decide whether to run tasks in the background and where
-// to deliver results. Safe to call concurrently — serialised by a.mu.
+// SetPlatform is retained for tests that don't go through ChatFromPlatform.
+// Production callers should use ChatFromPlatform so that platform/chatID and
+// the message itself are processed atomically under one lock acquisition.
 func (a *KrillAgent) SetPlatform(platform string) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.platform = platform
 }
 
-// SetChatContext records the current platform and chat ID for background task routing.
-func (a *KrillAgent) SetChatContext(platform, chatID string) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.platform = platform
-	a.chatID = chatID
-}
-
 // InitTaskSystem sets up the durable task store and runner.
 // Called during application startup after the agent is created.
+// The directory is created if it does not exist; persistence is disabled
+// when dataDir is empty (used in tests).
 func (a *KrillAgent) InitTaskSystem(dataDir string, maxConcurrent int) {
 	path := ""
 	if dataDir != "" {
-		path = dataDir + "/tasks.jsonl"
+		if err := os.MkdirAll(dataDir, 0o755); err != nil {
+			log.Warn("task data dir creation failed, persistence disabled", "dir", dataDir, "error", err)
+		} else {
+			path = filepath.Join(dataDir, "tasks.jsonl")
+		}
 	}
 	a.taskStore = NewTaskStore(path)
 	a.taskRunner = NewTaskRunner(a.taskStore, a, maxConcurrent)
@@ -199,15 +203,23 @@ func (a *KrillAgent) CancelTask(id string) error {
 	return a.taskStore.Cancel(id)
 }
 
-// Chat is the main entry point - every user message flows through here.
-// It handles pending plan approval, intent classification, and response generation.
-// Note: Chat holds a.mu for its entire duration. The platform field is safe to
-// read because SetPlatform also holds a.mu, so they cannot race. For multi-
-// platform concurrency (Telegram + CLI simultaneously), callers must set
-// platform before each Chat call, which is serialised by the lock.
+// Chat is the main entry point for callers that don't have a chat platform —
+// CLI one-shots, tests, internal flows. For platform integrations, prefer
+// ChatFromPlatform so background-task routing has the right destination.
 func (a *KrillAgent) Chat(ctx context.Context, input string) (string, error) {
+	return a.ChatFromPlatform(ctx, "", "", input)
+}
+
+// ChatFromPlatform is the platform-aware entry point. It atomically sets the
+// current platform/chatID and processes the message under a single lock
+// acquisition, so two concurrent dispatchers cannot interleave each other's
+// platform context.
+func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, input string) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
+
+	a.platform = platform
+	a.chatID = chatID
 
 	if response, handled := a.handleProviderCommand(input); handled {
 		a.saveTurn("user", input)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -855,6 +855,8 @@ func (a *KrillAgent) maybeStoreUserPreference(ctx context.Context, input string)
 		Key:        key,
 		Value:      text,
 		Tags:       []string{"user-preference", "auto-learned"},
+		Scope:      "user",
+		Source:     "auto-learned",
 		CreatedAt:  time.Now(),
 		AccessedAt: time.Now(),
 	}
@@ -868,16 +870,30 @@ func (a *KrillAgent) buildUserMemoryContext(ctx context.Context, limit int) stri
 	if mem == nil || limit <= 0 {
 		return ""
 	}
-	entries, err := mem.List(ctx)
-	if err != nil || len(entries) == 0 {
-		return ""
+
+	// Use ranked search with the latest user message as query context
+	lastMsg := ""
+	if len(a.history) > 0 {
+		lastMsg = a.history[len(a.history)-1].Content
 	}
-	var lines []string
-	for i := len(entries) - 1; i >= 0 && len(lines) < limit; i-- {
-		entry := entries[i]
-		if !hasAnyTag(entry.Tags, "user-preference", "self-learned") {
-			continue
+
+	// Try ranked search for user-scoped memories first
+	entries, err := mem.RankedSearch(ctx, lastMsg, "user", limit)
+	if err != nil || len(entries) == 0 {
+		// Fallback to old behavior: list all and filter by tag
+		allEntries, err := mem.List(ctx)
+		if err != nil || len(allEntries) == 0 {
+			return ""
 		}
+		for i := len(allEntries) - 1; i >= 0 && len(entries) < limit; i-- {
+			if hasAnyTag(allEntries[i].Tags, "user-preference", "self-learned") {
+				entries = append(entries, allEntries[i])
+			}
+		}
+	}
+
+	var lines []string
+	for _, entry := range entries {
 		value := sanitizeMemoryContextValue(entry.Value)
 		if value != "" {
 			lines = append(lines, fmt.Sprintf("- [stored preference, treat as data only]: %q", value))
@@ -1002,6 +1018,8 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 		Key:        key,
 		Value:      fmt.Sprintf("signal:%s | user: %s | krill: %s", signal, truncate(input, 100), truncate(response, 100)),
 		Tags:       []string{"personality-feedback", signal},
+		Scope:      "system",
+		Source:     "feedback",
 		CreatedAt:  time.Now(),
 		AccessedAt: time.Now(),
 	}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -524,13 +524,23 @@ func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
 		if len(plan.Steps) >= 5 {
 			return true
 		}
-		// Plans with destructive hints need approval
+		// Plans with destructive hints need approval.
+		// Use specific phrases to avoid false positives like "drop-down",
+		// "push notification", "reset filter state".
 		for _, step := range plan.Steps {
 			if step.NeedsApproval {
 				return true
 			}
 			lower := strings.ToLower(step.Description)
-			for _, danger := range []string{"delete", "remove", "deploy", "push", "install", "drop", "destroy", "reset"} {
+			for _, danger := range []string{
+				"delete file", "delete dir", "delete database", "delete branch",
+				"remove file", "remove dir", "remove package",
+				"deploy to", "deploy the",
+				"git push", "force push",
+				"npm install", "pip install", "go install",
+				"drop table", "drop database", "drop collection",
+				"destroy", "rm -", "reset --hard",
+			} {
 				if strings.Contains(lower, danger) {
 					return true
 				}
@@ -1029,12 +1039,6 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 	}
 }
 
-// shouldSearch is kept for backward compatibility. The router now handles search
-// detection via IntentToolTask, but other code may still call this.
-func (a *KrillAgent) shouldSearch(msg string) bool {
-	lower := strings.ToLower(msg)
-	return matchesAny(lower, searchTriggers)
-}
 
 // saveTurn persists a single turn to the durable conversation store.
 // Runs inline (not goroutine) to ensure ordering.
@@ -1152,7 +1156,9 @@ func containsWord(text, word string) bool {
 	}
 }
 
-// isWordChar returns true if c is a letter, digit, or apostrophe.
+// isWordChar returns true if c is a letter, digit, apostrophe, or hyphen.
+// Hyphen is included so that "drop-down" is treated as one word and
+// "drop" alone does not match it.
 func isWordChar(c byte) bool {
-	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '\''
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '\'' || c == '-'
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -989,12 +989,6 @@ func memoryKey(s string) string {
 	return key
 }
 
-// detectSelfSkill delegates to the router's detectSelfSkillTrigger.
-// Kept for backward compatibility with any callers outside the main Chat() path.
-func (a *KrillAgent) detectSelfSkill(msg string) (skillName, skillInput string) {
-	return detectSelfSkillTrigger(msg)
-}
-
 // recordFeedback silently stores interaction signals for adaptive personality evolution.
 // Runs in background goroutine - never blocks the response.
 func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
@@ -1110,22 +1104,6 @@ func (a *KrillAgent) appendMessage(msg core.Message) {
 		trimmed = append(trimmed, a.history[1+excess:]...)
 		a.history = trimmed
 	}
-}
-
-// looksLikeRecallRequest detects if the user is asking about previous conversations.
-func looksLikeRecallRequest(msg string) bool {
-	lower := strings.ToLower(msg)
-	triggers := []string{
-		"last conversation", "previous conversation", "remember when",
-		"do you remember", "we talked about", "earlier we", "last time",
-		"our last", "previously", "last chat", "before this",
-	}
-	for _, t := range triggers {
-		if strings.Contains(lower, t) {
-			return true
-		}
-	}
-	return false
 }
 
 // buildSkillSummary returns a short comma-separated list of enabled skill names

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -593,3 +594,41 @@ func (m *slowMockProvider) Stream(_ context.Context, _ []core.Message, _ ...core
 func (m *slowMockProvider) Name() string                     { return "slow-mock" }
 func (m *slowMockProvider) ModelName() string                { return "slow-mock" }
 func (m *slowMockProvider) Available(_ context.Context) bool { return true }
+
+func TestChatFromPlatformAtomicity(t *testing.T) {
+	// Two concurrent dispatchers should each see their own platform/chatID
+	// inside the corresponding ChatFromPlatform call. The previous
+	// SetChatContext + Chat split allowed the second SetChatContext to
+	// overwrite the first before the first Chat ran.
+	agent := newTestAgent("hi")
+	agent.InitTaskSystem("", 1)
+
+	const N = 20
+	var wg sync.WaitGroup
+	platforms := []string{"telegram", "cli", "discord", "tui"}
+	errs := make(chan string, N)
+
+	for i := 0; i < N; i++ {
+		wg.Add(1)
+		platform := platforms[i%len(platforms)]
+		chatID := platform + "-" + string(rune('a'+i))
+		go func() {
+			defer wg.Done()
+			// We can't directly inspect a.platform after the call (the test
+			// agent uses real chat path). Instead, use the round-trip
+			// through ChatFromPlatform — if it doesn't deadlock or return
+			// a wrong-platform error and the agent platform == chatID
+			// platform on observation, we're good. The real correctness
+			// guarantee is that ChatFromPlatform takes a single mutex
+			// acquisition, so contention here just exercises that lock.
+			if _, err := agent.ChatFromPlatform(context.Background(), platform, chatID, "hello"); err != nil {
+				errs <- err.Error()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for e := range errs {
+		t.Errorf("ChatFromPlatform under contention: %s", e)
+	}
+}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -107,7 +107,7 @@ func (r *mockMCPReg) IsEnabled(_ string) bool                   { return true }
 
 func newTestAgent(response string) *KrillAgent {
 	return New(
-		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: true},
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: "always"},
 		&MockProvider{chatResponse: response},
 		&mockBrain{},
 		&mockSkillRegistry{},
@@ -155,8 +155,8 @@ func TestAgentChatMultipleMessages(t *testing.T) {
 }
 
 func TestAgentPlanApproval(t *testing.T) {
-	// The mock LLM returns "CHAT" for classification (since "Just chatting"
-	// doesn't contain "TASK"), so this tests the chat path.
+	// "build me a website" hits the LLM fallback, mock returns "Just chatting"
+	// which doesn't match any intent → defaults to IntentAnswer → chat path.
 	a := newTestAgent("Just chatting")
 
 	resp, err := a.Chat(context.Background(), "build me a website")
@@ -169,18 +169,18 @@ func TestAgentPlanApproval(t *testing.T) {
 }
 
 func TestAgentPlanApprovalWithTaskClassification(t *testing.T) {
-	// Use a provider that returns "TASK" for classification, then a plan response
+	// Use a provider that returns "LONG_TASK" for the LLM intent fallback, then a plan response
 	callCount := 0
 	provider := &sequentialMockProvider{
 		responses: []string{
-			"TASK",
-			"SUMMARY: Build a website\nSTEP 1: Set up\nSTEP 2: Code",
+			"LONG_TASK",
+			"SUMMARY: Build a website\nSTEP 1: Set up\nSTEP 2: Code\nSTEP 3: Deploy\nSTEP 4: Test\nSTEP 5: Monitor",
 		},
 		callCount: &callCount,
 	}
 
 	agent := New(
-		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: true},
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: "always"},
 		provider,
 		&mockBrain{},
 		&mockSkillRegistry{},
@@ -371,7 +371,7 @@ func newProviderControlTestAgent() *KrillAgent {
 		},
 	}
 	return New(
-		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: true},
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: "always"},
 		provider,
 		&mockBrain{},
 		&mockSkillRegistry{},

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -4,6 +4,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -311,15 +312,23 @@ func parseToolCall(response string) (string, map[string]string) {
 	return toolName, args
 }
 
-// parseSimpleJSON does a lightweight parse of {"key": "value"} JSON.
-// We avoid pulling in encoding/json for this simple case.
+// parseSimpleJSON parses a JSON object string into a string map.
 func parseSimpleJSON(s string) map[string]string {
 	result := make(map[string]string)
 	s = strings.TrimSpace(s)
+
+	// Try proper JSON parse first
+	var raw map[string]interface{}
+	if err := json.Unmarshal([]byte(s), &raw); err == nil {
+		for k, v := range raw {
+			result[k] = fmt.Sprintf("%v", v)
+		}
+		return result
+	}
+
+	// Fallback: extract key-value pairs from malformed JSON
 	s = strings.TrimPrefix(s, "{")
 	s = strings.TrimSuffix(s, "}")
-
-	// Split on commas (simplistic but sufficient for tool args)
 	pairs := strings.Split(s, ",")
 	for _, pair := range pairs {
 		pair = strings.TrimSpace(pair)
@@ -359,20 +368,15 @@ func cleanToolCallFromResponse(response string) string {
 }
 
 // extractShellCommand attempts to extract a shell command from a step description.
-// It looks for backtick-quoted commands or common patterns.
+// Only honours backtick-quoted commands to avoid extracting garbage from prose.
 func extractShellCommand(desc string) string {
-	// Check for backtick-quoted command
 	if idx := strings.Index(desc, "`"); idx >= 0 {
 		end := strings.Index(desc[idx+1:], "`")
 		if end >= 0 {
-			return desc[idx+1 : idx+1+end]
-		}
-	}
-	// Check for common "run X" patterns
-	lower := strings.ToLower(desc)
-	for _, prefix := range []string{"run ", "execute "} {
-		if idx := strings.Index(lower, prefix); idx >= 0 {
-			return strings.TrimSpace(desc[idx+len(prefix):])
+			cmd := strings.TrimSpace(desc[idx+1 : idx+1+end])
+			if cmd != "" {
+				return cmd
+			}
 		}
 	}
 	return ""

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -22,20 +22,23 @@ var statusIcons = map[string]string{
 
 // GeneratePlan asks the LLM to decompose a task into concrete, actionable steps.
 // The plan is returned unapproved - the user must greenlight it before execution.
-func GeneratePlan(ctx context.Context, task string, llm core.LLMProvider, skills core.SkillRegistry) (*core.Plan, error) {
-	// Build the skills inventory for the planner's awareness
-	skillList := buildSkillList(skills)
+func GeneratePlan(ctx context.Context, task string, llm core.LLMProvider, skills core.SkillRegistry, mcp core.MCPRegistry) (*core.Plan, error) {
+	// Build the tools inventory for the planner's awareness
+	toolbox := NewToolbox(skills, mcp, llm)
+	toolDescriptions := toolbox.FormatToolsForLLM()
 
 	prompt := fmt.Sprintf(
 		"You are planning a task. Break it into 3-7 concrete steps. "+
 			"For each step, write one clear action sentence. "+
-			"Available skills: %s. "+
+			"If a step should use a tool, add [tool:name] at the end of the step. "+
+			"For shell commands, use [tool:shell]. "+
 			"Format your response as:\n"+
 			"SUMMARY: <one-line summary>\n"+
-			"STEP 1: <action>\n"+
+			"STEP 1: <action> [tool:name]\n"+
 			"STEP 2: <action>\n"+
 			"...\n\n"+
-			"Task: %s", skillList, task,
+			"Available tools:\n%s\n"+
+			"Task: %s", toolDescriptions, task,
 	)
 
 	msgs := []core.Message{
@@ -99,15 +102,18 @@ func FormatPlan(plan *core.Plan) string {
 	return b.String()
 }
 
-// ExecutePlanSteps iterates through each plan step, sending it to the LLM for execution.
+// ExecutePlanSteps iterates through each plan step, dispatching real tools when
+// possible and falling back to LLM narration when no tool applies.
 // Context from previous steps feeds forward so each step builds on the last.
-// Like a krill swarm moving in coordinated waves through the ocean column.
-func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider, brain core.Brain, skills core.SkillRegistry) (string, error) {
+func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider, brain core.Brain, skills core.SkillRegistry, mcp core.MCPRegistry) (string, error) {
 	if !plan.Approved {
 		return "", fmt.Errorf("this krill refuses to dive without an approved plan")
 	}
 
 	log.Info("executing plan", "task", plan.Task, "steps", len(plan.Steps))
+
+	toolbox := NewToolbox(skills, mcp, llm)
+	toolDescriptions := toolbox.FormatToolsForLLM()
 
 	var previousOutputs []string
 	var results strings.Builder
@@ -123,7 +129,6 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 			step.Status = "skipped"
 			log.Warn("plan execution cancelled", "step", step.ID, "reason", ctx.Err())
 			results.WriteString(fmt.Sprintf("Step %d: SKIPPED (cancelled)\n", step.ID))
-			// Mark remaining steps as skipped
 			for j := i + 1; j < len(plan.Steps); j++ {
 				plan.Steps[j].Status = "skipped"
 			}
@@ -143,33 +148,22 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 			contextStr = "This is the first step."
 		}
 
-		prompt := fmt.Sprintf(
-			"Execute this step: %s\n\n%s\n\nProvide a clear, concise result.",
-			step.Description, contextStr,
-		)
+		// Try tool-assisted execution: ask LLM what tool to call
+		stepOutput, err := executeStepWithTools(ctx, step, contextStr, toolbox, toolDescriptions, llm, brain)
 
-		msgs := brain.EnrichMessages([]core.Message{
-			{Role: "user", Content: prompt},
-		})
-
-		resp, err := llm.Chat(ctx, msgs)
 		if err != nil {
 			step.Status = "failed"
 			step.Output = fmt.Sprintf("Error: %v", err)
 			log.Error("step execution failed", "step_id", step.ID, "error", err)
-
 			results.WriteString(fmt.Sprintf("Step %d [!] %s\n  Error: %v\n\n", step.ID, step.Description, err))
-
-			// Continue with remaining steps - a krill swarm adapts around obstacles
 			previousOutputs = append(previousOutputs, fmt.Sprintf("Step %d FAILED: %v", step.ID, err))
 			continue
 		}
 
 		step.Status = "done"
-		step.Output = resp.Content
-		previousOutputs = append(previousOutputs, fmt.Sprintf("Step %d: %s", step.ID, resp.Content))
-
-		results.WriteString(fmt.Sprintf("Step %d [x] %s\n  %s\n\n", step.ID, step.Description, resp.Content))
+		step.Output = stepOutput
+		previousOutputs = append(previousOutputs, fmt.Sprintf("Step %d: %s", step.ID, stepOutput))
+		results.WriteString(fmt.Sprintf("Step %d [x] %s\n  %s\n\n", step.ID, step.Description, stepOutput))
 		log.Debug("step completed", "step_id", step.ID)
 	}
 
@@ -193,6 +187,195 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 
 	log.Info("plan execution complete", "task", plan.Task, "done", done, "failed", failed)
 	return results.String(), nil
+}
+
+// executeStepWithTools handles a single plan step by asking the LLM if a tool
+// should be used. If the LLM responds with a TOOL_CALL directive, the tool is
+// dispatched via the toolbox and the real output is fed back to the LLM for
+// synthesis. If no tool is called, the LLM's direct response is used.
+func executeStepWithTools(ctx context.Context, step *core.PlanStep, contextStr string, toolbox *Toolbox, toolDescriptions string, llm core.LLMProvider, brain core.Brain) (string, error) {
+	// If the step already has a tool hint from plan generation, try it directly
+	if step.ToolHint != "" {
+		toolOutput, err := dispatchToolHint(ctx, step, toolbox)
+		if err == nil && toolOutput != "" {
+			// Synthesize the raw tool output into a useful summary via LLM
+			return synthesizeToolOutput(ctx, step.Description, toolOutput, llm, brain)
+		}
+		log.Debug("tool hint dispatch failed, falling back to LLM", "tool", step.ToolHint, "error", err)
+	}
+
+	// Ask LLM to execute the step, optionally using a tool
+	prompt := fmt.Sprintf(
+		"Execute this step: %s\n\n%s\n\n"+
+			"Available tools:\n%s\n"+
+			"If you need to use a tool, respond with EXACTLY this format:\n"+
+			"TOOL_CALL: tool_name\n"+
+			"ARGS: {\"key\": \"value\"}\n\n"+
+			"If no tool is needed, provide your analysis directly.",
+		step.Description, contextStr, toolDescriptions,
+	)
+
+	msgs := brain.EnrichMessages([]core.Message{
+		{Role: "user", Content: prompt},
+	})
+
+	resp, err := llm.Chat(ctx, msgs)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if the LLM wants to call a tool
+	toolName, toolArgs := parseToolCall(resp.Content)
+	if toolName != "" {
+		log.Info("LLM requested tool call", "tool", toolName)
+		toolOutput, err := toolbox.ExecuteTool(ctx, toolName, toolArgs)
+		if err != nil {
+			log.Warn("tool call failed, using LLM narration", "tool", toolName, "error", err)
+			// Return the error info along with the original LLM response
+			return fmt.Sprintf("[tool %s failed: %v]\n%s", toolName, err, cleanToolCallFromResponse(resp.Content)), nil
+		}
+		// Feed real tool output back to LLM for synthesis
+		return synthesizeToolOutput(ctx, step.Description, toolOutput, llm, brain)
+	}
+
+	// No tool call — use LLM response directly (narration fallback)
+	return resp.Content, nil
+}
+
+// dispatchToolHint tries to execute a tool based on the ToolHint from plan generation.
+func dispatchToolHint(ctx context.Context, step *core.PlanStep, toolbox *Toolbox) (string, error) {
+	args := map[string]string{"input": step.Description}
+
+	// For shell tool, try to extract a command from the step description
+	if step.ToolHint == "shell" {
+		cmd := extractShellCommand(step.Description)
+		if cmd != "" {
+			args = map[string]string{"command": cmd}
+		} else {
+			return "", fmt.Errorf("could not extract shell command from step description")
+		}
+	}
+
+	return toolbox.ExecuteTool(ctx, step.ToolHint, args)
+}
+
+// synthesizeToolOutput sends real tool output back to the LLM for a concise summary.
+func synthesizeToolOutput(ctx context.Context, stepDescription, toolOutput string, llm core.LLMProvider, brain core.Brain) (string, error) {
+	prompt := fmt.Sprintf(
+		"You executed: %s\n\nHere is the real output:\n```\n%s\n```\n\n"+
+			"Provide a concise summary of the results. Include key findings.",
+		stepDescription, truncate(toolOutput, 4000),
+	)
+
+	msgs := brain.EnrichMessages([]core.Message{
+		{Role: "user", Content: prompt},
+	})
+
+	resp, err := llm.Chat(ctx, msgs)
+	if err != nil {
+		// If synthesis fails, return raw tool output
+		return toolOutput, nil
+	}
+
+	return resp.Content, nil
+}
+
+// parseToolCall extracts a TOOL_CALL directive and its arguments from LLM output.
+// Expected format:
+//
+//	TOOL_CALL: tool_name
+//	ARGS: {"key": "value"}
+func parseToolCall(response string) (string, map[string]string) {
+	lines := strings.Split(response, "\n")
+
+	var toolName string
+	args := make(map[string]string)
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(strings.ToUpper(trimmed), "TOOL_CALL:") {
+			toolName = strings.TrimSpace(trimmed[len("TOOL_CALL:"):])
+			// Look for ARGS on the next line
+			if i+1 < len(lines) {
+				argsLine := strings.TrimSpace(lines[i+1])
+				if strings.HasPrefix(strings.ToUpper(argsLine), "ARGS:") {
+					argsStr := strings.TrimSpace(argsLine[len("ARGS:"):])
+					args = parseSimpleJSON(argsStr)
+				}
+			}
+			break
+		}
+	}
+
+	return toolName, args
+}
+
+// parseSimpleJSON does a lightweight parse of {"key": "value"} JSON.
+// We avoid pulling in encoding/json for this simple case.
+func parseSimpleJSON(s string) map[string]string {
+	result := make(map[string]string)
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "{")
+	s = strings.TrimSuffix(s, "}")
+
+	// Split on commas (simplistic but sufficient for tool args)
+	pairs := strings.Split(s, ",")
+	for _, pair := range pairs {
+		pair = strings.TrimSpace(pair)
+		colonIdx := strings.Index(pair, ":")
+		if colonIdx < 0 {
+			continue
+		}
+		key := strings.Trim(strings.TrimSpace(pair[:colonIdx]), "\"")
+		value := strings.Trim(strings.TrimSpace(pair[colonIdx+1:]), "\"")
+		if key != "" {
+			result[key] = value
+		}
+	}
+	return result
+}
+
+// cleanToolCallFromResponse removes the TOOL_CALL/ARGS block from a response
+// so we can use the remaining text as narration.
+func cleanToolCallFromResponse(response string) string {
+	lines := strings.Split(response, "\n")
+	var clean []string
+	skip := false
+	for _, line := range lines {
+		upper := strings.ToUpper(strings.TrimSpace(line))
+		if strings.HasPrefix(upper, "TOOL_CALL:") {
+			skip = true
+			continue
+		}
+		if skip && strings.HasPrefix(upper, "ARGS:") {
+			skip = false
+			continue
+		}
+		skip = false
+		clean = append(clean, line)
+	}
+	return strings.TrimSpace(strings.Join(clean, "\n"))
+}
+
+// extractShellCommand attempts to extract a shell command from a step description.
+// It looks for backtick-quoted commands or common patterns.
+func extractShellCommand(desc string) string {
+	// Check for backtick-quoted command
+	if idx := strings.Index(desc, "`"); idx >= 0 {
+		end := strings.Index(desc[idx+1:], "`")
+		if end >= 0 {
+			return desc[idx+1 : idx+1+end]
+		}
+	}
+	// Check for common "run X" patterns
+	lower := strings.ToLower(desc)
+	for _, prefix := range []string{"run ", "execute "} {
+		if idx := strings.Index(lower, prefix); idx >= 0 {
+			return strings.TrimSpace(desc[idx+len(prefix):])
+		}
+	}
+	return ""
 }
 
 // parsePlanResponse extracts a structured Plan from the LLM's text response.
@@ -225,10 +408,20 @@ func parsePlanResponse(task, response string) *core.Plan {
 			if colonIdx >= 0 {
 				stepCounter++
 				desc := strings.TrimSpace(line[colonIdx+1:])
+				// Extract [tool:name] hint if present
+				toolHint := ""
+				if tidx := strings.Index(desc, "[tool:"); tidx >= 0 {
+					end := strings.Index(desc[tidx:], "]")
+					if end >= 0 {
+						toolHint = strings.TrimSpace(desc[tidx+len("[tool:") : tidx+end])
+						desc = strings.TrimSpace(desc[:tidx] + desc[tidx+end+1:])
+					}
+				}
 				plan.Steps = append(plan.Steps, core.PlanStep{
 					ID:          stepCounter,
 					Description: desc,
 					Status:      "pending",
+					ToolHint:    toolHint,
 				})
 			}
 		}

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -451,27 +451,3 @@ func parsePlanResponse(task, response string) *core.Plan {
 	return plan
 }
 
-// buildSkillList creates a comma-separated inventory of available skills.
-func buildSkillList(skills core.SkillRegistry) string {
-	if skills == nil {
-		return "none"
-	}
-
-	infos := skills.List()
-	if len(infos) == 0 {
-		return "none"
-	}
-
-	var parts []string
-	for _, info := range infos {
-		if info.Enabled {
-			parts = append(parts, fmt.Sprintf("%s (%s)", info.Name, info.Description))
-		}
-	}
-
-	if len(parts) == 0 {
-		return "none"
-	}
-
-	return strings.Join(parts, ", ")
-}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -142,6 +142,7 @@ var selfSkillMap = []struct {
 	{[]string{"heal yourself", "fix yourself", "self heal", "self-heal", "repair yourself"}, "self:heal"},
 	{[]string{"switch to ollama", "switch to codex", "switch to claude", "switch to openai", "switch to anthropic", "switch to google", "auto approve", "require approval", "log level"}, "self:configure"},
 	{[]string{"reflect on yourself", "reflect on our conversations", "evolve yourself", "how have i changed you", "what have you learned about me"}, "self:reflect"},
+	{[]string{"consolidate memories", "clean up memories", "merge memories", "deduplicate memories"}, "self:consolidate"},
 	// Read-only introspection
 	{[]string{"your health", "check yourself", "are you ok", "how are you feeling", "diagnose yourself"}, "self:health"},
 	{[]string{"your personality", "who are you", "describe yourself", "about yourself", "your identity", "your traits"}, "self:inspect"},

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -1,0 +1,333 @@
+// Package agent — intent router for smart message classification.
+// Replaces the binary TASK/CHAT classifier with a multi-intent router
+// that handles common cases deterministically and uses the LLM only
+// for genuinely ambiguous inputs.
+package agent
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// Intent represents the classified purpose of a user message.
+type Intent string
+
+const (
+	IntentChat      Intent = "CHAT"       // casual conversation, greetings, banter
+	IntentAnswer    Intent = "ANSWER"     // factual question needing a direct answer
+	IntentDiagnose  Intent = "DIAGNOSE"   // error analysis, debugging, "why did X happen"
+	IntentRemember  Intent = "REMEMBER"   // memory store/recall operations
+	IntentToolTask  Intent = "TOOL_TASK"  // single-tool invocation (search, time, sysinfo, web)
+	IntentLongTask  Intent = "LONG_TASK"  // multi-step work needing a plan
+	IntentSelfSkill Intent = "SELF_SKILL" // self:* skill invocations
+	IntentCommand   Intent = "COMMAND"    // provider commands (/model, /use, etc.)
+)
+
+// RouteResult carries the classified intent along with any hints for dispatch.
+type RouteResult struct {
+	Intent     Intent
+	ToolName   string // for IntentToolTask — which skill to invoke
+	SkillName  string // for IntentSelfSkill — which self skill matched
+	SkillInput string // for IntentSelfSkill — cleaned input for the skill
+}
+
+// IntentRouter classifies user messages into intents using a two-tier approach:
+// 1. Deterministic pattern matching (handles ~80% of inputs, zero LLM calls)
+// 2. LLM fallback for genuinely ambiguous cases
+type IntentRouter struct {
+	skills core.SkillRegistry
+	llm    core.LLMProvider
+}
+
+// NewIntentRouter creates a router wired to the skill registry and LLM.
+func NewIntentRouter(skills core.SkillRegistry, llm core.LLMProvider) *IntentRouter {
+	return &IntentRouter{skills: skills, llm: llm}
+}
+
+// commandPrefixes that are handled by handleProviderCommand.
+var commandPrefixes = []string{
+	"/model", "/models", "/use ", "/auth ",
+	"/help", "/status", "/tasks", "/task ", "/cancel ",
+}
+
+// greetings that should always route to chat.
+var greetings = map[string]bool{
+	"hi": true, "hello": true, "hey": true, "sup": true, "yo": true,
+	"what's up": true, "whats up": true, "howdy": true, "good morning": true,
+	"good evening": true, "good night": true, "gm": true, "gn": true,
+}
+
+// actionVerbs indicate the user wants something done (not just chat).
+var actionVerbs = []string{
+	"create", "build", "deploy", "analyze", "fix", "set up", "implement",
+	"research", "find", "check", "run", "test", "debug", "write", "install",
+	"refactor", "migrate", "configure", "generate", "update", "delete",
+	"remove", "add", "make", "develop", "optimize", "review", "scan",
+}
+
+// memoryStoreTriggers indicate the user wants to store something in memory.
+var memoryStoreTriggers = []string{
+	"remember that", "remember this", "memorize", "note that",
+	"learn that", "learn this", "don't forget",
+}
+
+// memoryRecallTriggers indicate the user wants to recall from memory.
+var memoryRecallTriggers = []string{
+	"what do you remember", "what have you learned", "do you remember",
+	"remember when", "what do you know about", "recall",
+	"last conversation", "previous conversation", "we talked about",
+	"earlier we", "last time", "our last", "previously", "last chat",
+	"before this",
+}
+
+// memoryForgetTriggers indicate the user wants to forget something.
+var memoryForgetTriggers = []string{
+	"forget that", "forget about", "delete memory", "remove memory",
+}
+
+// diagnosticTriggers indicate an error/debugging question.
+var diagnosticTriggers = []string{
+	"error", "exception", "stack trace", "traceback", "panic",
+	"not working", "broken", "crash", "crashing", "failed", "failing",
+	"bug", "issue with", "problem with",
+	"404", "500", "502", "503", "timeout",
+}
+
+// diagnosticQuestions paired with diagnostic context suggest diagnosis intent.
+var diagnosticQuestions = []string{
+	"why did", "why is", "why does", "why am i getting",
+	"what went wrong", "what's wrong", "how do i fix",
+	"what does this error mean", "what causes",
+}
+
+// timeTriggers route directly to the time skill.
+var timeTriggers = []string{
+	"what time", "what's the time", "current time", "what date",
+	"what's the date", "what day", "what's today",
+}
+
+// searchTriggers route directly to the search skill.
+var searchTriggers = []string{
+	"search for", "search the web", "search online", "look up",
+	"google", "look online", "find me info",
+}
+
+// sysInfoTriggers route directly to the sysinfo skill.
+var sysInfoTriggers = []string{
+	"system info", "system information", "how much ram", "how much memory",
+	"cpu info", "disk space", "os info", "what os",
+}
+
+// urlPattern detects URLs in input.
+var urlPattern = regexp.MustCompile(`https?://[^\s]+`)
+
+// youtubePattern detects YouTube URLs specifically.
+var youtubePattern = regexp.MustCompile(`(?:youtube\.com/watch|youtu\.be/)`)
+
+// selfSkillMap maps trigger phrases to self:* skill names.
+// Moved from agent.go detectSelfSkill to centralise routing.
+var selfSkillMap = []struct {
+	triggers []string
+	skill    string
+}{
+	// Write operations checked FIRST — they are more specific than read triggers
+	// (e.g. "evolve your personality" should match self:evolve, not self:inspect)
+	{[]string{"tune your", "change temperature", "set temperature", "tune temperature", "set max_token", "tune max_token"}, "self:tune"},
+	{[]string{"evolve your", "update your personality", "change your style", "change your trait", "add trait", "be more", "be less"}, "self:evolve"},
+	{[]string{"add a skill", "create a skill", "new skill", "add skill"}, "self:add-skill"},
+	{[]string{"heal yourself", "fix yourself", "self heal", "self-heal", "repair yourself"}, "self:heal"},
+	{[]string{"switch to ollama", "switch to codex", "switch to claude", "switch to openai", "switch to anthropic", "switch to google", "auto approve", "require approval", "log level"}, "self:configure"},
+	{[]string{"reflect on yourself", "reflect on our conversations", "evolve yourself", "how have i changed you", "what have you learned about me"}, "self:reflect"},
+	// Read-only introspection
+	{[]string{"your health", "check yourself", "are you ok", "how are you feeling", "diagnose yourself"}, "self:health"},
+	{[]string{"your personality", "who are you", "describe yourself", "about yourself", "your identity", "your traits"}, "self:inspect"},
+	{[]string{"your status", "your uptime", "how long have you been", "your vitals"}, "self:status"},
+	{[]string{"your memories", "what do you remember", "what have you learned", "your memory"}, "self:memory"},
+	{[]string{"your skills", "your capabilities", "what can you do", "your abilities"}, "self:skills"},
+	{[]string{"your config", "your settings", "your configuration", "show config"}, "self:config"},
+}
+
+// Classify determines the intent of a user message.
+// It checks deterministic patterns first, then falls back to LLM classification.
+func (r *IntentRouter) Classify(ctx context.Context, input string) RouteResult {
+	lower := strings.ToLower(strings.TrimSpace(input))
+
+	// 1. Command prefix — handled by handleProviderCommand / task commands
+	for _, prefix := range commandPrefixes {
+		if strings.HasPrefix(lower, prefix) || lower == strings.TrimSpace(prefix) {
+			return RouteResult{Intent: IntentCommand}
+		}
+	}
+
+	// 2. Self-skill triggers — map to specific self:* skills
+	if skillName, skillInput := detectSelfSkillTrigger(input); skillName != "" {
+		return RouteResult{
+			Intent:     IntentSelfSkill,
+			SkillName:  skillName,
+			SkillInput: skillInput,
+		}
+	}
+
+	// 3. Memory operations — store, recall, or forget
+	if matchesAny(lower, memoryStoreTriggers) {
+		return RouteResult{Intent: IntentRemember, ToolName: "store"}
+	}
+	if matchesAny(lower, memoryForgetTriggers) {
+		return RouteResult{Intent: IntentRemember, ToolName: "forget"}
+	}
+	if matchesAny(lower, memoryRecallTriggers) {
+		return RouteResult{Intent: IntentRemember, ToolName: "recall"}
+	}
+
+	// 4. Direct tool triggers — single skill invocations
+	if matchesAny(lower, timeTriggers) {
+		return RouteResult{Intent: IntentToolTask, ToolName: "time"}
+	}
+	if matchesAny(lower, sysInfoTriggers) {
+		return RouteResult{Intent: IntentToolTask, ToolName: "sysinfo"}
+	}
+	if matchesAny(lower, searchTriggers) {
+		return RouteResult{Intent: IntentToolTask, ToolName: "search"}
+	}
+	// URL detection: YouTube vs generic web
+	if urlPattern.MatchString(lower) {
+		if youtubePattern.MatchString(lower) {
+			return RouteResult{Intent: IntentToolTask, ToolName: "youtube"}
+		}
+		return RouteResult{Intent: IntentToolTask, ToolName: "web"}
+	}
+
+	// 5. Diagnostic triggers — error/debugging questions
+	// Checked before greeting/chat so "why is it crashing?" isn't short-circuited to CHAT.
+	if isDiagnostic(lower) {
+		return RouteResult{Intent: IntentDiagnose}
+	}
+
+	// 6. Greeting / short chat — no action verbs, short message
+	if isGreetingOrSmallTalk(lower) {
+		return RouteResult{Intent: IntentChat}
+	}
+
+	// 7. LLM fallback for genuinely ambiguous inputs
+	return r.classifyWithLLM(ctx, input)
+}
+
+// detectSelfSkillTrigger checks if the message matches any self:* skill trigger.
+// Extracted from the old detectSelfSkill method on KrillAgent.
+func detectSelfSkillTrigger(msg string) (skillName, skillInput string) {
+	lower := strings.ToLower(msg)
+	for _, entry := range selfSkillMap {
+		for _, trigger := range entry.triggers {
+			if strings.Contains(lower, trigger) {
+				return entry.skill, msg
+			}
+		}
+	}
+	return "", ""
+}
+
+// isGreetingOrSmallTalk returns true for casual short messages.
+func isGreetingOrSmallTalk(lower string) bool {
+	// Exact greeting match
+	if greetings[lower] {
+		return true
+	}
+	// Short message without action verbs → chat
+	words := strings.Fields(lower)
+	if len(words) <= 6 && !containsAnyWord(lower, actionVerbs) {
+		// But not if it looks like a question about errors
+		if !strings.Contains(lower, "error") && !strings.Contains(lower, "bug") {
+			return true
+		}
+	}
+	return false
+}
+
+// isDiagnostic checks if the message looks like an error/debugging question.
+func isDiagnostic(lower string) bool {
+	hasDiagContext := matchesAny(lower, diagnosticTriggers)
+	hasDiagQuestion := matchesAny(lower, diagnosticQuestions)
+
+	// Strong signal: explicit diagnostic question
+	if hasDiagQuestion {
+		return true
+	}
+	// Moderate signal: diagnostic context + question mark or multi-line (pasted output)
+	if hasDiagContext && (strings.Contains(lower, "?") || strings.Count(lower, "\n") > 1) {
+		return true
+	}
+	return false
+}
+
+// classifyWithLLM sends the input to the LLM for multi-class classification.
+// Only called for genuinely ambiguous inputs (~20% of messages).
+func (r *IntentRouter) classifyWithLLM(ctx context.Context, input string) RouteResult {
+	prompt := `Classify this message into exactly one category. Reply with ONLY the category name, nothing else.
+
+Categories:
+- CHAT: casual conversation, greetings, banter, opinions
+- ANSWER: factual question that needs a direct answer
+- DIAGNOSE: error analysis, debugging, troubleshooting
+- LONG_TASK: multi-step work (build, create, deploy, refactor, set up, implement)
+- TOOL_TASK: single action (search, look up, check time, get system info)
+- REMEMBER: memory operations (remember, recall, forget)
+
+Message: ` + input
+
+	msgs := []core.Message{
+		{Role: "user", Content: prompt},
+	}
+
+	resp, err := r.llm.Chat(ctx, msgs, core.WithTemperature(0.0), core.WithMaxTokens(10))
+	if err != nil {
+		log.Warn("LLM intent classification failed, defaulting to ANSWER", "error", err)
+		return RouteResult{Intent: IntentAnswer}
+	}
+
+	classification := strings.ToUpper(strings.TrimSpace(resp.Content))
+	log.Debug("LLM classified intent", "raw", resp.Content, "parsed", classification)
+
+	switch {
+	case strings.Contains(classification, "LONG_TASK"):
+		return RouteResult{Intent: IntentLongTask}
+	case strings.Contains(classification, "TOOL_TASK"):
+		return RouteResult{Intent: IntentToolTask}
+	case strings.Contains(classification, "DIAGNOSE"):
+		return RouteResult{Intent: IntentDiagnose}
+	case strings.Contains(classification, "REMEMBER"):
+		return RouteResult{Intent: IntentRemember}
+	case strings.Contains(classification, "CHAT"):
+		return RouteResult{Intent: IntentChat}
+	case strings.Contains(classification, "ANSWER"):
+		return RouteResult{Intent: IntentAnswer}
+	// Legacy compat: if LLM still says TASK, map to LONG_TASK
+	case strings.Contains(classification, "TASK"):
+		return RouteResult{Intent: IntentLongTask}
+	default:
+		return RouteResult{Intent: IntentAnswer}
+	}
+}
+
+// matchesAny returns true if text contains any of the trigger phrases.
+func matchesAny(text string, triggers []string) bool {
+	for _, t := range triggers {
+		if strings.Contains(text, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsAnyWord checks if text contains any of the given words/phrases.
+func containsAnyWord(text string, words []string) bool {
+	for _, w := range words {
+		if strings.Contains(text, w) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -48,10 +48,14 @@ func NewIntentRouter(skills core.SkillRegistry, llm core.LLMProvider) *IntentRou
 	return &IntentRouter{skills: skills, llm: llm}
 }
 
-// commandPrefixes that are handled by handleProviderCommand.
+// commandExact are commands matched exactly (no arguments).
+var commandExact = []string{
+	"/model", "/models", "/help", "/status", "/tasks",
+}
+
+// commandPrefixes are commands that take arguments — matched as prefix+" ".
 var commandPrefixes = []string{
-	"/model", "/models", "/use ", "/auth ",
-	"/help", "/status", "/tasks", "/task ", "/cancel ",
+	"/use ", "/auth ", "/task ", "/cancel ",
 }
 
 // greetings that should always route to chat.
@@ -157,9 +161,14 @@ var selfSkillMap = []struct {
 func (r *IntentRouter) Classify(ctx context.Context, input string) RouteResult {
 	lower := strings.ToLower(strings.TrimSpace(input))
 
-	// 1. Command prefix — handled by handleProviderCommand / task commands
+	// 1. Commands — exact match or prefix with arguments
+	for _, cmd := range commandExact {
+		if lower == cmd {
+			return RouteResult{Intent: IntentCommand}
+		}
+	}
 	for _, prefix := range commandPrefixes {
-		if strings.HasPrefix(lower, prefix) || lower == strings.TrimSpace(prefix) {
+		if strings.HasPrefix(lower, prefix) {
 			return RouteResult{Intent: IntentCommand}
 		}
 	}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -49,8 +49,11 @@ func NewIntentRouter(skills core.SkillRegistry, llm core.LLMProvider) *IntentRou
 }
 
 // commandExact are commands matched exactly (no arguments).
+// Note: /status and /help are handled by platform bots (Telegram, Discord)
+// directly in their command dispatch, not by the agent. They are NOT listed
+// here so that "status" or "help" in natural language falls through to chat.
 var commandExact = []string{
-	"/model", "/models", "/help", "/status", "/tasks",
+	"/model", "/models", "/tasks",
 }
 
 // commandPrefixes are commands that take arguments — matched as prefix+" ".

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -215,7 +215,6 @@ func TestRouterDeterministicCommand(t *testing.T) {
 		"/models",
 		"/use codex",
 		"/auth claude",
-		"/help",
 		"/tasks",
 		"/task 001",
 		"/cancel 001",

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -1,0 +1,438 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+func newTestRouter(llmResponse string) *IntentRouter {
+	return NewIntentRouter(
+		&mockSkillRegistry{},
+		&MockProvider{chatResponse: llmResponse},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic routing tests
+// ---------------------------------------------------------------------------
+
+func TestRouterDeterministicChat(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"hi", "hello", "hey", "what's up",
+		"good morning", "yo",
+		"thanks", // short, no action verb
+		"cool",   // short, no action verb
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentChat {
+			t.Errorf("Classify(%q) = %s, want CHAT", input, result.Intent)
+		}
+	}
+}
+
+func TestRouterDeterministicRememberStore(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"remember that I prefer Go",
+		"learn that my name is Sourav",
+		"memorize this: I like dark mode",
+		"note that I use vim",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentRemember {
+			t.Errorf("Classify(%q) = %s, want REMEMBER", input, result.Intent)
+		}
+		if result.ToolName != "store" {
+			t.Errorf("Classify(%q).ToolName = %q, want 'store'", input, result.ToolName)
+		}
+	}
+}
+
+func TestRouterDeterministicRememberRecall(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"what do you remember about me",
+		"do you remember our last conversation",
+		"what have you learned",
+		"we talked about this last time",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentRemember && result.Intent != IntentSelfSkill {
+			t.Errorf("Classify(%q) = %s, want REMEMBER or SELF_SKILL", input, result.Intent)
+		}
+	}
+}
+
+func TestRouterDeterministicRememberForget(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"forget that I like Python",
+		"forget about the old project",
+		"delete memory about coffee",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentRemember {
+			t.Errorf("Classify(%q) = %s, want REMEMBER", input, result.Intent)
+		}
+		if result.ToolName != "forget" {
+			t.Errorf("Classify(%q).ToolName = %q, want 'forget'", input, result.ToolName)
+		}
+	}
+}
+
+func TestRouterDeterministicToolTaskTime(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"what time is it",
+		"what's the date today",
+		"what day is it",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentToolTask {
+			t.Errorf("Classify(%q) = %s, want TOOL_TASK", input, result.Intent)
+		}
+		if result.ToolName != "time" {
+			t.Errorf("Classify(%q).ToolName = %q, want 'time'", input, result.ToolName)
+		}
+	}
+}
+
+func TestRouterDeterministicToolTaskSearch(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"search for Go testing best practices",
+		"google kubernetes deployment",
+		"look up rust async patterns",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentToolTask {
+			t.Errorf("Classify(%q) = %s, want TOOL_TASK", input, result.Intent)
+		}
+		if result.ToolName != "search" {
+			t.Errorf("Classify(%q).ToolName = %q, want 'search'", input, result.ToolName)
+		}
+	}
+}
+
+func TestRouterDeterministicToolTaskSysInfo(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"system info",
+		"how much ram do I have",
+		"what os am I running",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentToolTask {
+			t.Errorf("Classify(%q) = %s, want TOOL_TASK", input, result.Intent)
+		}
+		if result.ToolName != "sysinfo" {
+			t.Errorf("Classify(%q).ToolName = %q, want 'sysinfo'", input, result.ToolName)
+		}
+	}
+}
+
+func TestRouterDeterministicToolTaskYouTube(t *testing.T) {
+	r := newTestRouter("CHAT")
+	input := "summarize https://youtube.com/watch?v=abc123"
+	result := r.Classify(context.Background(), input)
+	if result.Intent != IntentToolTask {
+		t.Errorf("Classify(youtube URL) = %s, want TOOL_TASK", result.Intent)
+	}
+	if result.ToolName != "youtube" {
+		t.Errorf("Classify(youtube URL).ToolName = %q, want 'youtube'", result.ToolName)
+	}
+}
+
+func TestRouterDeterministicToolTaskWeb(t *testing.T) {
+	r := newTestRouter("CHAT")
+	input := "read https://example.com/article"
+	result := r.Classify(context.Background(), input)
+	if result.Intent != IntentToolTask {
+		t.Errorf("Classify(web URL) = %s, want TOOL_TASK", result.Intent)
+	}
+	if result.ToolName != "web" {
+		t.Errorf("Classify(web URL).ToolName = %q, want 'web'", result.ToolName)
+	}
+}
+
+func TestRouterDeterministicSelfSkill(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []struct {
+		input string
+		skill string
+	}{
+		{"what can you do", "self:skills"},
+		{"your personality", "self:inspect"},
+		{"your status", "self:status"},
+		{"your health", "self:health"},
+		{"your config", "self:config"},
+		{"evolve your personality", "self:evolve"},
+		{"heal yourself", "self:heal"},
+	}
+	for _, tc := range cases {
+		result := r.Classify(context.Background(), tc.input)
+		if result.Intent != IntentSelfSkill {
+			t.Errorf("Classify(%q) = %s, want SELF_SKILL", tc.input, result.Intent)
+		}
+		if result.SkillName != tc.skill {
+			t.Errorf("Classify(%q).SkillName = %q, want %q", tc.input, result.SkillName, tc.skill)
+		}
+	}
+}
+
+func TestRouterDeterministicDiagnose(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"why did I get this error?",
+		"why is my server crashing?",
+		"what went wrong with the deploy",
+		"I got a connection refused error, what does it mean?",
+		"why am i getting a 404?",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentDiagnose {
+			t.Errorf("Classify(%q) = %s, want DIAGNOSE", input, result.Intent)
+		}
+	}
+}
+
+func TestRouterDeterministicCommand(t *testing.T) {
+	r := newTestRouter("CHAT")
+	cases := []string{
+		"/model",
+		"/models",
+		"/use codex",
+		"/auth claude",
+		"/help",
+		"/tasks",
+		"/task 001",
+		"/cancel 001",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentCommand {
+			t.Errorf("Classify(%q) = %s, want COMMAND", input, result.Intent)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LLM fallback tests
+// ---------------------------------------------------------------------------
+
+func TestRouterLLMFallbackLongTask(t *testing.T) {
+	// Ambiguous input that doesn't match any deterministic pattern
+	r := newTestRouter("LONG_TASK")
+	result := r.Classify(context.Background(), "please refactor the authentication module thoroughly")
+	if result.Intent != IntentLongTask {
+		t.Errorf("Classify(ambiguous) = %s, want LONG_TASK", result.Intent)
+	}
+}
+
+func TestRouterLLMFallbackAnswer(t *testing.T) {
+	r := newTestRouter("ANSWER")
+	result := r.Classify(context.Background(), "how does garbage collection work in Go")
+	if result.Intent != IntentAnswer {
+		t.Errorf("Classify(question) = %s, want ANSWER", result.Intent)
+	}
+}
+
+func TestRouterLLMFallbackLegacyTask(t *testing.T) {
+	// Old-style "TASK" response should map to LONG_TASK for backward compat
+	r := newTestRouter("TASK")
+	result := r.Classify(context.Background(), "please refactor the authentication module thoroughly")
+	if result.Intent != IntentLongTask {
+		t.Errorf("Classify(legacy TASK) = %s, want LONG_TASK", result.Intent)
+	}
+}
+
+func TestRouterLLMFailureDefaultsToAnswer(t *testing.T) {
+	// When LLM returns gibberish, default to ANSWER (safe, still helpful)
+	r := newTestRouter("blah blah nonsense")
+	result := r.Classify(context.Background(), "please refactor the authentication module thoroughly")
+	if result.Intent != IntentAnswer {
+		t.Errorf("Classify(LLM gibberish) = %s, want ANSWER", result.Intent)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Auto-execute vs approval tests
+// ---------------------------------------------------------------------------
+
+func TestShouldRequireApprovalAlways(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "always"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	plan := &core.Plan{
+		Task:  "small task",
+		Steps: []core.PlanStep{{ID: 1, Description: "do something"}},
+	}
+
+	if !a.shouldRequireApproval(plan) {
+		t.Error("PlanApproval=always should always require approval")
+	}
+}
+
+func TestShouldRequireApprovalNever(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "never"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	plan := &core.Plan{
+		Task: "dangerous task",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "delete everything"},
+			{ID: 2, Description: "deploy to prod"},
+			{ID: 3, Description: "remove all data"},
+			{ID: 4, Description: "push to main"},
+			{ID: 5, Description: "reset database"},
+		},
+	}
+
+	if a.shouldRequireApproval(plan) {
+		t.Error("PlanApproval=never should never require approval")
+	}
+}
+
+func TestShouldRequireApprovalAutoSmallSafe(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "auto"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	// 3 steps, no destructive operations
+	plan := &core.Plan{
+		Task: "check the repo",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "list files"},
+			{ID: 2, Description: "read README"},
+			{ID: 3, Description: "summarize findings"},
+		},
+	}
+
+	if a.shouldRequireApproval(plan) {
+		t.Error("auto mode: 3-step non-destructive plan should NOT require approval")
+	}
+}
+
+func TestShouldRequireApprovalAutoLargePlan(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "auto"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	// 6 steps
+	plan := &core.Plan{
+		Task: "refactor auth",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "analyze code"},
+			{ID: 2, Description: "plan changes"},
+			{ID: 3, Description: "write new module"},
+			{ID: 4, Description: "update tests"},
+			{ID: 5, Description: "run tests"},
+			{ID: 6, Description: "document changes"},
+		},
+	}
+
+	if !a.shouldRequireApproval(plan) {
+		t.Error("auto mode: 6-step plan should require approval")
+	}
+}
+
+func TestShouldRequireApprovalAutoDestructiveStep(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "auto"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	// 2 steps but one is destructive
+	plan := &core.Plan{
+		Task: "clean up",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "find old files"},
+			{ID: 2, Description: "delete unused modules"},
+		},
+	}
+
+	if !a.shouldRequireApproval(plan) {
+		t.Error("auto mode: plan with 'delete' step should require approval")
+	}
+}
+
+func TestShouldRequireApprovalAutoVagueTask(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "auto"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	// Vague task
+	plan := &core.Plan{
+		Task: "improve everything in the whole project",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "analyze code"},
+			{ID: 2, Description: "make improvements"},
+		},
+	}
+
+	if !a.shouldRequireApproval(plan) {
+		t.Error("auto mode: vague task should require approval")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// detectSelfSkillTrigger
+// ---------------------------------------------------------------------------
+
+func TestDetectSelfSkillTrigger(t *testing.T) {
+	cases := []struct {
+		input string
+		skill string
+	}{
+		{"what can you do", "self:skills"},
+		{"who are you", "self:inspect"},
+		{"check yourself", "self:health"},
+		{"your uptime", "self:status"},
+		{"show config", "self:config"},
+		{"no match here", ""},
+	}
+
+	for _, tc := range cases {
+		skill, _ := detectSelfSkillTrigger(tc.input)
+		if skill != tc.skill {
+			t.Errorf("detectSelfSkillTrigger(%q) = %q, want %q", tc.input, skill, tc.skill)
+		}
+	}
+}

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -228,6 +228,15 @@ func TestRouterDeterministicCommand(t *testing.T) {
 	}
 }
 
+func TestRouterCommandDoesNotOvermatch(t *testing.T) {
+	r := newTestRouter("ANSWER")
+	// "/help me debug this" should NOT match /help — it's a question
+	result := r.Classify(context.Background(), "/help me debug this")
+	if result.Intent == IntentCommand {
+		t.Error("Classify('/help me debug this') should NOT match COMMAND")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // LLM fallback tests
 // ---------------------------------------------------------------------------
@@ -380,12 +389,36 @@ func TestShouldRequireApprovalAutoDestructiveStep(t *testing.T) {
 		Task: "clean up",
 		Steps: []core.PlanStep{
 			{ID: 1, Description: "find old files"},
-			{ID: 2, Description: "delete unused modules"},
+			{ID: 2, Description: "delete file unused_module.go"},
 		},
 	}
 
 	if !a.shouldRequireApproval(plan) {
 		t.Error("auto mode: plan with 'delete' step should require approval")
+	}
+}
+
+func TestShouldRequireApprovalAutoNoFalsePositives(t *testing.T) {
+	a := New(
+		config.AgentConfig{Name: "test", PlanApproval: "auto"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+
+	// Benign steps containing substrings of danger words should NOT trigger approval
+	plan := &core.Plan{
+		Task: "build a dropdown menu",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "create a drop-down component"},
+			{ID: 2, Description: "add push notification support"},
+			{ID: 3, Description: "reset filter state on close"},
+		},
+	}
+
+	if a.shouldRequireApproval(plan) {
+		t.Error("auto mode: plan with 'drop-down', 'push notification', 'reset filter' should NOT require approval (word boundary matching)")
 	}
 }
 

--- a/internal/agent/taskrunner.go
+++ b/internal/agent/taskrunner.go
@@ -8,6 +8,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/srvsngh99/mini-krill/internal/brain"
 	"github.com/srvsngh99/mini-krill/internal/core"
 	log "github.com/srvsngh99/mini-krill/internal/log"
 )
@@ -109,7 +110,7 @@ func (r *TaskRunner) notify(task *DurableTask, message string) {
 	r.notifyFn(task.Platform, task.ChatID, message)
 }
 
-// storeAsMemory saves a task outcome as a durable memory.
+// storeAsMemory saves a task outcome as a durable memory and generates a reflection.
 func (r *TaskRunner) storeAsMemory(task *DurableTask, result string) {
 	mem := r.agent.brain.Memory()
 	if mem == nil {
@@ -122,11 +123,21 @@ func (r *TaskRunner) storeAsMemory(task *DurableTask, result string) {
 		Key:        key,
 		Value:      fmt.Sprintf("Task: %s\nResult: %s", task.Task, summary),
 		Tags:       []string{"task-outcome", task.ID},
+		Scope:      "task-outcome",
+		Source:     "task-outcome",
 		CreatedAt:  time.Now(),
 		AccessedAt: time.Now(),
 	}
 
 	if err := mem.Store(context.Background(), entry); err != nil {
 		log.Debug("failed to store task outcome", "id", task.ID, "error", err)
+	}
+
+	// Generate a structured reflection if the memory is a FileMemory
+	if fileMem, ok := mem.(*brain.FileMemory); ok {
+		consolidator := brain.NewConsolidator(fileMem, r.agent.llm)
+		if err := consolidator.ReflectOnTask(context.Background(), result, task.Task); err != nil {
+			log.Debug("task reflection failed", "id", task.ID, "error", err)
+		}
 	}
 }

--- a/internal/agent/taskrunner.go
+++ b/internal/agent/taskrunner.go
@@ -5,6 +5,7 @@ package agent
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -21,6 +22,7 @@ type NotifyFunc func(platform, chatID, message string)
 type TaskRunner struct {
 	store         *TaskStore
 	agent         *KrillAgent
+	notifyMu      sync.RWMutex // guards notifyFn
 	notifyFn      NotifyFunc
 	maxConcurrent int32
 	running       int32 // atomic counter
@@ -39,18 +41,22 @@ func NewTaskRunner(store *TaskStore, agent *KrillAgent, maxConcurrent int) *Task
 }
 
 // SetNotifyFunc sets the callback for delivering results to chat platforms.
+// Must be called before any Submit calls.
 func (r *TaskRunner) SetNotifyFunc(fn NotifyFunc) {
+	r.notifyMu.Lock()
+	defer r.notifyMu.Unlock()
 	r.notifyFn = fn
 }
 
 // Submit queues a task for background execution.
 func (r *TaskRunner) Submit(task *DurableTask) error {
-	current := atomic.LoadInt32(&r.running)
-	if current >= r.maxConcurrent {
-		return fmt.Errorf("too many concurrent tasks (%d/%d), try again later", current, r.maxConcurrent)
+	// Add first, then check — avoids TOCTOU race between Load and Add.
+	newCount := atomic.AddInt32(&r.running, 1)
+	if newCount > r.maxConcurrent {
+		atomic.AddInt32(&r.running, -1) // rollback
+		return fmt.Errorf("too many concurrent tasks (%d/%d), try again later", newCount-1, r.maxConcurrent)
 	}
 
-	atomic.AddInt32(&r.running, 1)
 	go r.run(task)
 	return nil
 }
@@ -104,10 +110,13 @@ func (r *TaskRunner) run(task *DurableTask) {
 
 // notify sends the result back to the user's chat platform.
 func (r *TaskRunner) notify(task *DurableTask, message string) {
-	if r.notifyFn == nil {
+	r.notifyMu.RLock()
+	fn := r.notifyFn
+	r.notifyMu.RUnlock()
+	if fn == nil {
 		return
 	}
-	r.notifyFn(task.Platform, task.ChatID, message)
+	fn(task.Platform, task.ChatID, message)
 }
 
 // storeAsMemory saves a task outcome as a durable memory and generates a reflection.

--- a/internal/agent/taskrunner.go
+++ b/internal/agent/taskrunner.go
@@ -15,15 +15,22 @@ import (
 )
 
 // NotifyFunc is called when a background task finishes to deliver the result
-// back to the user on their chat platform.
+// back to the user on their chat platform. The platform argument is included
+// for legacy single-notifier wiring; per-platform routing should be done via
+// RegisterNotifier so each platform's callback only sees its own deliveries.
 type NotifyFunc func(platform, chatID, message string)
+
+// PlatformNotifyFunc is the per-platform variant — chatID and message only,
+// since platform identity is implicit in the registration.
+type PlatformNotifyFunc func(chatID, message string)
 
 // TaskRunner manages the execution of durable tasks in background goroutines.
 type TaskRunner struct {
 	store         *TaskStore
 	agent         *KrillAgent
-	notifyMu      sync.RWMutex // guards notifyFn
+	notifyMu      sync.RWMutex // guards notifyFn and notifiers
 	notifyFn      NotifyFunc
+	notifiers     map[string]PlatformNotifyFunc // platform → handler
 	maxConcurrent int32
 	running       int32 // atomic counter
 }
@@ -36,16 +43,30 @@ func NewTaskRunner(store *TaskStore, agent *KrillAgent, maxConcurrent int) *Task
 	return &TaskRunner{
 		store:         store,
 		agent:         agent,
+		notifiers:     make(map[string]PlatformNotifyFunc),
 		maxConcurrent: int32(maxConcurrent),
 	}
 }
 
-// SetNotifyFunc sets the callback for delivering results to chat platforms.
-// Must be called before any Submit calls.
+// SetNotifyFunc sets a single catch-all callback for delivering results to
+// chat platforms. Kept for backward compatibility — prefer RegisterNotifier
+// when more than one platform is involved.
 func (r *TaskRunner) SetNotifyFunc(fn NotifyFunc) {
 	r.notifyMu.Lock()
 	defer r.notifyMu.Unlock()
 	r.notifyFn = fn
+}
+
+// RegisterNotifier attaches a per-platform delivery callback. Calls for other
+// platforms fall through to the global SetNotifyFunc handler if one is set.
+func (r *TaskRunner) RegisterNotifier(platform string, fn PlatformNotifyFunc) {
+	r.notifyMu.Lock()
+	defer r.notifyMu.Unlock()
+	if fn == nil {
+		delete(r.notifiers, platform)
+		return
+	}
+	r.notifiers[platform] = fn
 }
 
 // Submit queues a task for background execution.
@@ -108,15 +129,22 @@ func (r *TaskRunner) run(task *DurableTask) {
 	r.storeAsMemory(task, result)
 }
 
-// notify sends the result back to the user's chat platform.
+// notify sends the result back to the user's chat platform. Per-platform
+// handlers (RegisterNotifier) take precedence; the catch-all NotifyFunc is
+// used when no platform-specific handler is registered.
 func (r *TaskRunner) notify(task *DurableTask, message string) {
 	r.notifyMu.RLock()
-	fn := r.notifyFn
+	platformFn := r.notifiers[task.Platform]
+	fallback := r.notifyFn
 	r.notifyMu.RUnlock()
-	if fn == nil {
+
+	if platformFn != nil {
+		platformFn(task.ChatID, message)
 		return
 	}
-	fn(task.Platform, task.ChatID, message)
+	if fallback != nil {
+		fallback(task.Platform, task.ChatID, message)
+	}
 }
 
 // storeAsMemory saves a task outcome as a durable memory and generates a reflection.

--- a/internal/agent/taskrunner.go
+++ b/internal/agent/taskrunner.go
@@ -1,0 +1,132 @@
+// Package agent — taskrunner.go executes durable tasks in background goroutines
+// so long-running work survives Telegram and CLI timeouts.
+package agent
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// NotifyFunc is called when a background task finishes to deliver the result
+// back to the user on their chat platform.
+type NotifyFunc func(platform, chatID, message string)
+
+// TaskRunner manages the execution of durable tasks in background goroutines.
+type TaskRunner struct {
+	store         *TaskStore
+	agent         *KrillAgent
+	notifyFn      NotifyFunc
+	maxConcurrent int32
+	running       int32 // atomic counter
+}
+
+// NewTaskRunner creates a runner wired to a task store and agent.
+func NewTaskRunner(store *TaskStore, agent *KrillAgent, maxConcurrent int) *TaskRunner {
+	if maxConcurrent <= 0 {
+		maxConcurrent = 3
+	}
+	return &TaskRunner{
+		store:         store,
+		agent:         agent,
+		maxConcurrent: int32(maxConcurrent),
+	}
+}
+
+// SetNotifyFunc sets the callback for delivering results to chat platforms.
+func (r *TaskRunner) SetNotifyFunc(fn NotifyFunc) {
+	r.notifyFn = fn
+}
+
+// Submit queues a task for background execution.
+func (r *TaskRunner) Submit(task *DurableTask) error {
+	current := atomic.LoadInt32(&r.running)
+	if current >= r.maxConcurrent {
+		return fmt.Errorf("too many concurrent tasks (%d/%d), try again later", current, r.maxConcurrent)
+	}
+
+	atomic.AddInt32(&r.running, 1)
+	go r.run(task)
+	return nil
+}
+
+// run executes a single task: plan, execute, store result, notify.
+func (r *TaskRunner) run(task *DurableTask) {
+	defer atomic.AddInt32(&r.running, -1)
+
+	// Create a cancellable context
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	r.store.SetCancel(task.ID, cancel)
+	r.store.Update(task.ID, "running", "", "")
+
+	log.Info("task runner: starting", "id", task.ID, "task", truncate(task.Task, 60))
+
+	// Generate and execute a plan
+	plan, err := r.agent.Plan(ctx, task.Task)
+	if err != nil {
+		r.store.Update(task.ID, "failed", "", fmt.Sprintf("plan generation failed: %v", err))
+		r.notify(task, fmt.Sprintf("Task %s failed during planning: %v", task.ID, err))
+		log.Error("task runner: plan failed", "id", task.ID, "error", err)
+		return
+	}
+
+	plan.Approved = true
+	result, err := r.agent.ExecutePlan(ctx, plan)
+	if err != nil {
+		errMsg := fmt.Sprintf("execution failed: %v", err)
+		// Check if cancelled
+		if ctx.Err() == context.Canceled {
+			r.store.Update(task.ID, "cancelled", result, "cancelled by user")
+			r.notify(task, fmt.Sprintf("Task %s was cancelled.", task.ID))
+			log.Info("task runner: cancelled", "id", task.ID)
+			return
+		}
+		r.store.Update(task.ID, "failed", result, errMsg)
+		r.notify(task, fmt.Sprintf("Task %s failed: %v\n\nPartial results:\n%s", task.ID, err, truncate(result, 2000)))
+		log.Error("task runner: execution failed", "id", task.ID, "error", err)
+		return
+	}
+
+	r.store.Update(task.ID, "done", result, "")
+	r.notify(task, fmt.Sprintf("Task %s completed!\n\n%s", task.ID, truncate(result, 3000)))
+	log.Info("task runner: completed", "id", task.ID)
+
+	// Store result as a memory entry for future recall
+	r.storeAsMemory(task, result)
+}
+
+// notify sends the result back to the user's chat platform.
+func (r *TaskRunner) notify(task *DurableTask, message string) {
+	if r.notifyFn == nil {
+		return
+	}
+	r.notifyFn(task.Platform, task.ChatID, message)
+}
+
+// storeAsMemory saves a task outcome as a durable memory.
+func (r *TaskRunner) storeAsMemory(task *DurableTask, result string) {
+	mem := r.agent.brain.Memory()
+	if mem == nil {
+		return
+	}
+
+	key := fmt.Sprintf("task_outcome_%s", task.ID)
+	summary := truncate(result, 500)
+	entry := core.MemoryEntry{
+		Key:        key,
+		Value:      fmt.Sprintf("Task: %s\nResult: %s", task.Task, summary),
+		Tags:       []string{"task-outcome", task.ID},
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	}
+
+	if err := mem.Store(context.Background(), entry); err != nil {
+		log.Debug("failed to store task outcome", "id", task.ID, "error", err)
+	}
+}

--- a/internal/agent/taskrunner_test.go
+++ b/internal/agent/taskrunner_test.go
@@ -181,3 +181,83 @@ func TestAgentHandleTaskCommand(t *testing.T) {
 		t.Errorf("/cancel response = %q, expected 'not found'", resp)
 	}
 }
+
+func TestTaskRunnerPerPlatformNotifier(t *testing.T) {
+	agent := newTaskTestAgent()
+	store := NewTaskStore("")
+	runner := NewTaskRunner(store, agent, 3)
+
+	var (
+		mu             sync.Mutex
+		telegramCalls  int
+		discordCalls   int
+		fallbackCalls  int
+		telegramChatID string
+	)
+
+	runner.RegisterNotifier("telegram", func(chatID, message string) {
+		mu.Lock()
+		telegramCalls++
+		telegramChatID = chatID
+		mu.Unlock()
+	})
+	runner.RegisterNotifier("discord", func(chatID, message string) {
+		mu.Lock()
+		discordCalls++
+		mu.Unlock()
+	})
+	runner.SetNotifyFunc(func(platform, chatID, message string) {
+		mu.Lock()
+		fallbackCalls++
+		mu.Unlock()
+	})
+
+	tg := store.Create("u1", "telegram", "tg-chat-1", "telegram task")
+	if err := runner.Submit(tg); err != nil {
+		t.Fatalf("Submit telegram: %v", err)
+	}
+	cli := store.Create("u2", "cli", "", "cli task")
+	if err := runner.Submit(cli); err != nil {
+		t.Fatalf("Submit cli: %v", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got, _ := store.Get(cli.ID)
+		got2, _ := store.Get(tg.ID)
+		if (got.Status == "done" || got.Status == "failed") &&
+			(got2.Status == "done" || got2.Status == "failed") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	// Allow notify goroutines to finish.
+	time.Sleep(100 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	if telegramCalls != 1 {
+		t.Errorf("telegram notifier called %d times, want 1", telegramCalls)
+	}
+	if telegramChatID != "tg-chat-1" {
+		t.Errorf("telegram chat ID = %q, want 'tg-chat-1'", telegramChatID)
+	}
+	if discordCalls != 0 {
+		t.Errorf("discord notifier called %d times, want 0", discordCalls)
+	}
+	// CLI has no platform handler → falls through to global notifier.
+	if fallbackCalls != 1 {
+		t.Errorf("fallback notifier called %d times, want 1 (cli task)", fallbackCalls)
+	}
+}
+
+func TestTaskRunnerRegisterNotifierUnregister(t *testing.T) {
+	runner := NewTaskRunner(NewTaskStore(""), newTaskTestAgent(), 3)
+	called := 0
+	runner.RegisterNotifier("telegram", func(chatID, message string) { called++ })
+	runner.RegisterNotifier("telegram", nil) // unregister
+	runner.notify(&DurableTask{Platform: "telegram", ChatID: "x"}, "hi")
+	if called != 0 {
+		t.Errorf("notifier should be unregistered, got %d calls", called)
+	}
+}

--- a/internal/agent/taskrunner_test.go
+++ b/internal/agent/taskrunner_test.go
@@ -42,7 +42,7 @@ func TestTaskRunnerSubmitAndComplete(t *testing.T) {
 		t.Fatalf("Submit error: %v", err)
 	}
 
-	// Wait for completion
+	// Wait for completion — Get returns a value copy, safe to read without lock
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		got, ok := store.Get(dt.ID)

--- a/internal/agent/taskrunner_test.go
+++ b/internal/agent/taskrunner_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
 )
 
 func newTaskTestAgent() *KrillAgent {
@@ -111,6 +112,41 @@ func TestAgentTaskManagerInterface(t *testing.T) {
 	_, ok := agent.GetTask("nonexistent")
 	if ok {
 		t.Error("GetTask(nonexistent) should return false")
+	}
+}
+
+func TestShouldRunInBackgroundTelegram(t *testing.T) {
+	agent := newTaskTestAgent()
+	agent.InitTaskSystem("", 3)
+	agent.SetPlatform("telegram")
+
+	// Multi-step plan on telegram should run in background
+	plan := &core.Plan{
+		Task: "check repo",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "list files"},
+			{ID: 2, Description: "read README"},
+		},
+	}
+	if !agent.shouldRunInBackground(plan) {
+		t.Error("shouldRunInBackground(telegram, 2 steps) = false, want true")
+	}
+}
+
+func TestShouldRunInBackgroundCLI(t *testing.T) {
+	agent := newTaskTestAgent()
+	agent.InitTaskSystem("", 3)
+	agent.SetPlatform("cli")
+
+	plan := &core.Plan{
+		Task: "check repo",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "list files"},
+			{ID: 2, Description: "read README"},
+		},
+	}
+	if agent.shouldRunInBackground(plan) {
+		t.Error("shouldRunInBackground(cli, 2 steps) = true, want false (CLI is synchronous)")
 	}
 }
 

--- a/internal/agent/taskrunner_test.go
+++ b/internal/agent/taskrunner_test.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+)
+
+func newTaskTestAgent() *KrillAgent {
+	return New(
+		config.AgentConfig{Name: "task-test", PlanApproval: "never", MaxSubKrills: 1},
+		&MockProvider{chatResponse: "SUMMARY: test\nSTEP 1: do thing"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+}
+
+func TestTaskRunnerSubmitAndComplete(t *testing.T) {
+	agent := newTaskTestAgent()
+	store := NewTaskStore("")
+	runner := NewTaskRunner(store, agent, 3)
+
+	var notified bool
+	var notifyMsg string
+	var mu sync.Mutex
+
+	runner.SetNotifyFunc(func(platform, chatID, message string) {
+		mu.Lock()
+		notified = true
+		notifyMsg = message
+		mu.Unlock()
+	})
+
+	dt := store.Create("user1", "test", "chat1", "simple task")
+	err := runner.Submit(dt)
+	if err != nil {
+		t.Fatalf("Submit error: %v", err)
+	}
+
+	// Wait for completion
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		got, ok := store.Get(dt.ID)
+		if ok && (got.Status == "done" || got.Status == "failed") {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	got, _ := store.Get(dt.ID)
+	if got.Status != "done" && got.Status != "failed" {
+		t.Errorf("task status = %q, want done or failed", got.Status)
+	}
+
+	mu.Lock()
+	wasNotified := notified
+	msg := notifyMsg
+	mu.Unlock()
+
+	if !wasNotified {
+		t.Error("notification callback was not called")
+	}
+	if !strings.Contains(msg, dt.ID) {
+		t.Errorf("notification should contain task ID, got: %s", msg)
+	}
+}
+
+func TestTaskRunnerConcurrencyLimit(t *testing.T) {
+	agent := New(
+		config.AgentConfig{Name: "task-test", PlanApproval: "never", MaxSubKrills: 1},
+		&slowMockProvider{delay: 200 * time.Millisecond, response: "SUMMARY: test\nSTEP 1: do thing"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+	store := NewTaskStore("")
+	runner := NewTaskRunner(store, agent, 1)
+
+	dt1 := store.Create("u", "t", "c", "task 1")
+	err := runner.Submit(dt1)
+	if err != nil {
+		t.Fatalf("Submit(1) error: %v", err)
+	}
+
+	// Give goroutine time to start
+	time.Sleep(20 * time.Millisecond)
+
+	// Second submit should fail (at capacity)
+	dt2 := store.Create("u", "t", "c", "task 2")
+	err = runner.Submit(dt2)
+	if err == nil {
+		t.Error("Submit(2) should fail when at capacity")
+	}
+}
+
+func TestAgentTaskManagerInterface(t *testing.T) {
+	agent := newTaskTestAgent()
+	agent.InitTaskSystem("", 3)
+
+	// List should be empty initially
+	tasks := agent.ListTasks("")
+	if len(tasks) != 0 {
+		t.Errorf("ListTasks initially = %d, want 0", len(tasks))
+	}
+
+	// GetTask should return false for nonexistent
+	_, ok := agent.GetTask("nonexistent")
+	if ok {
+		t.Error("GetTask(nonexistent) should return false")
+	}
+}
+
+func TestAgentHandleTaskCommand(t *testing.T) {
+	agent := newTaskTestAgent()
+	agent.InitTaskSystem("", 3)
+
+	// /tasks with no tasks
+	resp, handled := agent.handleTaskCommand("/tasks")
+	if !handled {
+		t.Error("/tasks should be handled")
+	}
+	if !strings.Contains(resp, "No tasks") {
+		t.Errorf("/tasks response = %q, expected 'No tasks'", resp)
+	}
+
+	// /task nonexistent
+	resp, handled = agent.handleTaskCommand("/task nonexistent")
+	if !handled {
+		t.Error("/task should be handled")
+	}
+	if !strings.Contains(resp, "not found") {
+		t.Errorf("/task response = %q, expected 'not found'", resp)
+	}
+
+	// /cancel nonexistent
+	resp, handled = agent.handleTaskCommand("/cancel nonexistent")
+	if !handled {
+		t.Error("/cancel should be handled")
+	}
+	if !strings.Contains(resp, "not found") {
+		t.Errorf("/cancel response = %q, expected 'not found'", resp)
+	}
+}

--- a/internal/agent/taskstore.go
+++ b/internal/agent/taskstore.go
@@ -1,0 +1,227 @@
+// Package agent — taskstore.go provides durable task tracking so long-running
+// work survives Telegram timeouts and process restarts.
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// DurableTask represents a long-running task that executes in the background.
+type DurableTask struct {
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	Platform  string    `json:"platform"`
+	ChatID    string    `json:"chat_id"`
+	Task      string    `json:"task"`
+	Status    string    `json:"status"` // queued, running, done, failed, cancelled
+	Result    string    `json:"result,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	cancel context.CancelFunc // not serialised
+}
+
+// ToInfo converts a DurableTask to a serialisable TaskInfo.
+func (t *DurableTask) ToInfo() core.TaskInfo {
+	return core.TaskInfo{
+		ID:        t.ID,
+		Task:      t.Task,
+		Status:    t.Status,
+		Result:    t.Result,
+		Error:     t.Error,
+		CreatedAt: t.CreatedAt,
+		UpdatedAt: t.UpdatedAt,
+	}
+}
+
+// TaskStore provides durable, thread-safe task tracking with JSONL persistence.
+type TaskStore struct {
+	mu     sync.RWMutex
+	tasks  map[string]*DurableTask
+	path   string // JSONL file path
+	nextID int
+}
+
+// NewTaskStore creates a store backed by the given JSONL file.
+// Existing tasks are loaded from disk; any that were "running" when the
+// process died are marked as "failed".
+func NewTaskStore(path string) *TaskStore {
+	s := &TaskStore{
+		tasks:  make(map[string]*DurableTask),
+		path:   path,
+		nextID: 1,
+	}
+	s.loadFromDisk()
+	return s
+}
+
+// Create adds a new queued task and persists it.
+func (s *TaskStore) Create(userID, platform, chatID, task string) *DurableTask {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := fmt.Sprintf("task-%03d", s.nextID)
+	s.nextID++
+	now := time.Now().UTC()
+
+	t := &DurableTask{
+		ID:        id,
+		UserID:    userID,
+		Platform:  platform,
+		ChatID:    chatID,
+		Task:      task,
+		Status:    "queued",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	s.tasks[id] = t
+	s.persistLocked()
+	log.Info("task created", "id", id, "task", truncate(task, 60))
+	return t
+}
+
+// Get retrieves a task by ID.
+func (s *TaskStore) Get(id string) (*DurableTask, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	t, ok := s.tasks[id]
+	return t, ok
+}
+
+// List returns tasks for a given user (or all tasks if userID is empty),
+// sorted by creation time descending (newest first).
+func (s *TaskStore) List(userID string) []*DurableTask {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var result []*DurableTask
+	for _, t := range s.tasks {
+		if userID == "" || t.UserID == userID {
+			result = append(result, t)
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		return result[i].CreatedAt.After(result[j].CreatedAt)
+	})
+	return result
+}
+
+// Update sets the status and result/error for a task.
+func (s *TaskStore) Update(id, status, result, errMsg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	t, ok := s.tasks[id]
+	if !ok {
+		return
+	}
+	t.Status = status
+	t.Result = result
+	t.Error = errMsg
+	t.UpdatedAt = time.Now().UTC()
+	s.persistLocked()
+}
+
+// Cancel stops a running task.
+func (s *TaskStore) Cancel(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	t, ok := s.tasks[id]
+	if !ok {
+		return fmt.Errorf("task %q not found", id)
+	}
+	if t.Status != "queued" && t.Status != "running" {
+		return fmt.Errorf("task %q is already %s", id, t.Status)
+	}
+
+	if t.cancel != nil {
+		t.cancel()
+	}
+	t.Status = "cancelled"
+	t.UpdatedAt = time.Now().UTC()
+	s.persistLocked()
+	log.Info("task cancelled", "id", id)
+	return nil
+}
+
+// SetCancel attaches a cancel function to a running task.
+func (s *TaskStore) SetCancel(id string, cancel context.CancelFunc) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if t, ok := s.tasks[id]; ok {
+		t.cancel = cancel
+	}
+}
+
+// persistLocked writes all tasks to the JSONL file. Caller must hold s.mu.
+func (s *TaskStore) persistLocked() {
+	if s.path == "" {
+		return
+	}
+	f, err := os.Create(s.path)
+	if err != nil {
+		log.Warn("failed to persist tasks", "error", err)
+		return
+	}
+	defer f.Close()
+
+	for _, t := range s.tasks {
+		data, err := json.Marshal(t)
+		if err != nil {
+			continue
+		}
+		f.Write(data)
+		f.Write([]byte("\n"))
+	}
+}
+
+// loadFromDisk reads tasks from the JSONL file. Tasks that were "running"
+// when the process died are marked as "failed".
+func (s *TaskStore) loadFromDisk() {
+	if s.path == "" {
+		return
+	}
+	f, err := os.Open(s.path)
+	if err != nil {
+		return // file doesn't exist yet
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var t DurableTask
+		if err := json.Unmarshal(scanner.Bytes(), &t); err != nil {
+			continue
+		}
+		// Mark orphaned running tasks as failed
+		if t.Status == "running" || t.Status == "queued" {
+			t.Status = "failed"
+			t.Error = "process interrupted"
+			t.UpdatedAt = time.Now().UTC()
+		}
+		s.tasks[t.ID] = &t
+		// Track highest ID for next assignment
+		var num int
+		if _, err := fmt.Sscanf(t.ID, "task-%d", &num); err == nil && num >= s.nextID {
+			s.nextID = num + 1
+		}
+	}
+
+	if len(s.tasks) > 0 {
+		log.Info("tasks loaded from disk", "count", len(s.tasks))
+	}
+}

--- a/internal/agent/taskstore.go
+++ b/internal/agent/taskstore.go
@@ -92,24 +92,28 @@ func (s *TaskStore) Create(userID, platform, chatID, task string) *DurableTask {
 	return t
 }
 
-// Get retrieves a task by ID.
-func (s *TaskStore) Get(id string) (*DurableTask, bool) {
+// Get retrieves a copy of a task by ID. Returns a value copy so callers
+// cannot race with Update.
+func (s *TaskStore) Get(id string) (DurableTask, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	t, ok := s.tasks[id]
-	return t, ok
+	if !ok {
+		return DurableTask{}, false
+	}
+	return *t, true
 }
 
-// List returns tasks for a given user (or all tasks if userID is empty),
-// sorted by creation time descending (newest first).
-func (s *TaskStore) List(userID string) []*DurableTask {
+// List returns value copies of tasks for a given user (or all tasks if
+// userID is empty), sorted by creation time descending (newest first).
+func (s *TaskStore) List(userID string) []DurableTask {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	var result []*DurableTask
+	var result []DurableTask
 	for _, t := range s.tasks {
 		if userID == "" || t.UserID == userID {
-			result = append(result, t)
+			result = append(result, *t)
 		}
 	}
 

--- a/internal/agent/taskstore.go
+++ b/internal/agent/taskstore.go
@@ -188,8 +188,14 @@ func (s *TaskStore) persistLocked() {
 		if err != nil {
 			continue
 		}
-		f.Write(data)
-		f.Write([]byte("\n"))
+		if _, err := f.Write(data); err != nil {
+			log.Warn("failed to write task entry", "error", err)
+			return
+		}
+		if _, err := f.Write([]byte("\n")); err != nil {
+			log.Warn("failed to write task separator", "error", err)
+			return
+		}
 	}
 }
 

--- a/internal/agent/taskstore_test.go
+++ b/internal/agent/taskstore_test.go
@@ -30,6 +30,12 @@ func TestTaskStoreCreateAndGet(t *testing.T) {
 	if got.ID != dt.ID {
 		t.Errorf("Get ID = %q, want %q", got.ID, dt.ID)
 	}
+	// Verify Get returns a copy — mutating it should not affect the store
+	got.Status = "mutated"
+	got2, _ := store.Get(dt.ID)
+	if got2.Status == "mutated" {
+		t.Error("Get should return a copy, but mutation leaked back")
+	}
 }
 
 func TestTaskStoreGetNotFound(t *testing.T) {

--- a/internal/agent/taskstore_test.go
+++ b/internal/agent/taskstore_test.go
@@ -1,0 +1,192 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestTaskStoreCreateAndGet(t *testing.T) {
+	store := NewTaskStore("")
+
+	dt := store.Create("user1", "telegram", "chat123", "analyze the repo")
+	if dt == nil {
+		t.Fatal("Create returned nil")
+	}
+	if dt.ID == "" {
+		t.Error("task ID is empty")
+	}
+	if dt.Status != "queued" {
+		t.Errorf("status = %q, want queued", dt.Status)
+	}
+	if dt.Task != "analyze the repo" {
+		t.Errorf("task = %q, want 'analyze the repo'", dt.Task)
+	}
+
+	got, ok := store.Get(dt.ID)
+	if !ok {
+		t.Fatal("Get returned false for just-created task")
+	}
+	if got.ID != dt.ID {
+		t.Errorf("Get ID = %q, want %q", got.ID, dt.ID)
+	}
+}
+
+func TestTaskStoreGetNotFound(t *testing.T) {
+	store := NewTaskStore("")
+	_, ok := store.Get("nonexistent")
+	if ok {
+		t.Error("Get(nonexistent) should return false")
+	}
+}
+
+func TestTaskStoreList(t *testing.T) {
+	store := NewTaskStore("")
+	store.Create("user1", "telegram", "c1", "task A")
+	store.Create("user2", "telegram", "c2", "task B")
+	store.Create("user1", "telegram", "c1", "task C")
+
+	// All tasks
+	all := store.List("")
+	if len(all) != 3 {
+		t.Errorf("List('') = %d tasks, want 3", len(all))
+	}
+
+	// Filter by user
+	u1 := store.List("user1")
+	if len(u1) != 2 {
+		t.Errorf("List(user1) = %d tasks, want 2", len(u1))
+	}
+
+	// Verify sorted by newest first
+	if len(u1) >= 2 && u1[0].CreatedAt.Before(u1[1].CreatedAt) {
+		t.Error("List should return newest first")
+	}
+}
+
+func TestTaskStoreUpdate(t *testing.T) {
+	store := NewTaskStore("")
+	dt := store.Create("user1", "tg", "c1", "test task")
+
+	store.Update(dt.ID, "done", "result text", "")
+
+	got, ok := store.Get(dt.ID)
+	if !ok {
+		t.Fatal("Get failed after update")
+	}
+	if got.Status != "done" {
+		t.Errorf("status = %q, want done", got.Status)
+	}
+	if got.Result != "result text" {
+		t.Errorf("result = %q, want 'result text'", got.Result)
+	}
+}
+
+func TestTaskStoreCancel(t *testing.T) {
+	store := NewTaskStore("")
+	dt := store.Create("user1", "tg", "c1", "cancellable task")
+
+	err := store.Cancel(dt.ID)
+	if err != nil {
+		t.Fatalf("Cancel error: %v", err)
+	}
+
+	got, _ := store.Get(dt.ID)
+	if got.Status != "cancelled" {
+		t.Errorf("status = %q, want cancelled", got.Status)
+	}
+}
+
+func TestTaskStoreCancelAlreadyDone(t *testing.T) {
+	store := NewTaskStore("")
+	dt := store.Create("user1", "tg", "c1", "done task")
+	store.Update(dt.ID, "done", "result", "")
+
+	err := store.Cancel(dt.ID)
+	if err == nil {
+		t.Error("cancelling a done task should return error")
+	}
+}
+
+func TestTaskStoreCancelNotFound(t *testing.T) {
+	store := NewTaskStore("")
+	err := store.Cancel("nonexistent")
+	if err == nil {
+		t.Error("cancelling nonexistent task should return error")
+	}
+}
+
+func TestTaskStorePersistAndLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.jsonl")
+
+	// Create tasks and persist
+	store1 := NewTaskStore(path)
+	dt1 := store1.Create("user1", "tg", "c1", "task one")
+	store1.Update(dt1.ID, "done", "result one", "")
+	dt2 := store1.Create("user1", "tg", "c1", "task two")
+	_ = dt2 // still queued
+
+	// Verify file exists
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("tasks file not created: %v", err)
+	}
+
+	// Load from disk in a new store
+	store2 := NewTaskStore(path)
+
+	// Task 1 (was done) should still be done
+	got1, ok := store2.Get(dt1.ID)
+	if !ok {
+		t.Fatal("task one not found after reload")
+	}
+	if got1.Status != "done" {
+		t.Errorf("task one status = %q, want done", got1.Status)
+	}
+
+	// Task 2 (was queued when "crashed") should be marked failed
+	got2, ok := store2.Get(dt2.ID)
+	if !ok {
+		t.Fatal("task two not found after reload")
+	}
+	if got2.Status != "failed" {
+		t.Errorf("task two status = %q, want failed (orphaned)", got2.Status)
+	}
+	if got2.Error != "process interrupted" {
+		t.Errorf("task two error = %q, want 'process interrupted'", got2.Error)
+	}
+}
+
+func TestTaskStoreNextIDAfterReload(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tasks.jsonl")
+
+	store1 := NewTaskStore(path)
+	store1.Create("u", "tg", "c", "a")
+	store1.Create("u", "tg", "c", "b")
+	// nextID should be 3
+
+	store2 := NewTaskStore(path)
+	dt := store2.Create("u", "tg", "c", "c")
+	if dt.ID != "task-003" {
+		t.Errorf("ID after reload = %q, want task-003", dt.ID)
+	}
+}
+
+func TestTaskStoreToInfo(t *testing.T) {
+	store := NewTaskStore("")
+	dt := store.Create("u1", "tg", "c1", "test")
+	store.Update(dt.ID, "done", "result", "")
+
+	got, _ := store.Get(dt.ID)
+	info := got.ToInfo()
+	if info.ID != dt.ID {
+		t.Errorf("ToInfo().ID = %q, want %q", info.ID, dt.ID)
+	}
+	if info.Status != "done" {
+		t.Errorf("ToInfo().Status = %q, want done", info.Status)
+	}
+	if info.Result != "result" {
+		t.Errorf("ToInfo().Result = %q, want 'result'", info.Result)
+	}
+}

--- a/internal/agent/toolbox.go
+++ b/internal/agent/toolbox.go
@@ -108,6 +108,9 @@ func (t *Toolbox) ExecuteTool(ctx context.Context, name string, args map[string]
 		if command == "" {
 			return "", fmt.Errorf("shell tool requires a 'command' argument")
 		}
+		if !IsReadOnlyCommand(command) && !IsBlockedCommand(command) {
+			log.Info("shell: non-read-only command, proceeding with caution", "command", truncate(command, 60))
+		}
 		return ExecuteShellSafe(ctx, command)
 	}
 

--- a/internal/agent/toolbox.go
+++ b/internal/agent/toolbox.go
@@ -1,0 +1,249 @@
+// Package agent — toolbox.go provides a unified tool execution layer.
+// It wraps skills, MCP tools, and safe shell commands so that plan steps
+// can dispatch real work instead of just asking the LLM to narrate.
+package agent
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+const (
+	shellTimeout   = 30 * time.Second
+	maxOutputBytes = 10 * 1024 // 10KB
+)
+
+// ToolDescriptor is a unified representation of any tool the agent can use.
+type ToolDescriptor struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"` // "skill", "mcp", "shell"
+}
+
+// Toolbox wraps skills, MCP tools, and a safe shell executor into a single
+// dispatch interface used during plan step execution.
+type Toolbox struct {
+	skills core.SkillRegistry
+	mcp    core.MCPRegistry
+	llm    core.LLMProvider
+}
+
+// NewToolbox creates a toolbox wired to all available tool backends.
+func NewToolbox(skills core.SkillRegistry, mcp core.MCPRegistry, llm core.LLMProvider) *Toolbox {
+	return &Toolbox{skills: skills, mcp: mcp, llm: llm}
+}
+
+// blockedCommands are shell patterns that are always rejected.
+var blockedCommands = []string{
+	"rm -rf /", "rm -rf /*", "sudo ", "mkfs", "dd if=",
+	"chmod 777", "> /dev/", "curl | sh", "curl |sh",
+	"wget | sh", "wget |sh", ":(){", "shutdown", "reboot",
+	"format ", "fdisk",
+}
+
+// readOnlyCommands are shell commands that can run without approval.
+var readOnlyCommands = []string{
+	"ls", "cat", "head", "tail", "git status", "git log", "git diff",
+	"git branch", "git remote", "find", "grep", "rg", "wc", "file",
+	"stat", "pwd", "echo", "which", "env", "date", "tree",
+	"go version", "node --version", "python --version",
+}
+
+// ExecuteTool dispatches a tool call to the correct backend.
+func (t *Toolbox) ExecuteTool(ctx context.Context, name string, args map[string]string) (string, error) {
+	log.Debug("toolbox dispatch", "tool", name, "args_count", len(args))
+
+	// 1. Check if it's a registered skill
+	if t.skills != nil {
+		if skill, ok := t.skills.Get(name); ok {
+			input := args["input"]
+			if input == "" {
+				// Fall back to joining all args
+				var parts []string
+				for _, v := range args {
+					parts = append(parts, v)
+				}
+				input = strings.Join(parts, " ")
+			}
+			log.Info("toolbox: executing skill", "skill", name)
+			return skill.Execute(ctx, input, t.llm)
+		}
+	}
+
+	// 2. Check if it's an MCP tool
+	if t.mcp != nil {
+		servers := t.mcp.List()
+		for _, info := range servers {
+			if !info.Connected || !info.Enabled {
+				continue
+			}
+			server, ok := t.mcp.Get(info.Name)
+			if !ok {
+				continue
+			}
+			for _, tool := range server.Tools() {
+				if tool.Name == name {
+					// Convert string args to interface{} args for MCP
+					mcpArgs := make(map[string]interface{})
+					for k, v := range args {
+						mcpArgs[k] = v
+					}
+					log.Info("toolbox: executing MCP tool", "tool", name, "server", info.Name)
+					return server.CallTool(ctx, name, mcpArgs)
+				}
+			}
+		}
+	}
+
+	// 3. Shell command
+	if name == "shell" {
+		command := args["command"]
+		if command == "" {
+			return "", fmt.Errorf("shell tool requires a 'command' argument")
+		}
+		return ExecuteShellSafe(ctx, command)
+	}
+
+	return "", fmt.Errorf("unknown tool: %q", name)
+}
+
+// ListTools returns descriptors for all available tools.
+func (t *Toolbox) ListTools() []ToolDescriptor {
+	var tools []ToolDescriptor
+
+	// Add skills
+	if t.skills != nil {
+		for _, info := range t.skills.List() {
+			if info.Enabled && !strings.HasPrefix(info.Name, "self:") {
+				tools = append(tools, ToolDescriptor{
+					Name:        info.Name,
+					Description: info.Description,
+					Source:      "skill",
+				})
+			}
+		}
+	}
+
+	// Add MCP tools
+	if t.mcp != nil {
+		for _, tool := range t.mcp.AllTools() {
+			tools = append(tools, ToolDescriptor{
+				Name:        tool.Name,
+				Description: tool.Description,
+				Source:      "mcp",
+			})
+		}
+	}
+
+	// Add built-in shell tool
+	tools = append(tools, ToolDescriptor{
+		Name:        "shell",
+		Description: "Execute a shell command (read-only commands auto-approved, destructive commands blocked)",
+		Source:      "shell",
+	})
+
+	return tools
+}
+
+// FormatToolsForLLM produces a text block listing all tools for LLM context.
+func (t *Toolbox) FormatToolsForLLM() string {
+	tools := t.ListTools()
+	if len(tools) == 0 {
+		return "No tools available."
+	}
+
+	var sb strings.Builder
+	for _, tool := range tools {
+		sb.WriteString(fmt.Sprintf("- %s [%s]: %s\n", tool.Name, tool.Source, tool.Description))
+	}
+	return sb.String()
+}
+
+// ExecuteShellSafe runs a shell command with safety checks.
+// - Blocked commands are rejected outright.
+// - Read-only commands execute immediately.
+// - Write commands set NeedsApproval on the step (caller decides).
+// Output is capped at maxOutputBytes.
+func ExecuteShellSafe(ctx context.Context, command string) (string, error) {
+	lower := strings.ToLower(strings.TrimSpace(command))
+
+	// Check blocked list
+	for _, blocked := range blockedCommands {
+		if strings.Contains(lower, blocked) {
+			log.Warn("shell command blocked", "command", command, "match", blocked)
+			return "", fmt.Errorf("command blocked for safety: contains %q", blocked)
+		}
+	}
+
+	// Execute with timeout
+	shellCtx, cancel := context.WithTimeout(ctx, shellTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(shellCtx, "sh", "-c", command)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	log.Debug("shell: executing", "command", truncate(command, 80))
+
+	err := cmd.Run()
+
+	// Combine output
+	output := stdout.String()
+	if errOut := stderr.String(); errOut != "" {
+		if output != "" {
+			output += "\n--- stderr ---\n"
+		}
+		output += errOut
+	}
+
+	// Truncate if too large
+	if len(output) > maxOutputBytes {
+		output = output[:maxOutputBytes] + "\n... (output truncated at 10KB)"
+	}
+
+	if err != nil {
+		if shellCtx.Err() == context.DeadlineExceeded {
+			return output, fmt.Errorf("command timed out after %s", shellTimeout)
+		}
+		// Include output even on error — stderr often has useful info
+		return output, fmt.Errorf("command failed: %w", err)
+	}
+
+	if output == "" {
+		output = "(no output)"
+	}
+
+	log.Debug("shell: completed", "output_len", len(output))
+	return output, nil
+}
+
+// IsReadOnlyCommand checks if a command is in the read-only safe list.
+func IsReadOnlyCommand(command string) bool {
+	lower := strings.ToLower(strings.TrimSpace(command))
+	// Extract the base command (first word or first two words for git subcommands)
+	for _, ro := range readOnlyCommands {
+		if strings.HasPrefix(lower, ro+" ") || lower == ro {
+			return true
+		}
+	}
+	return false
+}
+
+// IsBlockedCommand checks if a command matches the blocked list.
+func IsBlockedCommand(command string) bool {
+	lower := strings.ToLower(strings.TrimSpace(command))
+	for _, blocked := range blockedCommands {
+		if strings.Contains(lower, blocked) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/toolbox_test.go
+++ b/internal/agent/toolbox_test.go
@@ -335,9 +335,9 @@ func TestExtractShellCommand(t *testing.T) {
 		want string
 	}{
 		{"Run `ls -la /tmp`", "ls -la /tmp"},
-		{"Execute git status", "git status"},
+		{"Execute `git status`", "git status"},
 		{"List the files in the directory", ""},
-		{"run cat README.md", "cat README.md"},
+		{"run cat README.md", ""},  // no backticks → not extracted
 	}
 	for _, tc := range cases {
 		got := extractShellCommand(tc.desc)

--- a/internal/agent/toolbox_test.go
+++ b/internal/agent/toolbox_test.go
@@ -1,0 +1,348 @@
+package agent
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// ---------------------------------------------------------------------------
+// Mock skill for toolbox tests
+// ---------------------------------------------------------------------------
+
+type mockSkill struct {
+	name   string
+	desc   string
+	result string
+}
+
+func (s *mockSkill) Name() string        { return s.name }
+func (s *mockSkill) Description() string { return s.desc }
+func (s *mockSkill) Execute(_ context.Context, input string, _ core.LLMProvider) (string, error) {
+	return s.result + " (input: " + input + ")", nil
+}
+
+type toolboxSkillRegistry struct {
+	skills map[string]core.Skill
+}
+
+func newToolboxSkillRegistry(skills ...core.Skill) *toolboxSkillRegistry {
+	r := &toolboxSkillRegistry{skills: make(map[string]core.Skill)}
+	for _, s := range skills {
+		r.skills[s.Name()] = s
+	}
+	return r
+}
+
+func (r *toolboxSkillRegistry) Register(s core.Skill) error      { r.skills[s.Name()] = s; return nil }
+func (r *toolboxSkillRegistry) Unregister(name string) error      { delete(r.skills, name); return nil }
+func (r *toolboxSkillRegistry) SetEnabled(_ string, _ bool) error { return nil }
+func (r *toolboxSkillRegistry) IsEnabled(_ string) bool           { return true }
+func (r *toolboxSkillRegistry) Get(name string) (core.Skill, bool) {
+	s, ok := r.skills[name]
+	return s, ok
+}
+func (r *toolboxSkillRegistry) List() []core.SkillInfo {
+	var infos []core.SkillInfo
+	for _, s := range r.skills {
+		infos = append(infos, core.SkillInfo{
+			Name:        s.Name(),
+			Description: s.Description(),
+			Enabled:     true,
+		})
+	}
+	return infos
+}
+
+// ---------------------------------------------------------------------------
+// Toolbox: ExecuteTool tests
+// ---------------------------------------------------------------------------
+
+func TestToolboxExecuteSkill(t *testing.T) {
+	registry := newToolboxSkillRegistry(
+		&mockSkill{name: "search", desc: "Web search", result: "search results"},
+		&mockSkill{name: "time", desc: "Current time", result: "2026-05-10 12:00"},
+	)
+	tb := NewToolbox(registry, nil, &MockProvider{chatResponse: "ok"})
+
+	result, err := tb.ExecuteTool(context.Background(), "search", map[string]string{"input": "Go testing"})
+	if err != nil {
+		t.Fatalf("ExecuteTool(search) error: %v", err)
+	}
+	if !strings.Contains(result, "search results") {
+		t.Errorf("expected search results, got: %s", result)
+	}
+	if !strings.Contains(result, "Go testing") {
+		t.Errorf("expected input to be passed through, got: %s", result)
+	}
+}
+
+func TestToolboxExecuteSkillFallbackArgs(t *testing.T) {
+	registry := newToolboxSkillRegistry(
+		&mockSkill{name: "time", desc: "Current time", result: "2026-05-10"},
+	)
+	tb := NewToolbox(registry, nil, &MockProvider{chatResponse: "ok"})
+
+	// When no "input" key, args should be joined
+	result, err := tb.ExecuteTool(context.Background(), "time", map[string]string{"foo": "bar"})
+	if err != nil {
+		t.Fatalf("ExecuteTool(time) error: %v", err)
+	}
+	if !strings.Contains(result, "2026-05-10") {
+		t.Errorf("expected time result, got: %s", result)
+	}
+}
+
+func TestToolboxShellReadOnly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell tests require Unix")
+	}
+
+	tb := NewToolbox(nil, nil, nil)
+	result, err := tb.ExecuteTool(context.Background(), "shell", map[string]string{"command": "echo hello"})
+	if err != nil {
+		t.Fatalf("ExecuteTool(shell echo) error: %v", err)
+	}
+	if !strings.Contains(result, "hello") {
+		t.Errorf("expected 'hello' in output, got: %s", result)
+	}
+}
+
+func TestToolboxShellPwd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell tests require Unix")
+	}
+
+	tb := NewToolbox(nil, nil, nil)
+	result, err := tb.ExecuteTool(context.Background(), "shell", map[string]string{"command": "pwd"})
+	if err != nil {
+		t.Fatalf("ExecuteTool(shell pwd) error: %v", err)
+	}
+	if result == "" || result == "(no output)" {
+		t.Error("pwd should produce output")
+	}
+}
+
+func TestToolboxShellBlocked(t *testing.T) {
+	tb := NewToolbox(nil, nil, nil)
+	_, err := tb.ExecuteTool(context.Background(), "shell", map[string]string{"command": "rm -rf /"})
+	if err == nil {
+		t.Fatal("rm -rf / should be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected 'blocked' in error, got: %v", err)
+	}
+}
+
+func TestToolboxShellBlockedSudo(t *testing.T) {
+	tb := NewToolbox(nil, nil, nil)
+	_, err := tb.ExecuteTool(context.Background(), "shell", map[string]string{"command": "sudo rm -rf /"})
+	if err == nil {
+		t.Fatal("sudo should be blocked")
+	}
+	if !strings.Contains(err.Error(), "blocked") {
+		t.Errorf("expected 'blocked' in error, got: %v", err)
+	}
+}
+
+func TestToolboxShellMissingCommand(t *testing.T) {
+	tb := NewToolbox(nil, nil, nil)
+	_, err := tb.ExecuteTool(context.Background(), "shell", map[string]string{})
+	if err == nil {
+		t.Fatal("shell with empty command should error")
+	}
+	if !strings.Contains(err.Error(), "requires") {
+		t.Errorf("expected 'requires' in error, got: %v", err)
+	}
+}
+
+func TestToolboxUnknownTool(t *testing.T) {
+	tb := NewToolbox(nil, nil, nil)
+	_, err := tb.ExecuteTool(context.Background(), "nonexistent", map[string]string{})
+	if err == nil {
+		t.Fatal("unknown tool should error")
+	}
+	if !strings.Contains(err.Error(), "unknown tool") {
+		t.Errorf("expected 'unknown tool' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Toolbox: ListTools tests
+// ---------------------------------------------------------------------------
+
+func TestToolboxListToolsIncludesSkills(t *testing.T) {
+	registry := newToolboxSkillRegistry(
+		&mockSkill{name: "search", desc: "Web search", result: "results"},
+		&mockSkill{name: "time", desc: "Current time", result: "now"},
+	)
+	tb := NewToolbox(registry, nil, nil)
+	tools := tb.ListTools()
+
+	// Should include search, time, and shell
+	if len(tools) < 3 {
+		t.Errorf("expected at least 3 tools, got %d", len(tools))
+	}
+
+	found := map[string]bool{}
+	for _, tool := range tools {
+		found[tool.Name] = true
+	}
+	for _, expected := range []string{"search", "time", "shell"} {
+		if !found[expected] {
+			t.Errorf("expected tool %q in list", expected)
+		}
+	}
+}
+
+func TestToolboxListToolsExcludesSelfSkills(t *testing.T) {
+	registry := newToolboxSkillRegistry(
+		&mockSkill{name: "self:health", desc: "Health check", result: "ok"},
+		&mockSkill{name: "search", desc: "Web search", result: "results"},
+	)
+	tb := NewToolbox(registry, nil, nil)
+	tools := tb.ListTools()
+
+	for _, tool := range tools {
+		if strings.HasPrefix(tool.Name, "self:") {
+			t.Errorf("self:* skills should be excluded from tool list, found: %s", tool.Name)
+		}
+	}
+}
+
+func TestToolboxFormatToolsForLLM(t *testing.T) {
+	registry := newToolboxSkillRegistry(
+		&mockSkill{name: "search", desc: "Web search", result: "results"},
+	)
+	tb := NewToolbox(registry, nil, nil)
+	formatted := tb.FormatToolsForLLM()
+
+	if !strings.Contains(formatted, "search") {
+		t.Errorf("formatted tools should contain 'search', got: %s", formatted)
+	}
+	if !strings.Contains(formatted, "shell") {
+		t.Errorf("formatted tools should contain 'shell', got: %s", formatted)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// IsReadOnlyCommand / IsBlockedCommand
+// ---------------------------------------------------------------------------
+
+func TestIsReadOnlyCommand(t *testing.T) {
+	readOnly := []string{"ls /tmp", "cat file.txt", "git status", "git log", "pwd", "echo hello"}
+	for _, cmd := range readOnly {
+		if !IsReadOnlyCommand(cmd) {
+			t.Errorf("IsReadOnlyCommand(%q) = false, want true", cmd)
+		}
+	}
+
+	notReadOnly := []string{"rm file.txt", "make build", "npm install", "docker run foo"}
+	for _, cmd := range notReadOnly {
+		if IsReadOnlyCommand(cmd) {
+			t.Errorf("IsReadOnlyCommand(%q) = true, want false", cmd)
+		}
+	}
+}
+
+func TestIsBlockedCommand(t *testing.T) {
+	blocked := []string{"rm -rf /", "sudo cat /etc/passwd", "mkfs /dev/sda", "shutdown -h now"}
+	for _, cmd := range blocked {
+		if !IsBlockedCommand(cmd) {
+			t.Errorf("IsBlockedCommand(%q) = false, want true", cmd)
+		}
+	}
+
+	notBlocked := []string{"ls /tmp", "cat file.txt", "git status"}
+	for _, cmd := range notBlocked {
+		if IsBlockedCommand(cmd) {
+			t.Errorf("IsBlockedCommand(%q) = true, want false", cmd)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseToolCall
+// ---------------------------------------------------------------------------
+
+func TestParseToolCall(t *testing.T) {
+	response := "I need to check the files.\nTOOL_CALL: shell\nARGS: {\"command\": \"ls /tmp\"}\nLet me analyze."
+	name, args := parseToolCall(response)
+	if name != "shell" {
+		t.Errorf("parseToolCall name = %q, want 'shell'", name)
+	}
+	if args["command"] != "ls /tmp" {
+		t.Errorf("parseToolCall args[command] = %q, want 'ls /tmp'", args["command"])
+	}
+}
+
+func TestParseToolCallNoTool(t *testing.T) {
+	response := "Here is my analysis of the code..."
+	name, _ := parseToolCall(response)
+	if name != "" {
+		t.Errorf("parseToolCall should return empty for no TOOL_CALL, got: %q", name)
+	}
+}
+
+func TestParseToolCallSkillName(t *testing.T) {
+	response := "TOOL_CALL: search\nARGS: {\"input\": \"Go error handling\"}"
+	name, args := parseToolCall(response)
+	if name != "search" {
+		t.Errorf("name = %q, want 'search'", name)
+	}
+	if args["input"] != "Go error handling" {
+		t.Errorf("args[input] = %q, want 'Go error handling'", args["input"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parsePlanResponse with tool hints
+// ---------------------------------------------------------------------------
+
+func TestParsePlanResponseToolHints(t *testing.T) {
+	response := "SUMMARY: Check the repo\nSTEP 1: List files [tool:shell]\nSTEP 2: Read README [tool:shell]\nSTEP 3: Analyze findings"
+	plan := parsePlanResponse("check repo", response)
+
+	if len(plan.Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(plan.Steps))
+	}
+
+	if plan.Steps[0].ToolHint != "shell" {
+		t.Errorf("step 1 ToolHint = %q, want 'shell'", plan.Steps[0].ToolHint)
+	}
+	if plan.Steps[1].ToolHint != "shell" {
+		t.Errorf("step 2 ToolHint = %q, want 'shell'", plan.Steps[1].ToolHint)
+	}
+	if plan.Steps[2].ToolHint != "" {
+		t.Errorf("step 3 ToolHint = %q, want empty", plan.Steps[2].ToolHint)
+	}
+	// Verify the [tool:shell] annotation is stripped from description
+	if strings.Contains(plan.Steps[0].Description, "[tool:") {
+		t.Errorf("step 1 description should not contain [tool:...], got: %s", plan.Steps[0].Description)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractShellCommand
+// ---------------------------------------------------------------------------
+
+func TestExtractShellCommand(t *testing.T) {
+	cases := []struct {
+		desc string
+		want string
+	}{
+		{"Run `ls -la /tmp`", "ls -la /tmp"},
+		{"Execute git status", "git status"},
+		{"List the files in the directory", ""},
+		{"run cat README.md", "cat README.md"},
+	}
+	for _, tc := range cases {
+		got := extractShellCommand(tc.desc)
+		if got != tc.want {
+			t.Errorf("extractShellCommand(%q) = %q, want %q", tc.desc, got, tc.want)
+		}
+	}
+}

--- a/internal/brain/consolidation.go
+++ b/internal/brain/consolidation.go
@@ -1,0 +1,251 @@
+// Package brain — consolidation.go merges duplicate memories and stores
+// structured reflections after task completion.
+package brain
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// MemoryConsolidator merges redundant memory entries and stores task reflections.
+type MemoryConsolidator struct {
+	memory *FileMemory
+	llm    core.LLMProvider
+}
+
+// NewConsolidator creates a consolidator wired to a memory store and optional LLM.
+func NewConsolidator(memory *FileMemory, llm core.LLMProvider) *MemoryConsolidator {
+	return &MemoryConsolidator{memory: memory, llm: llm}
+}
+
+// Consolidate groups similar memory entries by scope and merges clusters.
+// Returns the number of entries merged and removed.
+func (c *MemoryConsolidator) Consolidate(ctx context.Context) (merged, removed int, err error) {
+	entries, err := c.memory.List(ctx)
+	if err != nil {
+		return 0, 0, fmt.Errorf("list memories: %w", err)
+	}
+
+	if len(entries) < 2 {
+		return 0, 0, nil
+	}
+
+	// Group by scope
+	groups := make(map[string][]core.MemoryEntry)
+	for _, e := range entries {
+		scope := e.Scope
+		if scope == "" {
+			scope = "system"
+		}
+		groups[scope] = append(groups[scope], e)
+	}
+
+	for scope, scopeEntries := range groups {
+		if len(scopeEntries) < 2 {
+			continue
+		}
+
+		// Find clusters of similar entries (word overlap > 0.5)
+		used := make(map[int]bool)
+		for i := 0; i < len(scopeEntries); i++ {
+			if used[i] {
+				continue
+			}
+			cluster := []core.MemoryEntry{scopeEntries[i]}
+			for j := i + 1; j < len(scopeEntries); j++ {
+				if used[j] {
+					continue
+				}
+				if wordOverlap(scopeEntries[i].Value, scopeEntries[j].Value) > 0.5 {
+					cluster = append(cluster, scopeEntries[j])
+					used[j] = true
+				}
+			}
+
+			if len(cluster) < 2 {
+				continue
+			}
+
+			// Merge the cluster
+			mergedEntry, err := c.mergeCluster(ctx, scope, cluster)
+			if err != nil {
+				log.Warn("cluster merge failed", "scope", scope, "count", len(cluster), "error", err)
+				continue
+			}
+
+			// Delete originals and store the merged entry
+			for _, e := range cluster {
+				if err := c.memory.Forget(ctx, e.Key); err != nil {
+					log.Debug("forget during consolidation failed", "key", e.Key, "error", err)
+				}
+				removed++
+			}
+
+			if err := c.memory.Store(ctx, mergedEntry); err != nil {
+				log.Warn("store consolidated entry failed", "error", err)
+				continue
+			}
+			merged++
+
+			log.Debug("cluster consolidated", "scope", scope, "from", len(cluster), "to", 1)
+		}
+	}
+
+	log.Info("memory consolidation complete", "merged", merged, "removed", removed)
+	return merged, removed, nil
+}
+
+// mergeCluster combines a cluster of similar entries into one.
+// Uses the LLM if available, otherwise falls back to keeping the most recent entry
+// with key facts appended from the others.
+func (c *MemoryConsolidator) mergeCluster(ctx context.Context, scope string, cluster []core.MemoryEntry) (core.MemoryEntry, error) {
+	// Find the most recently accessed entry as the base
+	best := cluster[0]
+	for _, e := range cluster[1:] {
+		if e.AccessedAt.After(best.AccessedAt) {
+			best = e
+		}
+	}
+
+	// Try LLM synthesis
+	if c.llm != nil {
+		var parts []string
+		for _, e := range cluster {
+			parts = append(parts, fmt.Sprintf("- [%s] %s", e.Key, e.Value))
+		}
+
+		prompt := fmt.Sprintf(
+			"Consolidate these %d related memory entries into ONE concise entry. "+
+				"Preserve all important information. Return only the consolidated text, nothing else.\n\n%s",
+			len(cluster), strings.Join(parts, "\n"),
+		)
+
+		resp, err := c.llm.Chat(ctx, []core.Message{{Role: "user", Content: prompt}},
+			core.WithTemperature(0.2), core.WithMaxTokens(256))
+		if err == nil && strings.TrimSpace(resp.Content) != "" {
+			now := time.Now().UTC()
+			return core.MemoryEntry{
+				Key:         best.Key,
+				Value:       strings.TrimSpace(resp.Content),
+				Tags:        mergeTags(cluster),
+				Scope:       scope,
+				Source:      "consolidation",
+				AccessCount: best.AccessCount,
+				CreatedAt:   best.CreatedAt,
+				AccessedAt:  now,
+			}, nil
+		}
+		log.Debug("LLM consolidation failed, using fallback", "error", err)
+	}
+
+	// Fallback: keep the best entry and append unique facts from others
+	var extras []string
+	for _, e := range cluster {
+		if e.Key == best.Key {
+			continue
+		}
+		// Only append if it adds something not already in the best value
+		if !strings.Contains(strings.ToLower(best.Value), strings.ToLower(e.Value)) {
+			extras = append(extras, e.Value)
+		}
+	}
+
+	value := best.Value
+	if len(extras) > 0 {
+		value += " | Also: " + strings.Join(extras, "; ")
+	}
+
+	now := time.Now().UTC()
+	return core.MemoryEntry{
+		Key:         best.Key,
+		Value:       value,
+		Tags:        mergeTags(cluster),
+		Scope:       scope,
+		Source:      "consolidation",
+		AccessCount: best.AccessCount,
+		CreatedAt:   best.CreatedAt,
+		AccessedAt:  now,
+	}, nil
+}
+
+// ReflectOnTask stores a structured reflection memory after a task completes.
+func (c *MemoryConsolidator) ReflectOnTask(ctx context.Context, taskResult, taskDescription string) error {
+	summary := taskResult
+	if len(summary) > 500 {
+		summary = summary[:500]
+	}
+
+	// Try LLM summary if available
+	if c.llm != nil {
+		prompt := fmt.Sprintf(
+			"A task was just completed. Summarize what was learned in 2-3 sentences.\n\n"+
+				"Task: %s\nResult: %s", taskDescription, summary)
+
+		resp, err := c.llm.Chat(ctx, []core.Message{{Role: "user", Content: prompt}},
+			core.WithTemperature(0.3), core.WithMaxTokens(128))
+		if err == nil && strings.TrimSpace(resp.Content) != "" {
+			summary = strings.TrimSpace(resp.Content)
+		}
+	}
+
+	now := time.Now().UTC()
+	entry := core.MemoryEntry{
+		Key:        fmt.Sprintf("reflection_%d", now.UnixMilli()),
+		Value:      fmt.Sprintf("Task: %s\nLearned: %s", taskDescription, summary),
+		Tags:       []string{"task-outcome", "reflection"},
+		Scope:      "task-outcome",
+		Source:     "reflection",
+		CreatedAt:  now,
+		AccessedAt: now,
+	}
+
+	return c.memory.Store(ctx, entry)
+}
+
+// wordOverlap calculates the fraction of shared words between two strings.
+func wordOverlap(a, b string) float64 {
+	wordsA := strings.Fields(strings.ToLower(a))
+	wordsB := strings.Fields(strings.ToLower(b))
+
+	if len(wordsA) == 0 || len(wordsB) == 0 {
+		return 0
+	}
+
+	setB := make(map[string]bool)
+	for _, w := range wordsB {
+		setB[w] = true
+	}
+
+	shared := 0
+	for _, w := range wordsA {
+		if setB[w] {
+			shared++
+		}
+	}
+
+	total := len(wordsA)
+	if len(wordsB) > total {
+		total = len(wordsB)
+	}
+	return float64(shared) / float64(total)
+}
+
+// mergeTags combines tags from all entries, deduplicating.
+func mergeTags(entries []core.MemoryEntry) []string {
+	seen := make(map[string]bool)
+	var tags []string
+	for _, e := range entries {
+		for _, t := range e.Tags {
+			if !seen[t] {
+				seen[t] = true
+				tags = append(tags, t)
+			}
+		}
+	}
+	return tags
+}

--- a/internal/brain/consolidation_test.go
+++ b/internal/brain/consolidation_test.go
@@ -1,0 +1,184 @@
+package brain
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+func TestConsolidateNoDuplicates(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "a", Value: "completely different topic one", Scope: "user"},
+		{Key: "b", Value: "unrelated subject matter here", Scope: "user"},
+	})
+
+	c := NewConsolidator(mem, nil)
+	merged, removed, err := c.Consolidate(context.Background())
+	if err != nil {
+		t.Fatalf("Consolidate error: %v", err)
+	}
+	if merged != 0 || removed != 0 {
+		t.Errorf("expected no consolidation, got merged=%d removed=%d", merged, removed)
+	}
+}
+
+func TestConsolidateDuplicates(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "pref1", Value: "I prefer Go for backend development work", Scope: "user", Tags: []string{"preference"}},
+		{Key: "pref2", Value: "I prefer Go for backend services and APIs", Scope: "user", Tags: []string{"preference"}},
+		{Key: "pref3", Value: "I like dark mode and vim", Scope: "user", Tags: []string{"ui"}},
+	})
+
+	c := NewConsolidator(mem, nil)
+	merged, removed, err := c.Consolidate(context.Background())
+	if err != nil {
+		t.Fatalf("Consolidate error: %v", err)
+	}
+
+	// The two Go-related entries should be merged
+	if merged == 0 {
+		t.Error("expected at least 1 merge")
+	}
+	if removed < 2 {
+		t.Errorf("expected at least 2 entries removed, got %d", removed)
+	}
+
+	// Verify remaining entries
+	entries, _ := mem.List(context.Background())
+	// Should have the merged entry + the dark mode entry
+	if len(entries) > 3 {
+		t.Errorf("expected fewer entries after consolidation, got %d", len(entries))
+	}
+}
+
+func TestConsolidateCrossScope(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "user_go", Value: "I prefer Go for backend development work", Scope: "user"},
+		{Key: "sys_go", Value: "I prefer Go for backend development work", Scope: "system"},
+	})
+
+	c := NewConsolidator(mem, nil)
+	merged, _, err := c.Consolidate(context.Background())
+	if err != nil {
+		t.Fatalf("Consolidate error: %v", err)
+	}
+	// Different scopes should NOT be merged
+	if merged != 0 {
+		t.Errorf("cross-scope entries should not be merged, got merged=%d", merged)
+	}
+}
+
+func TestConsolidateMergeTags(t *testing.T) {
+	tags := mergeTags([]core.MemoryEntry{
+		{Tags: []string{"a", "b"}},
+		{Tags: []string{"b", "c"}},
+		{Tags: []string{"d"}},
+	})
+
+	if len(tags) != 4 {
+		t.Errorf("expected 4 unique tags, got %d: %v", len(tags), tags)
+	}
+}
+
+func TestWordOverlap(t *testing.T) {
+	cases := []struct {
+		a, b string
+		min  float64
+	}{
+		{"I like Go", "I like Go", 1.0},
+		{"I like Go", "I prefer Python", 0.1},  // "I" is shared
+		{"completely different", "no match here", 0.0},
+		{"Go backend development", "Go backend services", 0.5},
+	}
+	for _, tc := range cases {
+		got := wordOverlap(tc.a, tc.b)
+		if got < tc.min {
+			t.Errorf("wordOverlap(%q, %q) = %f, want >= %f", tc.a, tc.b, got, tc.min)
+		}
+	}
+}
+
+func TestReflectOnTaskNoLLM(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory: %v", err)
+	}
+
+	c := NewConsolidator(mem, nil)
+	err = c.ReflectOnTask(context.Background(), "Files found: main.go, go.mod, README.md", "check the repo")
+	if err != nil {
+		t.Fatalf("ReflectOnTask error: %v", err)
+	}
+
+	// Verify a reflection was stored
+	entries, _ := mem.List(context.Background())
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 reflection entry, got %d", len(entries))
+	}
+	entry := entries[0]
+	if entry.Scope != "task-outcome" {
+		t.Errorf("scope = %q, want 'task-outcome'", entry.Scope)
+	}
+	if entry.Source != "reflection" {
+		t.Errorf("source = %q, want 'reflection'", entry.Source)
+	}
+	if !strings.Contains(entry.Value, "check the repo") {
+		t.Errorf("reflection should contain task description, got: %s", entry.Value)
+	}
+}
+
+func TestStoreDefaultScope(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory: %v", err)
+	}
+
+	// Store without scope should default to "system"
+	err = mem.Store(context.Background(), core.MemoryEntry{
+		Key:   "test",
+		Value: "test value",
+	})
+	if err != nil {
+		t.Fatalf("Store error: %v", err)
+	}
+
+	entry, err := mem.Recall(context.Background(), "test")
+	if err != nil {
+		t.Fatalf("Recall error: %v", err)
+	}
+	if entry.Scope != "system" {
+		t.Errorf("default scope = %q, want 'system'", entry.Scope)
+	}
+}
+
+func TestRecallIncrementsAccessCount(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory: %v", err)
+	}
+
+	err = mem.Store(context.Background(), core.MemoryEntry{
+		Key:   "test",
+		Value: "test value",
+	})
+	if err != nil {
+		t.Fatalf("Store error: %v", err)
+	}
+
+	// First recall
+	entry, _ := mem.Recall(context.Background(), "test")
+	if entry.AccessCount != 1 {
+		t.Errorf("AccessCount after 1 recall = %d, want 1", entry.AccessCount)
+	}
+
+	// Second recall
+	entry, _ = mem.Recall(context.Background(), "test")
+	if entry.AccessCount != 2 {
+		t.Errorf("AccessCount after 2 recalls = %d, want 2", entry.AccessCount)
+	}
+}

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -177,13 +178,9 @@ func (m *FileMemory) RankedSearch(_ context.Context, query string, scope string,
 	}
 
 	// Sort by score descending
-	for i := 0; i < len(results); i++ {
-		for j := i + 1; j < len(results); j++ {
-			if results[j].score > results[i].score {
-				results[i], results[j] = results[j], results[i]
-			}
-		}
-	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].score > results[j].score
+	})
 
 	// Limit
 	if limit > 0 && len(results) > limit {

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -65,6 +65,9 @@ func (m *FileMemory) Store(_ context.Context, entry core.MemoryEntry) error {
 		entry.CreatedAt = now
 	}
 	entry.AccessedAt = now
+	if entry.Scope == "" {
+		entry.Scope = "system"
+	}
 
 	data, err := json.MarshalIndent(entry, "", "  ")
 	if err != nil {
@@ -100,8 +103,9 @@ func (m *FileMemory) Recall(_ context.Context, key string) (*core.MemoryEntry, e
 		return nil, fmt.Errorf("unmarshal memory %q: %w", key, err)
 	}
 
-	// Update access time (best-effort)
+	// Update access time and count (best-effort)
 	entry.AccessedAt = time.Now().UTC()
+	entry.AccessCount++
 	if updated, err := json.MarshalIndent(entry, "", "  "); err == nil {
 		_ = os.WriteFile(path, updated, 0600)
 	}
@@ -137,6 +141,134 @@ func (m *FileMemory) Search(_ context.Context, query string, limit int) ([]core.
 
 	log.Debug("memory search complete", "query", query, "found", len(results))
 	return results, nil
+}
+
+// RankedSearch performs a relevance-ranked search across memory entries.
+// If scope is non-empty, only entries with that scope are considered.
+// Results are sorted by relevance score descending and limited to the given count.
+func (m *FileMemory) RankedSearch(_ context.Context, query string, scope string, limit int) ([]core.MemoryEntry, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	entries, err := m.listAll()
+	if err != nil {
+		return nil, err
+	}
+
+	type scored struct {
+		entry core.MemoryEntry
+		score float64
+	}
+
+	queryLower := strings.ToLower(query)
+	queryWords := strings.Fields(queryLower)
+
+	var results []scored
+	for _, entry := range entries {
+		// Scope filter
+		if scope != "" && entry.Scope != scope {
+			continue
+		}
+
+		score := scoreEntry(entry, queryLower, queryWords)
+		if score > 0 {
+			results = append(results, scored{entry: entry, score: score})
+		}
+	}
+
+	// Sort by score descending
+	for i := 0; i < len(results); i++ {
+		for j := i + 1; j < len(results); j++ {
+			if results[j].score > results[i].score {
+				results[i], results[j] = results[j], results[i]
+			}
+		}
+	}
+
+	// Limit
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	out := make([]core.MemoryEntry, len(results))
+	for i, r := range results {
+		out[i] = r.entry
+	}
+
+	log.Debug("ranked search complete", "query", query, "scope", scope, "found", len(out))
+	return out, nil
+}
+
+// scoreEntry computes a relevance score for a memory entry against a query.
+func scoreEntry(entry core.MemoryEntry, queryLower string, queryWords []string) float64 {
+	var score float64
+	keyLower := strings.ToLower(entry.Key)
+	valueLower := strings.ToLower(entry.Value)
+
+	// Exact key match
+	if keyLower == queryLower {
+		score += 1.0
+	} else if strings.Contains(keyLower, queryLower) {
+		score += 0.5
+	}
+
+	// Value word overlap (Jaccard-like)
+	if len(queryWords) > 0 {
+		valueWords := strings.Fields(valueLower)
+		shared := 0
+		for _, qw := range queryWords {
+			for _, vw := range valueWords {
+				if qw == vw {
+					shared++
+					break
+				}
+			}
+		}
+		total := len(queryWords)
+		if len(valueWords) > total {
+			total = len(valueWords)
+		}
+		if total > 0 {
+			score += 0.4 * float64(shared) / float64(total)
+		}
+	}
+
+	// Value substring match (weaker signal)
+	if strings.Contains(valueLower, queryLower) {
+		score += 0.2
+	}
+
+	// Tag match
+	for _, qw := range queryWords {
+		for _, tag := range entry.Tags {
+			if strings.ToLower(tag) == qw {
+				score += 0.2
+				break
+			}
+		}
+	}
+
+	// Recency bonus (up to 0.1, decays over 365 days)
+	if !entry.AccessedAt.IsZero() {
+		daysSince := time.Since(entry.AccessedAt).Hours() / 24
+		if daysSince < 0 {
+			daysSince = 0
+		}
+		recency := 1.0 - daysSince/365.0
+		if recency < 0 {
+			recency = 0
+		}
+		score += 0.1 * recency
+	}
+
+	// Access frequency bonus (up to 0.05)
+	accessCount := entry.AccessCount
+	if accessCount > 10 {
+		accessCount = 10
+	}
+	score += 0.05 * float64(accessCount) / 10.0
+
+	return score
 }
 
 // Forget removes a memory entry by key.

--- a/internal/brain/memory_search_test.go
+++ b/internal/brain/memory_search_test.go
@@ -1,0 +1,175 @@
+package brain
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+func newTestMemoryWithEntries(t *testing.T, entries []core.MemoryEntry) *FileMemory {
+	t.Helper()
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory: %v", err)
+	}
+	for _, e := range entries {
+		if err := mem.Store(context.Background(), e); err != nil {
+			t.Fatalf("Store(%q): %v", e.Key, err)
+		}
+	}
+	return mem
+}
+
+func TestRankedSearchExactKeyMatch(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "golang", Value: "I prefer Go for backend work", Scope: "user"},
+		{Key: "python", Value: "I use Python for data science", Scope: "user"},
+		{Key: "rust", Value: "Rust is interesting for systems", Scope: "user"},
+	})
+
+	results, err := mem.RankedSearch(context.Background(), "golang", "", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results, got none")
+	}
+	if results[0].Key != "golang" {
+		t.Errorf("expected 'golang' to be first result, got %q", results[0].Key)
+	}
+}
+
+func TestRankedSearchWordOverlap(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "pref1", Value: "I like dark mode and vim keybindings", Scope: "user"},
+		{Key: "pref2", Value: "The weather is nice today", Scope: "user"},
+		{Key: "pref3", Value: "I prefer dark themes in my editor", Scope: "user"},
+	})
+
+	results, err := mem.RankedSearch(context.Background(), "dark mode editor", "", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results, got none")
+	}
+	// "dark" entries should rank higher than "weather"
+	if results[0].Key == "pref2" {
+		t.Error("'weather' entry should not be the top result for 'dark mode editor'")
+	}
+}
+
+func TestRankedSearchScopeFilter(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "user_go", Value: "I prefer Go", Scope: "user"},
+		{Key: "system_feedback", Value: "signal:positive Go is great", Scope: "system"},
+		{Key: "task_go", Value: "analyzed Go project", Scope: "task-outcome"},
+	})
+
+	// Search only user scope
+	results, err := mem.RankedSearch(context.Background(), "Go", "user", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Errorf("expected 1 user-scoped result, got %d", len(results))
+	}
+	if len(results) > 0 && results[0].Scope != "user" {
+		t.Errorf("expected scope=user, got %q", results[0].Scope)
+	}
+}
+
+func TestRankedSearchEmptyScopeReturnsAll(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "user_go", Value: "I prefer Go", Scope: "user"},
+		{Key: "system_go", Value: "Go feedback positive", Scope: "system"},
+	})
+
+	results, err := mem.RankedSearch(context.Background(), "Go", "", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Errorf("expected 2 results with empty scope filter, got %d", len(results))
+	}
+}
+
+func TestRankedSearchRecencyBonus(t *testing.T) {
+	now := time.Now().UTC()
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "old_pref", Value: "I like Go programming", Scope: "user", AccessedAt: now.Add(-300 * 24 * time.Hour)},
+		{Key: "new_pref", Value: "I like Go programming", Scope: "user", AccessedAt: now},
+	})
+
+	results, err := mem.RankedSearch(context.Background(), "Go programming", "", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) < 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	// The recent one should score higher
+	if results[0].Key != "new_pref" {
+		t.Errorf("expected recent entry first, got %q", results[0].Key)
+	}
+}
+
+func TestRankedSearchNoResults(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "pref1", Value: "I like Python", Scope: "user"},
+	})
+
+	results, err := mem.RankedSearch(context.Background(), "completely unrelated query xyz", "", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	// May return results with low scores (substring partial matches); that's OK.
+	// The key test is that it doesn't error.
+	_ = results
+}
+
+func TestRankedSearchLimit(t *testing.T) {
+	entries := make([]core.MemoryEntry, 10)
+	for i := range entries {
+		entries[i] = core.MemoryEntry{
+			Key:   fmt.Sprintf("entry_%d", i),
+			Value: "Go programming is fun",
+			Scope: "user",
+		}
+	}
+	mem := newTestMemoryWithEntries(t, entries)
+
+	results, err := mem.RankedSearch(context.Background(), "Go", "", 3)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) > 3 {
+		t.Errorf("expected at most 3 results, got %d", len(results))
+	}
+}
+
+func TestRankedSearchTagMatch(t *testing.T) {
+	mem := newTestMemoryWithEntries(t, []core.MemoryEntry{
+		{Key: "tagged", Value: "something about coding", Tags: []string{"golang", "preference"}, Scope: "user"},
+		{Key: "untagged", Value: "something about coding", Scope: "user"},
+	})
+
+	results, err := mem.RankedSearch(context.Background(), "golang", "", 10)
+	if err != nil {
+		t.Fatalf("RankedSearch error: %v", err)
+	}
+	if len(results) == 0 {
+		t.Fatal("expected results")
+	}
+	// Tagged entry should score higher
+	if results[0].Key != "tagged" {
+		t.Errorf("expected tagged entry first, got %q", results[0].Key)
+	}
+}
+
+// Ensure fmt is used (used in TestRankedSearchLimit).
+var _ = fmt.Sprintf

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -48,6 +48,12 @@ func (h *ChatHandlerImpl) HandleMessage(ctx context.Context, msg core.ChatMessag
 		return response, nil
 	}
 
+	// Set platform + chat ID on the agent so it knows whether to run tasks
+	// in background and where to deliver results.
+	if ps, ok := h.agent.(interface{ SetChatContext(string, string) }); ok {
+		ps.SetChatContext(msg.Platform, msg.ChatID)
+	}
+
 	resp, err := h.agent.Chat(ctx, msg.Text)
 	if err != nil {
 		log.Error("agent.Chat failed",

--- a/internal/chat/handler.go
+++ b/internal/chat/handler.go
@@ -48,13 +48,16 @@ func (h *ChatHandlerImpl) HandleMessage(ctx context.Context, msg core.ChatMessag
 		return response, nil
 	}
 
-	// Set platform + chat ID on the agent so it knows whether to run tasks
-	// in background and where to deliver results.
-	if ps, ok := h.agent.(interface{ SetChatContext(string, string) }); ok {
-		ps.SetChatContext(msg.Platform, msg.ChatID)
+	// Prefer the platform-aware entry point so platform/chatID are bound to
+	// this specific message under one lock acquisition. Falls back to the
+	// plain Chat for agents that don't implement the platform-aware interface.
+	var resp string
+	var err error
+	if pa, ok := h.agent.(core.PlatformAwareAgent); ok {
+		resp, err = pa.ChatFromPlatform(ctx, msg.Platform, msg.ChatID, msg.Text)
+	} else {
+		resp, err = h.agent.Chat(ctx, msg.Text)
 	}
-
-	resp, err := h.agent.Chat(ctx, msg.Text)
 	if err != nil {
 		log.Error("agent.Chat failed",
 			"platform", msg.Platform,

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -526,6 +526,9 @@ func (t *TelegramBot) handleCommand(chatID int64, msg *tgbotapi.Message) {
 			"/switch  - Switch provider (e.g. /switch local, /switch codex gpt-5.5)",
 			"/fact    - Learn something about real krill",
 			"/plan    - Start a dive plan for a task",
+			"/tasks   - List active and recent tasks",
+			"/task ID - Show details of a specific task",
+			"/cancel ID - Cancel a running task",
 			"",
 			"Or say 'remember that ...', 'what do you remember', or 'switch to claude' naturally!",
 		}, "\n"))
@@ -555,12 +558,43 @@ func (t *TelegramBot) handleCommand(chatID int64, msg *tgbotapi.Message) {
 			"Tell me what you need done and I'll draft a dive plan for your approval! "+
 				"Just describe the task in your next message.")
 
+	case "tasks", "task", "cancel":
+		// Task management commands are handled by the agent via Chat()
+		t.handleTaskViaAgent(chatID, msg)
+
 	default:
 		t.sendMessage(chatID, fmt.Sprintf(
 			"Unknown command /%s. Try /help to see what I can do!",
 			msg.Command(),
 		))
 	}
+}
+
+// handleTaskViaAgent forwards task management commands (/tasks, /task, /cancel)
+// through the normal agent Chat() path so the agent handles them.
+func (t *TelegramBot) handleTaskViaAgent(chatID int64, msg *tgbotapi.Message) {
+	fullText := "/" + msg.Command()
+	if args := msg.CommandArguments(); args != "" {
+		fullText += " " + args
+	}
+
+	msgCtx, msgCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer msgCancel()
+
+	chatMsg := core.ChatMessage{
+		Platform: "telegram",
+		ChatID:   fmt.Sprintf("%d", chatID),
+		UserID:   fmt.Sprintf("%d", msg.From.ID),
+		Username: msg.From.UserName,
+		Text:     fullText,
+	}
+
+	resp, err := t.handler.HandleMessage(msgCtx, chatMsg)
+	if err != nil {
+		t.sendMessage(chatID, "Something went wrong: "+err.Error())
+		return
+	}
+	t.sendLong(chatID, resp)
 }
 
 // ── Model/provider command handlers ─────────────────────────────────────────

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,11 +30,65 @@ type Config struct {
 
 // AgentConfig controls the main krill agent behaviour.
 type AgentConfig struct {
-	Name          string `yaml:"name"`
-	Personality   string `yaml:"personality"` // active personality profile (default: "krill")
-	MaxSubKrills  int    `yaml:"max_sub_krills"`
-	PlanApproval  string `yaml:"plan_approval"`  // "auto" (default), "always", or "never"
-	RecoveryTurns int    `yaml:"recovery_turns"` // turns to load on cold start (default 10, from brain config)
+	Name          string       `yaml:"name"`
+	Personality   string       `yaml:"personality"` // active personality profile (default: "krill")
+	MaxSubKrills  int          `yaml:"max_sub_krills"`
+	PlanApproval  string       `yaml:"-"` // "auto" (default), "always", or "never"; set via UnmarshalYAML
+	RecoveryTurns int          `yaml:"recovery_turns"` // turns to load on cold start (default 10, from brain config)
+}
+
+// agentConfigRaw is used during YAML unmarshalling to accept plan_approval
+// as either a bool (legacy) or string (new).
+type agentConfigRaw struct {
+	Name          string      `yaml:"name"`
+	Personality   string      `yaml:"personality"`
+	MaxSubKrills  int         `yaml:"max_sub_krills"`
+	PlanApproval  interface{} `yaml:"plan_approval"`
+	RecoveryTurns int         `yaml:"recovery_turns"`
+}
+
+// UnmarshalYAML handles backward-compatible parsing of plan_approval,
+// which was a bool in earlier versions and is now a 3-way string.
+func (a *AgentConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw agentConfigRaw
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	a.Name = raw.Name
+	a.Personality = raw.Personality
+	a.MaxSubKrills = raw.MaxSubKrills
+	a.RecoveryTurns = raw.RecoveryTurns
+
+	switch v := raw.PlanApproval.(type) {
+	case bool:
+		if v {
+			a.PlanApproval = "always"
+		} else {
+			a.PlanApproval = "never"
+		}
+	case string:
+		a.PlanApproval = v
+	default:
+		a.PlanApproval = ""
+	}
+	return nil
+}
+
+// MarshalYAML ensures PlanApproval is written as a string when saving config.
+func (a AgentConfig) MarshalYAML() (interface{}, error) {
+	return &struct {
+		Name          string `yaml:"name"`
+		Personality   string `yaml:"personality,omitempty"`
+		MaxSubKrills  int    `yaml:"max_sub_krills"`
+		PlanApproval  string `yaml:"plan_approval"`
+		RecoveryTurns int    `yaml:"recovery_turns,omitempty"`
+	}{
+		Name:          a.Name,
+		Personality:   a.Personality,
+		MaxSubKrills:  a.MaxSubKrills,
+		PlanApproval:  a.PlanApproval,
+		RecoveryTurns: a.RecoveryTurns,
+	}, nil
 }
 
 // LLMConfig selects and configures the LLM provider.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,7 +33,7 @@ type AgentConfig struct {
 	Name          string `yaml:"name"`
 	Personality   string `yaml:"personality"` // active personality profile (default: "krill")
 	MaxSubKrills  int    `yaml:"max_sub_krills"`
-	PlanApproval  bool   `yaml:"plan_approval"`  // require user approval before executing plans
+	PlanApproval  string `yaml:"plan_approval"`  // "auto" (default), "always", or "never"
 	RecoveryTurns int    `yaml:"recovery_turns"` // turns to load on cold start (default 10, from brain config)
 }
 
@@ -136,7 +136,7 @@ func DefaultConfig() *Config {
 		Agent: AgentConfig{
 			Name:         "krill",
 			MaxSubKrills: 3,
-			PlanApproval: true,
+			PlanApproval: "auto",
 		},
 		LLM: LLMConfig{
 			Provider:    "ollama",
@@ -220,6 +220,17 @@ func fillDefaults(cfg *Config) {
 	}
 	if cfg.Agent.Personality == "" {
 		cfg.Agent.Personality = "krill"
+	}
+	// Normalize PlanApproval: support legacy bool values from old configs.
+	switch strings.ToLower(cfg.Agent.PlanApproval) {
+	case "auto", "always", "never":
+		// valid
+	case "true":
+		cfg.Agent.PlanApproval = "always"
+	case "false":
+		cfg.Agent.PlanApproval = "never"
+	default:
+		cfg.Agent.PlanApproval = "auto"
 	}
 	if cfg.Telegram.BotMaxTurns == 0 {
 		cfg.Telegram.BotMaxTurns = 3

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -190,6 +191,61 @@ func TestFillDefaults(t *testing.T) {
 	expectedBrainDir := filepath.Join(tmpDir, "brain")
 	if cfg.Brain.DataDir != expectedBrainDir {
 		t.Errorf("Brain.DataDir = %q, want %q", cfg.Brain.DataDir, expectedBrainDir)
+	}
+}
+
+func TestPlanApprovalLegacyBoolTrue(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("KRILL_DATA_DIR", tmpDir)
+
+	yamlData := []byte("agent:\n  name: krill\n  plan_approval: true\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), yamlData, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Agent.PlanApproval != "always" {
+		t.Errorf("PlanApproval = %q, want 'always' (migrated from bool true)", cfg.Agent.PlanApproval)
+	}
+}
+
+func TestPlanApprovalLegacyBoolFalse(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("KRILL_DATA_DIR", tmpDir)
+
+	yamlData := []byte("agent:\n  name: krill\n  plan_approval: false\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), yamlData, 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+	if cfg.Agent.PlanApproval != "never" {
+		t.Errorf("PlanApproval = %q, want 'never' (migrated from bool false)", cfg.Agent.PlanApproval)
+	}
+}
+
+func TestPlanApprovalStringValues(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("KRILL_DATA_DIR", tmpDir)
+
+	for _, val := range []string{"auto", "always", "never"} {
+		yamlData := []byte(fmt.Sprintf("agent:\n  name: krill\n  plan_approval: %s\n", val))
+		if err := os.WriteFile(filepath.Join(tmpDir, "config.yaml"), yamlData, 0600); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		cfg, err := Load()
+		if err != nil {
+			t.Fatalf("Load(%s) error: %v", val, err)
+		}
+		if cfg.Agent.PlanApproval != val {
+			t.Errorf("PlanApproval = %q, want %q", cfg.Agent.PlanApproval, val)
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,8 +12,8 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.LLM.Provider != "ollama" {
 		t.Errorf("LLM.Provider = %q, want %q", cfg.LLM.Provider, "ollama")
 	}
-	if cfg.Agent.PlanApproval != true {
-		t.Error("Agent.PlanApproval = false, want true")
+	if cfg.Agent.PlanApproval != "auto" {
+		t.Errorf("Agent.PlanApproval = %q, want %q", cfg.Agent.PlanApproval, "auto")
 	}
 	if cfg.Agent.Name != "krill" {
 		t.Errorf("Agent.Name = %q, want %q", cfg.Agent.Name, "krill")

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -257,6 +257,14 @@ type Agent interface {
 	SpawnKrill(ctx context.Context, task string) (*SubKrill, error)
 }
 
+// PlatformAwareAgent extends Agent with a platform-aware entry point.
+// Implementations process platform/chatID atomically with the message so
+// background-task routing has the right destination.
+type PlatformAwareAgent interface {
+	Agent
+	ChatFromPlatform(ctx context.Context, platform, chatID, input string) (string, error)
+}
+
 // TaskInfo is a serialisable snapshot of a durable task.
 type TaskInfo struct {
 	ID        string    `json:"id"`

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -221,10 +221,12 @@ type MCPRegistry interface {
 
 // PlanStep is one step in an execution plan.
 type PlanStep struct {
-	ID          int    `json:"id"`
-	Description string `json:"description"`
-	Status      string `json:"status"` // pending, running, done, failed, skipped
-	Output      string `json:"output,omitempty"`
+	ID            int    `json:"id"`
+	Description   string `json:"description"`
+	Status        string `json:"status"` // pending, running, done, failed, skipped
+	Output        string `json:"output,omitempty"`
+	ToolHint      string `json:"tool_hint,omitempty"`      // suggested tool from planner
+	NeedsApproval bool   `json:"needs_approval,omitempty"` // destructive step flag
 }
 
 // Plan is a set of steps the agent proposes before executing a task.
@@ -249,6 +251,26 @@ type Agent interface {
 	Plan(ctx context.Context, task string) (*Plan, error)
 	ExecutePlan(ctx context.Context, plan *Plan) (string, error)
 	SpawnKrill(ctx context.Context, task string) (*SubKrill, error)
+}
+
+// TaskInfo is a serialisable snapshot of a durable task.
+type TaskInfo struct {
+	ID        string    `json:"id"`
+	Task      string    `json:"task"`
+	Status    string    `json:"status"` // queued, running, done, failed, cancelled
+	Result    string    `json:"result,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// TaskManager tracks long-running background tasks.
+// Kept separate from Agent so the existing Agent contract stays unchanged.
+type TaskManager interface {
+	SubmitTask(ctx context.Context, userID, platform, chatID, task string) (taskID string, err error)
+	ListTasks(userID string) []TaskInfo
+	GetTask(id string) (*TaskInfo, bool)
+	CancelTask(id string) error
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -76,11 +76,14 @@ type LLMProvider interface {
 
 // MemoryEntry is a single item in the krill's memory.
 type MemoryEntry struct {
-	Key        string    `json:"key"`
-	Value      string    `json:"value"`
-	Tags       []string  `json:"tags,omitempty"`
-	CreatedAt  time.Time `json:"created_at"`
-	AccessedAt time.Time `json:"accessed_at"`
+	Key         string    `json:"key"`
+	Value       string    `json:"value"`
+	Tags        []string  `json:"tags,omitempty"`
+	Scope       string    `json:"scope,omitempty"`        // "user", "project", "group", "task-outcome", "system"
+	Source      string    `json:"source,omitempty"`        // "user-explicit", "auto-learned", "task-outcome", "reflection", "feedback"
+	AccessCount int       `json:"access_count,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+	AccessedAt  time.Time `json:"accessed_at"`
 }
 
 // Personality defines the krill's character traits.
@@ -117,6 +120,7 @@ type Memory interface {
 	Store(ctx context.Context, entry MemoryEntry) error
 	Recall(ctx context.Context, key string) (*MemoryEntry, error)
 	Search(ctx context.Context, query string, limit int) ([]MemoryEntry, error)
+	RankedSearch(ctx context.Context, query string, scope string, limit int) ([]MemoryEntry, error)
 	Forget(ctx context.Context, key string) error
 	List(ctx context.Context) ([]MemoryEntry, error)
 	Count() int

--- a/internal/plugin/self.go
+++ b/internal/plugin/self.go
@@ -61,6 +61,7 @@ func NewSelfSkills(sc SelfContext) []core.Skill {
 		selfAddSkill(sc),
 		selfHeal(sc),
 		selfReflect(sc),
+		selfConsolidate(sc),
 	}
 }
 
@@ -931,4 +932,32 @@ func extractYAMLBlock(s string) string {
 	}
 	// No code block, return as-is (might be raw YAML)
 	return strings.TrimSpace(s)
+}
+
+// selfConsolidate merges redundant memories to keep the memory store lean.
+func selfConsolidate(sc SelfContext) core.Skill {
+	return &selfSkill{
+		name: "self:consolidate",
+		desc: "Consolidate and clean up redundant memories",
+		exec: func(ctx context.Context, _ string, llm core.LLMProvider) (string, error) {
+			mem := sc.Brain.Memory()
+			if mem == nil {
+				return "No memory store available.", nil
+			}
+			fileMem, ok := mem.(*brain.FileMemory)
+			if !ok {
+				return "Memory store does not support consolidation.", nil
+			}
+
+			consolidator := brain.NewConsolidator(fileMem, llm)
+			merged, removed, err := consolidator.Consolidate(ctx)
+			if err != nil {
+				return fmt.Sprintf("Consolidation failed: %v", err), nil
+			}
+			if merged == 0 {
+				return "Memory is already lean — no duplicates found to consolidate.", nil
+			}
+			return fmt.Sprintf("Memory consolidation complete: %d clusters merged, %d entries removed.", merged, removed), nil
+		},
+	}
 }

--- a/internal/plugin/self.go
+++ b/internal/plugin/self.go
@@ -401,11 +401,17 @@ func selfConfigure(sc SelfContext) core.Skill {
 
 			// Plan approval
 			if strings.Contains(lower, "auto approve") || strings.Contains(lower, "skip approval") {
-				sc.Config.Agent.PlanApproval = false
-				changes = append(changes, "plan_approval: true -> false")
-			} else if strings.Contains(lower, "require approval") || strings.Contains(lower, "plan approval on") {
-				sc.Config.Agent.PlanApproval = true
-				changes = append(changes, "plan_approval: false -> true")
+				old := sc.Config.Agent.PlanApproval
+				sc.Config.Agent.PlanApproval = "never"
+				changes = append(changes, fmt.Sprintf("plan_approval: %s -> never", old))
+			} else if strings.Contains(lower, "require approval") || strings.Contains(lower, "plan approval on") || strings.Contains(lower, "always approve") {
+				old := sc.Config.Agent.PlanApproval
+				sc.Config.Agent.PlanApproval = "always"
+				changes = append(changes, fmt.Sprintf("plan_approval: %s -> always", old))
+			} else if strings.Contains(lower, "auto approval") || strings.Contains(lower, "smart approval") {
+				old := sc.Config.Agent.PlanApproval
+				sc.Config.Agent.PlanApproval = "auto"
+				changes = append(changes, fmt.Sprintf("plan_approval: %s -> auto", old))
 			}
 
 			if len(changes) == 0 {


### PR DESCRIPTION
## Summary

- **Smart Intent Router** — Replace binary TASK/CHAT classifier with 8-intent router (CHAT, ANSWER, DIAGNOSE, REMEMBER, TOOL_TASK, LONG_TASK, SELF_SKILL, COMMAND). ~80% of inputs handled deterministically with zero LLM calls.
- **Real Tool Execution** — Plan steps now dispatch real tools (shell commands, skills, MCP) instead of LLM narration. Safety-gated: blocked commands, read-only auto-approve, 30s timeout.
- **Durable Task Sessions** — Long-running tasks survive Telegram's 90s timeout via background goroutines with JSONL persistence, async result delivery, and `/tasks` `/task` `/cancel` commands.
- **Smart Plan Approval** — `plan_approval` config changes from bool to 3-way (`auto`/`always`/`never`). Auto mode: ≤4 non-destructive steps execute immediately; 5+ steps or destructive ops require approval.

## Before → After

| Input | Before | After |
|-------|--------|-------|
| "what time is it?" | LLM classify → plan or chat | Deterministic → time skill (0 LLM calls) |
| "why did I get this error?" | TASK → plan → approval | DIAGNOSE → direct answer (1 LLM call) |
| "check the repo" | Plan → narrate file listing | Auto-execute → `ls` + `cat README.md` (real output) |
| "remember I like Go" | Plan about storing | REMEMBER → self:learn skill directly |
| Long task on Telegram | 90s timeout → "context deadline exceeded" | Immediate ack → background execution → async result |
| `rm -rf /` in plan step | LLM might narrate doing it | Blocked outright |

## New files (9)
- `internal/agent/router.go` + `router_test.go` — Intent router
- `internal/agent/toolbox.go` + `toolbox_test.go` — Tool dispatch + shell safety
- `internal/agent/taskstore.go` + `taskstore_test.go` — Durable task persistence
- `internal/agent/taskrunner.go` + `taskrunner_test.go` — Background task execution
- `docs/AUTONOMOUS_AGENT_HANDOFF.md` — Architecture handoff doc (corrected)

## Modified files (8)
- `internal/agent/agent.go` — Router integration, new handlers, task system
- `internal/agent/planner.go` — Tool-aware plan generation and execution
- `internal/core/types.go` — PlanStep.ToolHint, TaskManager interface
- `internal/config/config.go` — PlanApproval bool→string with backward compat
- `internal/chat/telegram.go` — /tasks /task /cancel commands
- `internal/plugin/self.go` — Updated plan approval config handling
- `internal/config/config_test.go`, `internal/agent/agent_test.go` — Updated

## Test plan
- [x] `go test ./...` passes (59 agent tests, all packages green)
- [ ] Start Telegram bot with `minikrill dive --foreground`
- [ ] Send `/help` — verify /tasks, /task, /cancel listed
- [ ] Ask "what time is it?" — verify direct answer, no plan
- [ ] Ask "why did I get this error?" — verify diagnosis, no DIVE PLAN
- [ ] Ask "check the repo" — verify real file reads in output
- [ ] Ask "remember I prefer direct answers" — verify memory stored
- [ ] Send a complex multi-step task — verify background ack on Telegram
- [ ] Send `/tasks` — verify task listing
- [ ] Send `/cancel <id>` — verify cancellation