### PR TITLE
Make agent smart and autonomous instead of rigid

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -30,31 +31,13 @@ const maxHistory = 20
 
 const unifiedConversationChannel = "unified"
 
-// approvalWords are inputs that greenlight a pending plan.
-var approvalWords = map[string]bool{
-	"yes":      true,
-	"approve":  true,
-	"go":       true,
-	"do it":    true,
-	"lgtm":     true,
-	"go ahead": true,
-	"y":        true,
-	"yep":      true,
-	"sure":     true,
-	"proceed":  true,
-}
+// approvalRegex matches obvious approval shorthand on the fast path so we
+// don't burn an LLM call on "yes". Anything not matched here OR by
+// rejectionRegex falls through to the LLM-judged classifier.
+var approvalRegex = regexp.MustCompile(`^(?:y|yes|yea|yeah|yep|yup|ya|sure|ok|okay|k|👍|do it|go|go ahead|let'?s go|lgtm|proceed|approve|approved|fine|alright|sounds good)[\s\.!]*$`)
 
-// rejectionWords are inputs that scrap a pending plan.
-var rejectionWords = map[string]bool{
-	"no":     true,
-	"reject": true,
-	"cancel": true,
-	"stop":   true,
-	"nah":    true,
-	"nope":   true,
-	"n":      true,
-	"abort":  true,
-}
+// rejectionRegex covers obvious "scrap it" shorthand.
+var rejectionRegex = regexp.MustCompile(`^(?:n|no|nah|nope|cancel|cancelled|stop|abort|reject|rejected|skip|nevermind|never mind|forget it|don'?t)[\s\.!]*$`)
 
 // KrillAgent is the main agent that implements core.Agent.
 // It is the executive function of the krill brain - classifying intent,
@@ -228,8 +211,19 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 	}
 
 	// --- Phase 1: Check for pending plan approval ---
+	// Even with a pending plan, we still want preference learning to fire so
+	// "stop asking me to approve" gets captured *during* the approval state,
+	// not after. The pending-plan handler itself decides whether to consume
+	// the input or release it back to normal routing.
 	if a.pendingPlan != nil {
-		return a.handlePendingPlan(ctx, input)
+		a.maybeStoreUserPreference(ctx, input)
+		response, handled := a.handlePendingPlan(ctx, input)
+		if handled {
+			return response, nil
+		}
+		// Fell through: input was unrelated to the pending plan. Drop the
+		// pending plan and route the input normally.
+		a.pendingPlan = nil
 	}
 
 	// --- Phase 2: Record user message ---
@@ -379,38 +373,105 @@ func authInstructions(provider string) string {
 	}
 }
 
-// handlePendingPlan processes user input when a plan is awaiting approval.
-func (a *KrillAgent) handlePendingPlan(ctx context.Context, input string) (string, error) {
-	normalized := strings.ToLower(strings.TrimSpace(input))
+// approvalDecision is the four-way outcome of judging a user reply against a
+// pending plan. It replaces the old yes/no/else trichotomy that looped on
+// anything outside a static word list.
+type approvalDecision string
 
-	// Check approval
-	if approvalWords[normalized] {
+const (
+	decisionApprove   approvalDecision = "APPROVE"   // run the plan
+	decisionReject    approvalDecision = "REJECT"    // scrap the plan
+	decisionModify    approvalDecision = "MODIFY"    // adjust the plan with new instructions
+	decisionUnrelated approvalDecision = "UNRELATED" // user moved on; drop pending plan and re-route
+)
+
+// handlePendingPlan processes user input when a plan is awaiting approval.
+// Returns (response, true) when the input was consumed by the approval flow,
+// or ("", false) when the caller should route the input as a fresh message.
+func (a *KrillAgent) handlePendingPlan(ctx context.Context, input string) (string, bool) {
+	decision := a.classifyApprovalReply(ctx, input)
+	switch decision {
+	case decisionApprove:
 		log.Info("plan approved by user", "task", a.pendingPlan.Task)
 		a.pendingPlan.Approved = true
 		plan := a.pendingPlan
 		a.pendingPlan = nil
-
 		result, err := a.ExecutePlan(ctx, plan)
 		if err != nil {
-			return fmt.Sprintf("This krill hit a reef executing the plan: %v", err), nil
+			return fmt.Sprintf("This krill hit a reef executing the plan: %v", err), true
 		}
-
 		a.appendMessage(core.Message{Role: "assistant", Content: result})
 		a.saveTurn("assistant", result)
-		return result, nil
-	}
+		return result, true
 
-	// Check rejection
-	if rejectionWords[normalized] {
+	case decisionReject:
 		log.Info("plan rejected by user", "task", a.pendingPlan.Task)
 		a.pendingPlan = nil
-		return "Plan scrapped. What else?", nil
+		return "Plan scrapped. What else?", true
+
+	case decisionModify:
+		// Regenerate from the user's new instructions instead of re-rendering
+		// the same prompt. This kills the loop that re-asked forever.
+		log.Info("plan modification requested", "task", a.pendingPlan.Task)
+		oldTask := a.pendingPlan.Task
+		a.pendingPlan = nil
+		// Compose: original task + user's modifier. Cheap and good enough.
+		newTask := oldTask + " — adjustment: " + strings.TrimSpace(input)
+		response, err := a.handleTask(ctx, newTask)
+		if err != nil {
+			return fmt.Sprintf("Could not adjust the plan: %v", err), true
+		}
+		return response, true
+
+	default: // decisionUnrelated
+		// User moved on. Release control so the caller routes the input as a
+		// brand new message.
+		log.Debug("pending plan released — input unrelated", "input_preview", truncate(input, 50))
+		return "", false
+	}
+}
+
+// classifyApprovalReply judges a user reply against a pending plan: regex fast
+// path for unambiguous yes/no, LLM fallback for everything else.
+func (a *KrillAgent) classifyApprovalReply(ctx context.Context, input string) approvalDecision {
+	normalized := strings.ToLower(strings.TrimSpace(input))
+	if approvalRegex.MatchString(normalized) {
+		return decisionApprove
+	}
+	if rejectionRegex.MatchString(normalized) {
+		return decisionReject
 	}
 
-	// Neither approval nor rejection - treat as modification request
-	log.Debug("ambiguous plan response", "input", normalized)
-	return fmt.Sprintf("I have a plan waiting for your call.\n\n%s\nReply with **yes** to approve, **no** to scrap, or describe what you want changed.",
-		FormatPlan(a.pendingPlan)), nil
+	// LLM judge — runs only on genuinely ambiguous replies.
+	prompt := `A user was shown a plan and asked to approve, reject, or modify it. Classify their reply into exactly ONE of:
+
+APPROVE   — they accept the plan as-is
+REJECT    — they want it scrapped entirely
+MODIFY    — they want changes to this specific plan
+UNRELATED — they ignored the plan and asked something else
+
+Reply with ONLY the category name. No explanation.
+
+Plan task: ` + a.pendingPlan.Task + `
+User reply: ` + input
+
+	resp, err := a.llm.Chat(ctx, []core.Message{{Role: "user", Content: prompt}},
+		core.WithTemperature(0.0), core.WithMaxTokens(8))
+	if err != nil {
+		log.Warn("approval LLM judge failed, treating as unrelated", "error", err)
+		return decisionUnrelated
+	}
+	out := strings.ToUpper(strings.TrimSpace(resp.Content))
+	switch {
+	case strings.Contains(out, "APPROVE"):
+		return decisionApprove
+	case strings.Contains(out, "REJECT"):
+		return decisionReject
+	case strings.Contains(out, "MODIFY"):
+		return decisionModify
+	default:
+		return decisionUnrelated
+	}
 }
 
 // handleTask generates a plan and presents it for approval.
@@ -539,6 +600,12 @@ func (a *KrillAgent) handleTaskCommand(input string) (string, bool) {
 
 // shouldRequireApproval decides if a plan needs user approval before execution.
 // Uses a three-way config: "always", "never", or "auto" (smart default).
+//
+// Explicit config wins (the operator made a deliberate choice). The user's
+// runtime pref:no_plan_approval flag is honoured under "auto" so the agent
+// stops re-asking once the user has said "stop asking" — but destructive
+// plans still gate under "auto" regardless of the pref. That keeps casual
+// "auto approve" phrases from authorising rm -rf.
 func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
 	switch a.cfg.PlanApproval {
 	case "always":
@@ -546,31 +613,16 @@ func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
 	case "never":
 		return false
 	default: // "auto"
-		// Large plans (5+ steps) need approval
-		if len(plan.Steps) >= 5 {
+		if planIsDestructive(plan) {
 			return true
 		}
-		// Plans with destructive hints need approval.
-		// Use specific phrases to avoid false positives like "drop-down",
-		// "push notification", "reset filter state".
-		for _, step := range plan.Steps {
-			if step.NeedsApproval {
-				return true
-			}
-			lower := strings.ToLower(step.Description)
-			for _, danger := range []string{
-				"delete file", "delete dir", "delete database", "delete branch",
-				"remove file", "remove dir", "remove package",
-				"deploy to", "deploy the",
-				"git push", "force push",
-				"npm install", "pip install", "go install",
-				"drop table", "drop database", "drop collection",
-				"destroy", "rm -", "reset --hard",
-			} {
-				if strings.Contains(lower, danger) {
-					return true
-				}
-			}
+		// User has said "stop asking" → trust them on non-destructive work.
+		if GetBoolPref(context.Background(), a.brain.Memory(), PrefNoPlanApproval, false) {
+			return false
+		}
+		// Large plans need approval
+		if len(plan.Steps) >= 5 {
+			return true
 		}
 		// Vague task descriptions need approval
 		lower := strings.ToLower(plan.Task)
@@ -582,6 +634,31 @@ func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
 		}
 		return false
 	}
+}
+
+// planIsDestructive returns true for plans whose steps touch destructive verbs
+// or are explicitly flagged. Kept separate so the safety check is easy to read.
+func planIsDestructive(plan *core.Plan) bool {
+	for _, step := range plan.Steps {
+		if step.NeedsApproval {
+			return true
+		}
+		lower := strings.ToLower(step.Description)
+		for _, danger := range []string{
+			"delete file", "delete dir", "delete database", "delete branch",
+			"remove file", "remove dir", "remove package",
+			"deploy to", "deploy the",
+			"git push", "force push",
+			"npm install", "pip install", "go install",
+			"drop table", "drop database", "drop collection",
+			"destroy", "rm -", "reset --hard",
+		} {
+			if strings.Contains(lower, danger) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // handleChat generates a conversational response using the LLM with brain enrichment.
@@ -606,6 +683,11 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 			Content: "Known user preferences and durable memories. Use these quietly for personalization; do not mention them unless relevant:\n\n" + memoryCtx,
 		}
 		enriched = append(enriched[:len(enriched)-1], memoryMsg, enriched[len(enriched)-1])
+	}
+
+	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
+		styleMsg := core.Message{Role: "system", Content: styleDirective}
+		enriched = append(enriched[:len(enriched)-1], styleMsg, enriched[len(enriched)-1])
 	}
 
 	resp, err := a.llm.Chat(ctx, enriched)
@@ -839,6 +921,11 @@ func (a *KrillAgent) handleAnswer(ctx context.Context) (string, error) {
 		enriched = append(enriched[:len(enriched)-1], memoryMsg, enriched[len(enriched)-1])
 	}
 
+	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
+		styleMsg := core.Message{Role: "system", Content: styleDirective}
+		enriched = append(enriched[:len(enriched)-1], styleMsg, enriched[len(enriched)-1])
+	}
+
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
 		log.Error("LLM answer failed", "error", err)
@@ -859,6 +946,16 @@ func (a *KrillAgent) maybeStoreUserPreference(ctx context.Context, input string)
 	if text == "" {
 		return
 	}
+
+	// Typed preferences first — these get a stable key so decision sites
+	// (shouldRequireApproval, persona builder) can read them directly without
+	// scanning free-text memories.
+	if key, value, matched := detectTypedPreference(text); matched {
+		SetBoolPref(ctx, mem, key, value)
+		log.Info("typed preference stored", "key", key, "value", value)
+		// Fall through so a free-text record is also kept for human-readable recall.
+	}
+
 	lower := strings.ToLower(text)
 	for _, explicit := range []string{"remember ", "remember that ", "learn ", "learn that ", "note ", "note that ", "memorize ", "memorize that "} {
 		if strings.HasPrefix(lower, explicit) {
@@ -874,6 +971,25 @@ func (a *KrillAgent) maybeStoreUserPreference(ctx context.Context, input string)
 		"please always ",
 		"please don't ",
 		"do not ",
+		"no need for ",
+		"no need to ",
+		"stop asking",
+		"don't ask",
+		"skip approval",
+		"auto approve",
+		"auto-approve",
+		"just do it",
+		"ask me before",
+		"require approval",
+		"be terse",
+		"be brief",
+		"be concise",
+		"shorter responses",
+		"keep it short",
+		"less verbose",
+		"no metaphor",
+		"drop the metaphor",
+		"stop with the metaphor",
 	}
 	matched := false
 	for _, trigger := range triggers {
@@ -1056,6 +1172,61 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 
 	if err := a.brain.Memory().Store(ctx, entry); err != nil {
 		log.Debug("failed to store feedback", "error", err)
+	}
+
+	// Adaptive personality: if the user has corrected us several times in
+	// rapid succession (and hasn't already opted into terse mode), assume
+	// they want shorter responses and flip the pref. They can undo this by
+	// asking for more detail later.
+	if signal == "correction" || signal == "negative" {
+		a.maybeAutoEvolveStyle(ctx, signal)
+	}
+}
+
+// maybeAutoEvolveStyle counts recent negative/correction signals and, when
+// they cross a threshold, flips a style preference automatically. This is
+// the "evolves with usage" loop — explicit feedback is great, but most users
+// communicate through corrections, not config commands.
+func (a *KrillAgent) maybeAutoEvolveStyle(ctx context.Context, latestSignal string) {
+	mem := a.brain.Memory()
+	if mem == nil {
+		return
+	}
+
+	// Already terse? Nothing to do.
+	if GetBoolPref(ctx, mem, PrefStyleTerse, false) {
+		return
+	}
+
+	// Look at recent feedback within the last hour. Three corrections in
+	// that window is a strong-enough signal.
+	entries, err := mem.Search(ctx, "personality-feedback", 20)
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-1 * time.Hour)
+	count := 0
+	for _, e := range entries {
+		if e.CreatedAt.Before(cutoff) {
+			continue
+		}
+		for _, tag := range e.Tags {
+			if tag == "correction" || tag == "negative" {
+				count++
+				break
+			}
+		}
+	}
+	// +1 for the signal we just observed (which is already stored above
+	// but may not be returned by Search depending on the backend's freshness).
+	if latestSignal == "correction" || latestSignal == "negative" {
+		count++
+	}
+
+	const threshold = 3
+	if count >= threshold {
+		log.Info("auto-evolving style: switching to terse mode", "recent_corrections", count)
+		SetBoolPref(ctx, mem, PrefStyleTerse, true)
 	}
 }
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -215,21 +215,26 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 	// "stop asking me to approve" gets captured *during* the approval state,
 	// not after. The pending-plan handler itself decides whether to consume
 	// the input or release it back to normal routing.
+	prefStored := false
 	if a.pendingPlan != nil {
 		a.maybeStoreUserPreference(ctx, input)
+		prefStored = true
 		response, handled := a.handlePendingPlan(ctx, input)
 		if handled {
 			return response, nil
 		}
 		// Fell through: input was unrelated to the pending plan. Drop the
-		// pending plan and route the input normally.
+		// pending plan and route the input normally — but don't store the
+		// preference twice, since pendingPlan already did it above.
 		a.pendingPlan = nil
 	}
 
 	// --- Phase 2: Record user message ---
 	a.appendMessage(core.Message{Role: "user", Content: input})
 	a.saveTurn("user", input)
-	a.maybeStoreUserPreference(ctx, input)
+	if !prefStored {
+		a.maybeStoreUserPreference(ctx, input)
+	}
 
 	// --- Phase 3: Classify intent via multi-intent router ---
 	route := a.router.Classify(ctx, input)
@@ -455,8 +460,11 @@ Reply with ONLY the category name. No explanation.
 Plan task: ` + a.pendingPlan.Task + `
 User reply: ` + input
 
+	// 24 tokens leaves headroom for category names that tokenize larger
+	// than expected (e.g. "UNRELATED" can be 2-3 tokens) plus a leading
+	// newline some instruction-following models emit.
 	resp, err := a.llm.Chat(ctx, []core.Message{{Role: "user", Content: prompt}},
-		core.WithTemperature(0.0), core.WithMaxTokens(8))
+		core.WithTemperature(0.0), core.WithMaxTokens(24))
 	if err != nil {
 		log.Warn("approval LLM judge failed, treating as unrelated", "error", err)
 		return decisionUnrelated
@@ -482,7 +490,7 @@ func (a *KrillAgent) handleTask(ctx context.Context, input string) (string, erro
 		return fmt.Sprintf("This krill's sonar is glitching - could not plan that task: %v", err), nil
 	}
 
-	if a.shouldRequireApproval(plan) {
+	if a.shouldRequireApproval(ctx, plan) {
 		// Store as pending and present for approval
 		a.pendingPlan = plan
 		formatted := FormatPlan(plan)
@@ -606,7 +614,7 @@ func (a *KrillAgent) handleTaskCommand(input string) (string, bool) {
 // stops re-asking once the user has said "stop asking" — but destructive
 // plans still gate under "auto" regardless of the pref. That keeps casual
 // "auto approve" phrases from authorising rm -rf.
-func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
+func (a *KrillAgent) shouldRequireApproval(ctx context.Context, plan *core.Plan) bool {
 	switch a.cfg.PlanApproval {
 	case "always":
 		return true
@@ -617,7 +625,7 @@ func (a *KrillAgent) shouldRequireApproval(plan *core.Plan) bool {
 			return true
 		}
 		// User has said "stop asking" → trust them on non-destructive work.
-		if GetBoolPref(context.Background(), a.brain.Memory(), PrefNoPlanApproval, false) {
+		if GetBoolPref(ctx, a.brain.Memory(), PrefNoPlanApproval, false) {
 			return false
 		}
 		// Large plans need approval
@@ -674,7 +682,7 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 			Role:    "system",
 			Content: "Your available capabilities: " + skillList + ". You CANNOT do anything outside these capabilities. If asked to do something not listed, say so honestly.",
 		}
-		enriched = append(enriched[:len(enriched)-1], capabilityMsg, enriched[len(enriched)-1])
+		enriched = insertBeforeLast(enriched, capabilityMsg)
 	}
 
 	if memoryCtx := a.buildUserMemoryContext(ctx, 8); memoryCtx != "" {
@@ -682,12 +690,12 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 			Role:    "system",
 			Content: "Known user preferences and durable memories. Use these quietly for personalization; do not mention them unless relevant:\n\n" + memoryCtx,
 		}
-		enriched = append(enriched[:len(enriched)-1], memoryMsg, enriched[len(enriched)-1])
+		enriched = insertBeforeLast(enriched, memoryMsg)
 	}
 
 	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
 		styleMsg := core.Message{Role: "system", Content: styleDirective}
-		enriched = append(enriched[:len(enriched)-1], styleMsg, enriched[len(enriched)-1])
+		enriched = insertBeforeLast(enriched, styleMsg)
 	}
 
 	resp, err := a.llm.Chat(ctx, enriched)
@@ -745,7 +753,7 @@ func (a *KrillAgent) handleSelfSkill(ctx context.Context, skillName, skillInput 
 		Role:    "system",
 		Content: "Here is information about yourself that the user is asking about. Use it to respond naturally in first person:\n\n" + result,
 	}
-	enriched = append(enriched[:len(enriched)-1], selfCtx, enriched[len(enriched)-1])
+	enriched = insertBeforeLast(enriched, selfCtx)
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
 		// Fallback: return raw self-skill output
@@ -808,7 +816,7 @@ func (a *KrillAgent) handleRemember(ctx context.Context, input, operation string
 					Role:    "system",
 					Content: "Here are the krill's relevant memories. Respond naturally:\n\n" + result,
 				}
-				enriched = append(enriched[:len(enriched)-1], recallCtx, enriched[len(enriched)-1])
+				enriched = insertBeforeLast(enriched, recallCtx)
 				resp, err := a.llm.Chat(ctx, enriched)
 				if err != nil {
 					a.appendMessage(core.Message{Role: "assistant", Content: result})
@@ -862,7 +870,7 @@ func (a *KrillAgent) handleToolTask(ctx context.Context, input, toolName string)
 		Role:    "system",
 		Content: fmt.Sprintf("Here are the results from the %s tool. Use them to answer the user's question:\n\n%s", toolName, result),
 	}
-	enriched = append(enriched[:len(enriched)-1], toolCtx, enriched[len(enriched)-1])
+	enriched = insertBeforeLast(enriched, toolCtx)
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
 		// Fallback: return raw tool output
@@ -887,7 +895,7 @@ func (a *KrillAgent) handleDiagnose(ctx context.Context) (string, error) {
 			"suggest concrete fixes, and keep your answer focused and actionable. " +
 			"Do NOT create a plan or ask for approval - just answer directly.",
 	}
-	enriched = append(enriched[:len(enriched)-1], diagMsg, enriched[len(enriched)-1])
+	enriched = insertBeforeLast(enriched, diagMsg)
 
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
@@ -911,19 +919,19 @@ func (a *KrillAgent) handleAnswer(ctx context.Context) (string, error) {
 			"Do not create a plan, do not ask for approval, and do not ask follow-up questions " +
 			"unless you truly need clarification to give a useful answer.",
 	}
-	enriched = append(enriched[:len(enriched)-1], answerMsg, enriched[len(enriched)-1])
+	enriched = insertBeforeLast(enriched, answerMsg)
 
 	if memoryCtx := a.buildUserMemoryContext(ctx, 8); memoryCtx != "" {
 		memoryMsg := core.Message{
 			Role:    "system",
 			Content: "Known user preferences:\n\n" + memoryCtx,
 		}
-		enriched = append(enriched[:len(enriched)-1], memoryMsg, enriched[len(enriched)-1])
+		enriched = insertBeforeLast(enriched, memoryMsg)
 	}
 
 	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
 		styleMsg := core.Message{Role: "system", Content: styleDirective}
-		enriched = append(enriched[:len(enriched)-1], styleMsg, enriched[len(enriched)-1])
+		enriched = insertBeforeLast(enriched, styleMsg)
 	}
 
 	resp, err := a.llm.Chat(ctx, enriched)
@@ -1176,10 +1184,10 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 
 	// Adaptive personality: if the user has corrected us several times in
 	// rapid succession (and hasn't already opted into terse mode), assume
-	// they want shorter responses and flip the pref. They can undo this by
-	// asking for more detail later.
+	// they want shorter responses and flip the pref. The user can undo this
+	// by saying "be verbose" / "more detail" — see detectTypedPreference.
 	if signal == "correction" || signal == "negative" {
-		a.maybeAutoEvolveStyle(ctx, signal)
+		a.maybeAutoEvolveStyle(ctx, key, signal)
 	}
 }
 
@@ -1187,7 +1195,13 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 // they cross a threshold, flips a style preference automatically. This is
 // the "evolves with usage" loop — explicit feedback is great, but most users
 // communicate through corrections, not config commands.
-func (a *KrillAgent) maybeAutoEvolveStyle(ctx context.Context, latestSignal string) {
+//
+// latestKey is the storage key of the entry that recordFeedback just stored;
+// it's skipped during the search loop and counted exactly once via the
+// explicit increment below. Without this guard, a backend that returns the
+// fresh entry would double-count it (loop adds 1, then the explicit +1 adds
+// another), tripping the threshold one signal early.
+func (a *KrillAgent) maybeAutoEvolveStyle(ctx context.Context, latestKey, latestSignal string) {
 	mem := a.brain.Memory()
 	if mem == nil {
 		return
@@ -1207,6 +1221,9 @@ func (a *KrillAgent) maybeAutoEvolveStyle(ctx context.Context, latestSignal stri
 	cutoff := time.Now().Add(-1 * time.Hour)
 	count := 0
 	for _, e := range entries {
+		if e.Key == latestKey {
+			continue // counted once via the explicit increment below
+		}
 		if e.CreatedAt.Before(cutoff) {
 			continue
 		}
@@ -1217,8 +1234,8 @@ func (a *KrillAgent) maybeAutoEvolveStyle(ctx context.Context, latestSignal stri
 			}
 		}
 	}
-	// +1 for the signal we just observed (which is already stored above
-	// but may not be returned by Search depending on the backend's freshness).
+	// Always +1 for the signal we just observed. Combined with the key skip
+	// above this gives an exact count regardless of backend consistency.
 	if latestSignal == "correction" || latestSignal == "negative" {
 		count++
 	}
@@ -1275,6 +1292,30 @@ func (a *KrillAgent) appendMessage(msg core.Message) {
 		trimmed = append(trimmed, a.history[1+excess:]...)
 		a.history = trimmed
 	}
+}
+
+// insertBeforeLast returns a new slice with `inserts` placed just before the
+// final element of `msgs`. The final element is conventionally the latest
+// user message, so this is how we add system-context messages (capabilities,
+// memory, style directives) without disturbing turn order.
+//
+// Always allocates a fresh backing array, so callers don't have to reason
+// about aliasing or capacity surprises that the previous append-trick had.
+func insertBeforeLast(msgs []core.Message, inserts ...core.Message) []core.Message {
+	if len(msgs) == 0 {
+		return append([]core.Message{}, inserts...)
+	}
+	if len(inserts) == 0 {
+		out := make([]core.Message, len(msgs))
+		copy(out, msgs)
+		return out
+	}
+	n := len(msgs)
+	out := make([]core.Message, 0, n+len(inserts))
+	out = append(out, msgs[:n-1]...)
+	out = append(out, inserts...)
+	out = append(out, msgs[n-1])
+	return out
 }
 
 // buildSkillSummary returns a short comma-separated list of enabled skill names

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -112,7 +112,7 @@ func detectTypedPreference(input string) (key string, value bool, matched bool) 
 		}
 	}
 
-	// Style: terseness.
+	// Style: terseness — flip on.
 	tersePhrases := []string{
 		"be terse", "be more terse", "be brief", "be more brief",
 		"shorter responses", "keep it short", "be concise", "be more concise",
@@ -121,6 +121,18 @@ func detectTypedPreference(input string) (key string, value bool, matched bool) 
 	for _, p := range tersePhrases {
 		if strings.Contains(lower, p) {
 			return PrefStyleTerse, true, true
+		}
+	}
+
+	// Style: terseness — flip off (verbose mode). Symmetric inverse so a
+	// user who got auto-flipped to terse can recover with natural language.
+	verbosePhrases := []string{
+		"be verbose", "be more verbose", "be detailed", "more detail",
+		"longer responses", "give me more detail", "more thorough",
+	}
+	for _, p := range verbosePhrases {
+		if strings.Contains(lower, p) {
+			return PrefStyleTerse, false, true
 		}
 	}
 

--- a/internal/agent/prefs.go
+++ b/internal/agent/prefs.go
@@ -1,0 +1,167 @@
+// Package agent — typed user-preference layer on top of brain.Memory().
+// Free-text memory was the only learning channel before; this gives the
+// agent a small set of stable boolean keys it can read and write at decision
+// time (e.g. shouldRequireApproval reading pref:no_plan_approval).
+package agent
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// Stable preference keys. Add new ones here so callers can't typo them.
+const (
+	PrefNoPlanApproval = "pref:no_plan_approval"
+	PrefStyleTerse     = "pref:style_terse"
+	PrefNoMetaphors    = "pref:no_metaphors"
+)
+
+// GetBoolPref returns the boolean value of a typed preference, or `def` if
+// the entry is missing or the memory layer is unavailable.
+func GetBoolPref(ctx context.Context, mem core.Memory, key string, def bool) bool {
+	if mem == nil {
+		return def
+	}
+	entry, err := mem.Recall(ctx, key)
+	if err != nil || entry == nil {
+		return def
+	}
+	switch strings.ToLower(strings.TrimSpace(entry.Value)) {
+	case "true", "yes", "1", "on":
+		return true
+	case "false", "no", "0", "off":
+		return false
+	}
+	return def
+}
+
+// SetBoolPref writes a typed boolean preference. Stored in user scope so it
+// survives across platforms.
+func SetBoolPref(ctx context.Context, mem core.Memory, key string, value bool) {
+	if mem == nil {
+		return
+	}
+	v := "false"
+	if value {
+		v = "true"
+	}
+	entry := core.MemoryEntry{
+		Key:        key,
+		Value:      v,
+		Tags:       []string{"user-preference", "typed", "auto-learned"},
+		Scope:      "user",
+		Source:     "auto-learned",
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	}
+	if err := mem.Store(ctx, entry); err != nil {
+		log.Debug("set bool pref failed", "key", key, "error", err)
+	}
+}
+
+// detectTypedPreference scans the user's input for phrases that should flip
+// a typed preference. Returns (key, value, matched). matched=false means the
+// caller should fall through to the free-text preference path.
+//
+// We deliberately keep this list small. Each entry is a phrase the user is
+// likely to actually type when they want a behavior change.
+func detectTypedPreference(input string) (key string, value bool, matched bool) {
+	lower := strings.ToLower(strings.TrimSpace(input))
+	if lower == "" {
+		return "", false, false
+	}
+
+	// "Stop asking me to approve" / "no need for approval" → set true.
+	skipApprovalPhrases := []string{
+		"no need for approval",
+		"no need to approve",
+		"no need for taking my approval",
+		"no need to take my approval",
+		"don't ask for approval",
+		"do not ask for approval",
+		"stop asking for approval",
+		"stop asking me to approve",
+		"skip approval",
+		"skip the approval",
+		"auto approve",
+		"auto-approve",
+		"just do it",
+		"don't ask, just do",
+	}
+	for _, p := range skipApprovalPhrases {
+		if strings.Contains(lower, p) {
+			return PrefNoPlanApproval, true, true
+		}
+	}
+
+	// Inverse: "ask me before doing things" → set false (re-enable approval).
+	requireApprovalPhrases := []string{
+		"ask me before",
+		"always ask before",
+		"require approval",
+		"please ask first",
+		"check with me before",
+	}
+	for _, p := range requireApprovalPhrases {
+		if strings.Contains(lower, p) {
+			return PrefNoPlanApproval, false, true
+		}
+	}
+
+	// Style: terseness.
+	tersePhrases := []string{
+		"be terse", "be more terse", "be brief", "be more brief",
+		"shorter responses", "keep it short", "be concise", "be more concise",
+		"less verbose",
+	}
+	for _, p := range tersePhrases {
+		if strings.Contains(lower, p) {
+			return PrefStyleTerse, true, true
+		}
+	}
+
+	// Style: drop the krill metaphors.
+	noMetaphorPhrases := []string{
+		"no metaphor", "stop with the metaphors", "drop the metaphors",
+		"less ocean", "less krill metaphor", "no krill metaphor",
+		"stop the ocean talk",
+	}
+	for _, p := range noMetaphorPhrases {
+		if strings.Contains(lower, p) {
+			return PrefNoMetaphors, true, true
+		}
+	}
+
+	return "", false, false
+}
+
+// buildStyleDirective composes a short style instruction from the user's
+// typed preferences, suitable for injection as a system message. Returns ""
+// when no style preferences are set.
+//
+// This is the "evolves with usage" hook: as the user accrues preferences,
+// the persona delta grows; the static soul.go prompt is the floor, this is
+// the user-specific overlay.
+func buildStyleDirective(ctx context.Context, mem core.Memory) string {
+	if mem == nil {
+		return ""
+	}
+	var parts []string
+	if GetBoolPref(ctx, mem, PrefStyleTerse, false) {
+		parts = append(parts, "Keep responses short and to the point. No filler, no lengthy preambles, no trailing summaries.")
+	}
+	if GetBoolPref(ctx, mem, PrefNoMetaphors, false) {
+		parts = append(parts, "Skip ocean/krill metaphors and ocean-themed framing. Plain technical language only.")
+	}
+	if GetBoolPref(ctx, mem, PrefNoPlanApproval, false) {
+		parts = append(parts, "The user has opted out of plan approval. Don't ask for approval on non-destructive work — just do it.")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "User style preferences (apply silently):\n- " + strings.Join(parts, "\n- ")
+}

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -186,6 +186,22 @@ func TestDetectTypedPreference_Style(t *testing.T) {
 	}
 }
 
+func TestDetectTypedPreference_VerboseFlipsTerseOff(t *testing.T) {
+	cases := []string{
+		"be verbose",
+		"give me more detail",
+		"longer responses please",
+		"be more thorough",
+	}
+	for _, c := range cases {
+		key, val, matched := detectTypedPreference(c)
+		if !matched || key != PrefStyleTerse || val {
+			t.Errorf("detectTypedPreference(%q) → (%q, %v, %v); want (%q, false, true)",
+				c, key, val, matched, PrefStyleTerse)
+		}
+	}
+}
+
 func TestDetectTypedPreference_NoMatch(t *testing.T) {
 	cases := []string{
 		"hello",
@@ -293,7 +309,7 @@ func TestShouldRequireApproval_PrefSkipsForSafePlan(t *testing.T) {
 		},
 	}
 
-	if a.shouldRequireApproval(plan) {
+	if a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("auto + pref:no_plan_approval should skip approval on non-destructive plan")
 	}
 }
@@ -310,7 +326,7 @@ func TestShouldRequireApproval_PrefDoesNotSkipDestructive(t *testing.T) {
 		},
 	}
 
-	if !a.shouldRequireApproval(plan) {
+	if !a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("destructive plan must still gate even with pref:no_plan_approval=true")
 	}
 }
@@ -325,7 +341,7 @@ func TestShouldRequireApproval_PrefDoesNotOverrideAlways(t *testing.T) {
 		Steps: []core.PlanStep{{ID: 1, Description: "do something"}},
 	}
 
-	if !a.shouldRequireApproval(plan) {
+	if !a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("config 'always' must override the pref")
 	}
 }
@@ -539,7 +555,7 @@ func TestMaybeAutoEvolveStyle_FlipsAfterThreshold(t *testing.T) {
 	}
 
 	// One more correction triggers the threshold.
-	a.maybeAutoEvolveStyle(ctx, "correction")
+	a.maybeAutoEvolveStyle(ctx, "feedback_test_latest", "correction")
 
 	if !GetBoolPref(ctx, mem, PrefStyleTerse, false) {
 		t.Error("expected pref:style_terse to flip after 3 corrections")
@@ -562,10 +578,79 @@ func TestMaybeAutoEvolveStyle_BelowThresholdDoesNothing(t *testing.T) {
 	}
 	_ = mem.Store(ctx, entry)
 
-	a.maybeAutoEvolveStyle(ctx, "correction")
+	a.maybeAutoEvolveStyle(ctx, "feedback_test_latest", "correction")
 
 	if GetBoolPref(ctx, mem, PrefStyleTerse, false) {
 		t.Error("pref:style_terse should not flip below threshold")
+	}
+}
+
+func TestMaybeAutoEvolveStyle_NoDoubleCountOnLatestKey(t *testing.T) {
+	// Reproduces the original review concern: recordFeedback stores the entry
+	// before calling maybeAutoEvolveStyle, so when Memory.Search returns it,
+	// we'd double-count without the latestKey skip. Two stored entries +
+	// one already-stored "latest" should equal 3, not 4.
+	mem := newFakeMemory()
+	a := newAgentWithMemory("auto", mem)
+	ctx := context.Background()
+
+	// Two pre-existing recent corrections.
+	for i := 0; i < 2; i++ {
+		_ = mem.Store(ctx, core.MemoryEntry{
+			Key:        "feedback_pre_" + string(rune('a'+i)),
+			Value:      "signal:correction",
+			Tags:       []string{"personality-feedback", "correction"},
+			Scope:      "system",
+			CreatedAt:  time.Now(),
+			AccessedAt: time.Now(),
+		})
+	}
+
+	// Simulate recordFeedback: store the latest first, then call evolve.
+	latestKey := "feedback_latest"
+	_ = mem.Store(ctx, core.MemoryEntry{
+		Key:        latestKey,
+		Value:      "signal:correction",
+		Tags:       []string{"personality-feedback", "correction"},
+		Scope:      "system",
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	})
+
+	a.maybeAutoEvolveStyle(ctx, latestKey, "correction")
+
+	// Threshold is 3. With the skip, count = 2 (pre) + 1 (explicit) = 3 → flips.
+	// Without the skip, count = 3 (all in store) + 1 (explicit) = 4 → also flips,
+	// so this test on its own can't catch double-counting at threshold. Run a
+	// second sub-case with only ONE pre-stored signal: with skip, count = 1+1=2
+	// (no flip). Without skip, count = 2+1=3 (incorrectly flips).
+	if !GetBoolPref(ctx, mem, PrefStyleTerse, false) {
+		t.Error("expected pref:style_terse to flip with 3 distinct signals")
+	}
+
+	// Sub-case: only one pre-stored + the latest = 2 distinct signals total,
+	// should NOT flip even though the latest is in store.
+	mem2 := newFakeMemory()
+	a2 := newAgentWithMemory("auto", mem2)
+	_ = mem2.Store(ctx, core.MemoryEntry{
+		Key:        "feedback_only_one",
+		Value:      "signal:correction",
+		Tags:       []string{"personality-feedback", "correction"},
+		Scope:      "system",
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	})
+	_ = mem2.Store(ctx, core.MemoryEntry{
+		Key:        "feedback_latest",
+		Value:      "signal:correction",
+		Tags:       []string{"personality-feedback", "correction"},
+		Scope:      "system",
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	})
+	a2.maybeAutoEvolveStyle(ctx, "feedback_latest", "correction")
+	if GetBoolPref(ctx, mem2, PrefStyleTerse, false) {
+		t.Error("with only 2 distinct signals, threshold should NOT trip; double-counting bug detected")
 	}
 }
 
@@ -588,7 +673,7 @@ func TestMaybeAutoEvolveStyle_OldSignalsDontCount(t *testing.T) {
 		_ = mem.Store(ctx, entry)
 	}
 
-	a.maybeAutoEvolveStyle(ctx, "correction")
+	a.maybeAutoEvolveStyle(ctx, "feedback_test_latest", "correction")
 
 	if GetBoolPref(ctx, mem, PrefStyleTerse, false) {
 		t.Error("old corrections (>1h) should not contribute to threshold")

--- a/internal/agent/prefs_test.go
+++ b/internal/agent/prefs_test.go
@@ -1,0 +1,596 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// ---------------------------------------------------------------------------
+// In-memory Memory mock — needed for tests that exercise typed preferences
+// and feedback signals. The default mockBrain returns nil for Memory(), so
+// pref-related code paths are bypassed and can't be tested with it.
+// ---------------------------------------------------------------------------
+
+type memBrain struct {
+	mem core.Memory
+}
+
+func (b *memBrain) Memory() core.Memory                       { return b.mem }
+func (b *memBrain) ConversationStore() core.ConversationStore { return nil }
+func (b *memBrain) GetPersonality() *core.Personality         { return &core.Personality{Name: "TestKrill"} }
+func (b *memBrain) GetSoul() *core.Soul {
+	return &core.Soul{SystemPrompt: "You are a test krill.", Identity: "test"}
+}
+func (b *memBrain) SystemPrompt() string { return "You are a test krill." }
+func (b *memBrain) RandomFact() string   { return "Krill are tiny." }
+func (b *memBrain) EnrichMessages(msgs []core.Message) []core.Message {
+	sysMsg := core.Message{Role: "system", Content: "You are a test krill."}
+	if len(msgs) > 0 && msgs[0].Role == "system" {
+		out := make([]core.Message, len(msgs))
+		copy(out, msgs)
+		out[0] = sysMsg
+		return out
+	}
+	out := make([]core.Message, 0, len(msgs)+1)
+	out = append(out, sysMsg)
+	out = append(out, msgs...)
+	return out
+}
+
+type fakeMemory struct {
+	mu      sync.Mutex
+	entries map[string]core.MemoryEntry
+}
+
+func newFakeMemory() *fakeMemory { return &fakeMemory{entries: map[string]core.MemoryEntry{}} }
+
+func (m *fakeMemory) Store(_ context.Context, entry core.MemoryEntry) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries[entry.Key] = entry
+	return nil
+}
+func (m *fakeMemory) Recall(_ context.Context, key string) (*core.MemoryEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	e, ok := m.entries[key]
+	if !ok {
+		return nil, nil
+	}
+	return &e, nil
+}
+func (m *fakeMemory) Search(_ context.Context, query string, limit int) ([]core.MemoryEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []core.MemoryEntry
+	for _, e := range m.entries {
+		if query == "" {
+			out = append(out, e)
+			continue
+		}
+		// substring match on value or any tag
+		if strings.Contains(strings.ToLower(e.Value), strings.ToLower(query)) {
+			out = append(out, e)
+			continue
+		}
+		for _, t := range e.Tags {
+			if strings.Contains(strings.ToLower(t), strings.ToLower(query)) {
+				out = append(out, e)
+				break
+			}
+		}
+	}
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
+}
+func (m *fakeMemory) RankedSearch(ctx context.Context, query, _ string, limit int) ([]core.MemoryEntry, error) {
+	return m.Search(ctx, query, limit)
+}
+func (m *fakeMemory) Forget(_ context.Context, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.entries, key)
+	return nil
+}
+func (m *fakeMemory) List(_ context.Context) ([]core.MemoryEntry, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]core.MemoryEntry, 0, len(m.entries))
+	for _, e := range m.entries {
+		out = append(out, e)
+	}
+	return out, nil
+}
+func (m *fakeMemory) Count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.entries)
+}
+
+// ---------------------------------------------------------------------------
+// detectTypedPreference
+// ---------------------------------------------------------------------------
+
+func TestDetectTypedPreference_NoApproval(t *testing.T) {
+	cases := []string{
+		"no need for approval",
+		"No need for taking my approval on this kind of things",
+		"Stop asking me to approve",
+		"don't ask for approval",
+		"skip approval",
+		"auto approve",
+		"just do it",
+	}
+	for _, c := range cases {
+		key, val, matched := detectTypedPreference(c)
+		if !matched {
+			t.Errorf("detectTypedPreference(%q) = not matched, want matched", c)
+			continue
+		}
+		if key != PrefNoPlanApproval {
+			t.Errorf("detectTypedPreference(%q) key = %q, want %q", c, key, PrefNoPlanApproval)
+		}
+		if !val {
+			t.Errorf("detectTypedPreference(%q) val = false, want true", c)
+		}
+	}
+}
+
+func TestDetectTypedPreference_RequireApproval(t *testing.T) {
+	cases := []string{
+		"ask me before doing things",
+		"please ask first",
+		"require approval",
+		"check with me before deploying",
+	}
+	for _, c := range cases {
+		key, val, matched := detectTypedPreference(c)
+		if !matched {
+			t.Errorf("detectTypedPreference(%q) = not matched, want matched", c)
+			continue
+		}
+		if key != PrefNoPlanApproval {
+			t.Errorf("detectTypedPreference(%q) key = %q, want %q", c, key, PrefNoPlanApproval)
+		}
+		if val {
+			t.Errorf("detectTypedPreference(%q) val = true, want false", c)
+		}
+	}
+}
+
+func TestDetectTypedPreference_Style(t *testing.T) {
+	terseInputs := []string{"be terse", "be more concise", "shorter responses please", "keep it short"}
+	for _, c := range terseInputs {
+		key, val, matched := detectTypedPreference(c)
+		if !matched || key != PrefStyleTerse || !val {
+			t.Errorf("detectTypedPreference(%q) → (%q, %v, %v); want (%q, true, true)",
+				c, key, val, matched, PrefStyleTerse)
+		}
+	}
+
+	noMetaInputs := []string{"no metaphors", "stop with the metaphors", "drop the metaphors"}
+	for _, c := range noMetaInputs {
+		key, val, matched := detectTypedPreference(c)
+		if !matched || key != PrefNoMetaphors || !val {
+			t.Errorf("detectTypedPreference(%q) → (%q, %v, %v); want (%q, true, true)",
+				c, key, val, matched, PrefNoMetaphors)
+		}
+	}
+}
+
+func TestDetectTypedPreference_NoMatch(t *testing.T) {
+	cases := []string{
+		"hello",
+		"what time is it",
+		"build me a website",
+		"give me some ideas",
+		"",
+	}
+	for _, c := range cases {
+		_, _, matched := detectTypedPreference(c)
+		if matched {
+			t.Errorf("detectTypedPreference(%q) unexpectedly matched", c)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetBoolPref / SetBoolPref round-trip
+// ---------------------------------------------------------------------------
+
+func TestBoolPrefRoundTrip(t *testing.T) {
+	mem := newFakeMemory()
+	ctx := context.Background()
+
+	if v := GetBoolPref(ctx, mem, PrefNoPlanApproval, false); v != false {
+		t.Errorf("default should be false, got true")
+	}
+	if v := GetBoolPref(ctx, mem, PrefNoPlanApproval, true); v != true {
+		t.Errorf("default should be true when entry missing, got false")
+	}
+
+	SetBoolPref(ctx, mem, PrefNoPlanApproval, true)
+	if v := GetBoolPref(ctx, mem, PrefNoPlanApproval, false); v != true {
+		t.Errorf("after set true, GetBoolPref returned false")
+	}
+
+	SetBoolPref(ctx, mem, PrefNoPlanApproval, false)
+	if v := GetBoolPref(ctx, mem, PrefNoPlanApproval, true); v != false {
+		t.Errorf("after set false, GetBoolPref returned true")
+	}
+}
+
+func TestBoolPrefNilMemory(t *testing.T) {
+	ctx := context.Background()
+	if v := GetBoolPref(ctx, nil, PrefNoPlanApproval, true); v != true {
+		t.Errorf("nil memory should fall back to default")
+	}
+	// SetBoolPref with nil memory must not panic.
+	SetBoolPref(ctx, nil, PrefNoPlanApproval, true)
+}
+
+// ---------------------------------------------------------------------------
+// buildStyleDirective
+// ---------------------------------------------------------------------------
+
+func TestBuildStyleDirective_Empty(t *testing.T) {
+	mem := newFakeMemory()
+	if got := buildStyleDirective(context.Background(), mem); got != "" {
+		t.Errorf("expected empty directive when no prefs set, got: %q", got)
+	}
+}
+
+func TestBuildStyleDirective_Composes(t *testing.T) {
+	mem := newFakeMemory()
+	ctx := context.Background()
+	SetBoolPref(ctx, mem, PrefStyleTerse, true)
+	SetBoolPref(ctx, mem, PrefNoMetaphors, true)
+
+	got := buildStyleDirective(ctx, mem)
+	if got == "" {
+		t.Fatal("expected non-empty directive")
+	}
+	if !strings.Contains(strings.ToLower(got), "short") {
+		t.Errorf("expected terse directive, got: %s", got)
+	}
+	if !strings.Contains(strings.ToLower(got), "metaphor") {
+		t.Errorf("expected metaphor directive, got: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// shouldRequireApproval honours pref:no_plan_approval
+// ---------------------------------------------------------------------------
+
+func newAgentWithMemory(approval string, mem core.Memory) *KrillAgent {
+	return New(
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: approval},
+		&MockProvider{chatResponse: "CHAT"},
+		&memBrain{mem: mem},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+}
+
+func TestShouldRequireApproval_PrefSkipsForSafePlan(t *testing.T) {
+	mem := newFakeMemory()
+	SetBoolPref(context.Background(), mem, PrefNoPlanApproval, true)
+	a := newAgentWithMemory("auto", mem)
+
+	plan := &core.Plan{
+		Task: "improve everything in the whole project", // would normally gate on "everything"
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "analyze code"},
+			{ID: 2, Description: "make improvements"},
+		},
+	}
+
+	if a.shouldRequireApproval(plan) {
+		t.Error("auto + pref:no_plan_approval should skip approval on non-destructive plan")
+	}
+}
+
+func TestShouldRequireApproval_PrefDoesNotSkipDestructive(t *testing.T) {
+	mem := newFakeMemory()
+	SetBoolPref(context.Background(), mem, PrefNoPlanApproval, true)
+	a := newAgentWithMemory("auto", mem)
+
+	plan := &core.Plan{
+		Task: "cleanup old branches",
+		Steps: []core.PlanStep{
+			{ID: 1, Description: "delete branch old-feature"},
+		},
+	}
+
+	if !a.shouldRequireApproval(plan) {
+		t.Error("destructive plan must still gate even with pref:no_plan_approval=true")
+	}
+}
+
+func TestShouldRequireApproval_PrefDoesNotOverrideAlways(t *testing.T) {
+	mem := newFakeMemory()
+	SetBoolPref(context.Background(), mem, PrefNoPlanApproval, true)
+	a := newAgentWithMemory("always", mem)
+
+	plan := &core.Plan{
+		Task:  "small task",
+		Steps: []core.PlanStep{{ID: 1, Description: "do something"}},
+	}
+
+	if !a.shouldRequireApproval(plan) {
+		t.Error("config 'always' must override the pref")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// planIsDestructive
+// ---------------------------------------------------------------------------
+
+func TestPlanIsDestructive(t *testing.T) {
+	cases := []struct {
+		name string
+		plan *core.Plan
+		want bool
+	}{
+		{
+			name: "rm -rf",
+			plan: &core.Plan{Steps: []core.PlanStep{{Description: "rm -rf node_modules"}}},
+			want: true,
+		},
+		{
+			name: "git push",
+			plan: &core.Plan{Steps: []core.PlanStep{{Description: "git push origin main"}}},
+			want: true,
+		},
+		{
+			name: "needs-approval flag",
+			plan: &core.Plan{Steps: []core.PlanStep{{Description: "innocuous", NeedsApproval: true}}},
+			want: true,
+		},
+		{
+			name: "drop-down (false positive guard)",
+			plan: &core.Plan{Steps: []core.PlanStep{{Description: "create a drop-down menu"}}},
+			want: false,
+		},
+		{
+			name: "summarize results",
+			plan: &core.Plan{Steps: []core.PlanStep{{Description: "summarize the findings"}}},
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := planIsDestructive(tc.plan); got != tc.want {
+				t.Errorf("planIsDestructive(%s) = %v, want %v", tc.name, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Approval / rejection regex coverage
+// ---------------------------------------------------------------------------
+
+func TestApprovalRegexAcceptsCasualYes(t *testing.T) {
+	approving := []string{"yes", "Yes", "YES", "y", "yea", "yeah", "yep", "yup",
+		"sure", "ok", "okay", "alright", "alright!", "Sounds good", "lgtm", "go ahead",
+		"do it", "proceed", "approve", "approved", "go", "fine", "👍"}
+	for _, s := range approving {
+		norm := strings.ToLower(strings.TrimSpace(s))
+		if !approvalRegex.MatchString(norm) {
+			t.Errorf("approvalRegex missed %q", s)
+		}
+	}
+}
+
+func TestRejectionRegexAcceptsCasualNo(t *testing.T) {
+	rejecting := []string{"no", "No", "n", "nah", "nope", "cancel", "cancelled",
+		"stop", "abort", "reject", "rejected", "skip", "nevermind", "never mind",
+		"forget it", "don't", "dont"}
+	for _, s := range rejecting {
+		norm := strings.ToLower(strings.TrimSpace(s))
+		if !rejectionRegex.MatchString(norm) {
+			t.Errorf("rejectionRegex missed %q", s)
+		}
+	}
+}
+
+func TestApprovalRegexDoesNotMatchSentences(t *testing.T) {
+	// Real sentences should fall through to LLM judging, not be auto-approved
+	notApproval := []string{
+		"yes but change step 3",
+		"actually no",
+		"can you make the plan smaller",
+		"why did you choose go",
+	}
+	for _, s := range notApproval {
+		norm := strings.ToLower(strings.TrimSpace(s))
+		if approvalRegex.MatchString(norm) {
+			t.Errorf("approvalRegex unexpectedly matched %q (should fall through)", s)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pending-plan flow: MODIFY regenerates, UNRELATED releases control,
+// "yea" approves (the original transcript bug)
+// ---------------------------------------------------------------------------
+
+func TestPendingPlan_YeaApproves(t *testing.T) {
+	a := newTestAgent("execution result")
+	a.pendingPlan = &core.Plan{
+		Task:  "test task",
+		Steps: []core.PlanStep{{ID: 1, Description: "step", Status: "pending"}},
+	}
+
+	resp, err := a.Chat(context.Background(), "yea")
+	if err != nil {
+		t.Fatalf("Chat error: %v", err)
+	}
+	if a.pendingPlan != nil {
+		t.Error("pending plan should be nil after 'yea' approval")
+	}
+	if resp == "" {
+		t.Error("expected execution response")
+	}
+}
+
+func TestPendingPlan_UnrelatedReleasesControl(t *testing.T) {
+	// Sequential mock: first call is the LLM approval judge (returns UNRELATED),
+	// second is the chat response after the input was re-routed.
+	callCount := 0
+	provider := &sequentialMockProvider{
+		responses: []string{
+			"UNRELATED",
+			"hello back",
+		},
+		callCount: &callCount,
+	}
+	a := New(
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: "always"},
+		provider,
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+	a.pendingPlan = &core.Plan{
+		Task:  "old task",
+		Steps: []core.PlanStep{{ID: 1, Description: "step", Status: "pending"}},
+	}
+
+	// "hi" is unambiguously unrelated to the pending plan; the LLM judge mock
+	// returns UNRELATED so the agent should drop the plan and route normally.
+	resp, err := a.Chat(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("Chat error: %v", err)
+	}
+	if a.pendingPlan != nil {
+		t.Error("pending plan should be nil after UNRELATED reply (control released)")
+	}
+	if resp == "" {
+		t.Error("expected a response after re-routing")
+	}
+	if strings.Contains(resp, "Approve this plan") {
+		t.Errorf("UNRELATED reply must not loop the approval prompt, got: %s", resp)
+	}
+}
+
+func TestPendingPlan_LearnsNoApprovalDuringPending(t *testing.T) {
+	// Even while a plan is pending, "no need for approval" should be captured
+	// so the next plan does not gate.
+	mem := newFakeMemory()
+	callCount := 0
+	provider := &sequentialMockProvider{
+		responses: []string{
+			"UNRELATED", // approval judge for "no need for approval"
+			"chat reply", // re-routed chat
+		},
+		callCount: &callCount,
+	}
+	a := New(
+		config.AgentConfig{Name: "test-krill", MaxSubKrills: 3, PlanApproval: "auto"},
+		provider,
+		&memBrain{mem: mem},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+	a.pendingPlan = &core.Plan{
+		Task:  "old task",
+		Steps: []core.PlanStep{{ID: 1, Description: "step"}},
+	}
+
+	if _, err := a.Chat(context.Background(), "no need for approval on this kind of things"); err != nil {
+		t.Fatalf("Chat error: %v", err)
+	}
+
+	if !GetBoolPref(context.Background(), mem, PrefNoPlanApproval, false) {
+		t.Error("pref:no_plan_approval should have been set during pending-plan state")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// maybeAutoEvolveStyle: 3 corrections → terse mode
+// ---------------------------------------------------------------------------
+
+func TestMaybeAutoEvolveStyle_FlipsAfterThreshold(t *testing.T) {
+	mem := newFakeMemory()
+	a := newAgentWithMemory("auto", mem)
+	ctx := context.Background()
+
+	// Pre-populate two recent correction signals.
+	for i := 0; i < 2; i++ {
+		entry := core.MemoryEntry{
+			Key:        "feedback_" + time.Now().Format(time.RFC3339Nano) + "_" + string(rune('a'+i)),
+			Value:      "signal:correction | user: that's wrong | krill: ok",
+			Tags:       []string{"personality-feedback", "correction"},
+			Scope:      "system",
+			CreatedAt:  time.Now(),
+			AccessedAt: time.Now(),
+		}
+		_ = mem.Store(ctx, entry)
+	}
+
+	// One more correction triggers the threshold.
+	a.maybeAutoEvolveStyle(ctx, "correction")
+
+	if !GetBoolPref(ctx, mem, PrefStyleTerse, false) {
+		t.Error("expected pref:style_terse to flip after 3 corrections")
+	}
+}
+
+func TestMaybeAutoEvolveStyle_BelowThresholdDoesNothing(t *testing.T) {
+	mem := newFakeMemory()
+	a := newAgentWithMemory("auto", mem)
+	ctx := context.Background()
+
+	// One pre-existing correction + one fresh one = 2 (below threshold).
+	entry := core.MemoryEntry{
+		Key:        "feedback_x",
+		Value:      "signal:correction",
+		Tags:       []string{"personality-feedback", "correction"},
+		Scope:      "system",
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	}
+	_ = mem.Store(ctx, entry)
+
+	a.maybeAutoEvolveStyle(ctx, "correction")
+
+	if GetBoolPref(ctx, mem, PrefStyleTerse, false) {
+		t.Error("pref:style_terse should not flip below threshold")
+	}
+}
+
+func TestMaybeAutoEvolveStyle_OldSignalsDontCount(t *testing.T) {
+	mem := newFakeMemory()
+	a := newAgentWithMemory("auto", mem)
+	ctx := context.Background()
+
+	// Two old corrections (>1h) plus one fresh — only the fresh one counts,
+	// so we should be below threshold.
+	for i := 0; i < 2; i++ {
+		entry := core.MemoryEntry{
+			Key:        "feedback_old_" + string(rune('a'+i)),
+			Value:      "signal:correction",
+			Tags:       []string{"personality-feedback", "correction"},
+			Scope:      "system",
+			CreatedAt:  time.Now().Add(-2 * time.Hour),
+			AccessedAt: time.Now().Add(-2 * time.Hour),
+		}
+		_ = mem.Store(ctx, entry)
+	}
+
+	a.maybeAutoEvolveStyle(ctx, "correction")
+
+	if GetBoolPref(ctx, mem, PrefStyleTerse, false) {
+		t.Error("old corrections (>1h) should not contribute to threshold")
+	}
+}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -68,13 +68,31 @@ var greetings = map[string]bool{
 	"good evening": true, "good night": true, "gm": true, "gn": true,
 }
 
-// actionVerbs indicate the user wants something done (not just chat).
-var actionVerbs = []string{
-	"create", "build", "deploy", "analyze", "fix", "set up", "implement",
-	"research", "find", "check", "run", "test", "debug", "write", "install",
-	"refactor", "migrate", "configure", "generate", "update", "delete",
-	"remove", "add", "make", "develop", "optimize", "review", "scan",
+// hardActionVerbs strongly imply concrete multi-step work touching real
+// systems (filesystem, network, packages, services) or producing concrete
+// artifacts (code, files, websites). These bias toward LONG_TASK classification.
+var hardActionVerbs = []string{
+	"deploy", "install", "uninstall", "refactor", "migrate", "configure",
+	"set up", "scaffold", "bootstrap", "provision", "rollback", "publish",
+	"merge", "rebase", "commit", "push", "pull", "checkout",
+	"build", "create", "make", "write", "implement", "develop",
+	"fix", "debug", "generate",
 }
+
+// softActionVerbs are commonly ideation/explanation phrasing ("give me ideas",
+// "find me some news", "write a summary"). Alone they should NOT trigger plan
+// mode — they're conversational asks. They route to ANSWER/CHAT unless paired
+// with a hard verb or a concrete artifact.
+var softActionVerbs = []string{
+	"find", "give", "show", "tell", "explain", "describe", "list",
+	"suggest", "recommend", "compare", "review", "analyze", "research",
+	"think", "brainstorm", "draft", "summarize",
+}
+
+// actionVerbs is the legacy combined list, kept for callers that just want
+// "does this look like a request to do something" without distinguishing
+// hard vs soft.
+var actionVerbs = append(append([]string{}, hardActionVerbs...), softActionVerbs...)
 
 // memoryStoreTriggers indicate the user wants to store something in memory.
 var memoryStoreTriggers = []string{
@@ -117,10 +135,26 @@ var timeTriggers = []string{
 	"what's the date", "what day", "what's today",
 }
 
-// searchTriggers route directly to the search skill.
+// searchTriggers route directly to the search skill. The list is intentionally
+// generous so phrases people actually type ("find me", "latest news on") get
+// caught here instead of falling to the LLM classifier where the model tends
+// to invent a "I need permission" response.
 var searchTriggers = []string{
-	"search for", "search the web", "search online", "look up",
-	"google", "look online", "find me info",
+	"search for", "search the web", "search online", "look up", "lookup",
+	"google", "look online", "find me info", "find me", "find some",
+	"news on", "news about", "latest on", "latest news", "any news",
+	"any updates on", "what's new with", "whats new with", "what's happening with",
+	"digest", "headlines", "recent updates", "recent news",
+	"what happened today", "what happened yesterday", "today in",
+	"current price of", "price of", "stock price",
+}
+
+// freshnessKeywords pair a topic with a time-cue. When both are present we
+// route to the search tool automatically — the user wants up-to-date info,
+// not whatever the model remembers.
+var freshnessKeywords = []string{
+	"today", "this week", "this month", "right now", "latest", "current",
+	"recent", "just announced", "breaking", "as of now", "live",
 }
 
 // sysInfoTriggers route directly to the sysinfo skill.
@@ -206,6 +240,12 @@ func (r *IntentRouter) Classify(ctx context.Context, input string) RouteResult {
 	if matchesAny(lower, searchTriggers) {
 		return RouteResult{Intent: IntentToolTask, ToolName: "search"}
 	}
+	// Freshness auto-route: a time cue ("today", "latest") plus a topic noun
+	// nearly always means "go search the web". Catches things like
+	// "find me some AI digest from today" that don't match an explicit search trigger.
+	if matchesAny(lower, freshnessKeywords) && len(strings.Fields(lower)) >= 3 {
+		return RouteResult{Intent: IntentToolTask, ToolName: "search"}
+	}
 	// URL detection: YouTube vs generic web
 	if urlPattern.MatchString(lower) {
 		if youtubePattern.MatchString(lower) {
@@ -244,14 +284,18 @@ func detectSelfSkillTrigger(msg string) (skillName, skillInput string) {
 }
 
 // isGreetingOrSmallTalk returns true for casual short messages.
+// Soft verbs ("find me ideas", "give me suggestions") are allowed through —
+// they're conversational asks that should land in CHAT/ANSWER, not LONG_TASK.
 func isGreetingOrSmallTalk(lower string) bool {
 	// Exact greeting match
 	if greetings[lower] {
 		return true
 	}
-	// Short message without action verbs → chat
+	// Short message without HARD action verbs → chat. Soft verbs alone don't
+	// disqualify it, so "give me ideas" still routes here instead of being
+	// pushed into the LLM classifier where it tends to come back LONG_TASK.
 	words := strings.Fields(lower)
-	if len(words) <= 6 && !containsAnyWord(lower, actionVerbs) {
+	if len(words) <= 6 && !containsAnyWord(lower, hardActionVerbs) {
 		// But not if it looks like a question about errors
 		if !strings.Contains(lower, "error") && !strings.Contains(lower, "bug") {
 			return true
@@ -282,12 +326,14 @@ func (r *IntentRouter) classifyWithLLM(ctx context.Context, input string) RouteR
 	prompt := `Classify this message into exactly one category. Reply with ONLY the category name, nothing else.
 
 Categories:
-- CHAT: casual conversation, greetings, banter, opinions
-- ANSWER: factual question that needs a direct answer
+- CHAT: casual conversation, greetings, banter, opinions, "what should we build", "tell me about yourself"
+- ANSWER: factual question that needs a direct answer, including ideation/brainstorming asks ("give me ideas", "suggest options", "what are some approaches")
 - DIAGNOSE: error analysis, debugging, troubleshooting
-- LONG_TASK: multi-step work (build, create, deploy, refactor, set up, implement)
-- TOOL_TASK: single action (search, look up, check time, get system info)
+- LONG_TASK: multi-step work that actually touches real systems — deploys, installs, migrations, refactors, file changes, scaffolding new projects. Brainstorming, suggesting, listing, explaining, or thinking are NOT long tasks.
+- TOOL_TASK: single action (search, look up, check time, get system info, fetch a URL)
 - REMEMBER: memory operations (remember, recall, forget)
+
+Important: ideation, advice, recommendations, and explanations are CHAT or ANSWER, never LONG_TASK. LONG_TASK requires the user to want something built or changed in their environment.
 
 Message: ` + input
 

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -71,6 +71,11 @@ var greetings = map[string]bool{
 // hardActionVerbs strongly imply concrete multi-step work touching real
 // systems (filesystem, network, packages, services) or producing concrete
 // artifacts (code, files, websites). These bias toward LONG_TASK classification.
+//
+// Soft verbs ("find", "give", "suggest", "brainstorm") are intentionally
+// excluded — alone they signal ideation/explanation, not work, and should
+// stay in CHAT/ANSWER. The classifier prompt in classifyWithLLM mirrors
+// this distinction for ambiguous inputs.
 var hardActionVerbs = []string{
 	"deploy", "install", "uninstall", "refactor", "migrate", "configure",
 	"set up", "scaffold", "bootstrap", "provision", "rollback", "publish",
@@ -78,21 +83,6 @@ var hardActionVerbs = []string{
 	"build", "create", "make", "write", "implement", "develop",
 	"fix", "debug", "generate",
 }
-
-// softActionVerbs are commonly ideation/explanation phrasing ("give me ideas",
-// "find me some news", "write a summary"). Alone they should NOT trigger plan
-// mode — they're conversational asks. They route to ANSWER/CHAT unless paired
-// with a hard verb or a concrete artifact.
-var softActionVerbs = []string{
-	"find", "give", "show", "tell", "explain", "describe", "list",
-	"suggest", "recommend", "compare", "review", "analyze", "research",
-	"think", "brainstorm", "draft", "summarize",
-}
-
-// actionVerbs is the legacy combined list, kept for callers that just want
-// "does this look like a request to do something" without distinguishing
-// hard vs soft.
-var actionVerbs = append(append([]string{}, hardActionVerbs...), softActionVerbs...)
 
 // memoryStoreTriggers indicate the user wants to store something in memory.
 var memoryStoreTriggers = []string{

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -293,7 +293,7 @@ func TestShouldRequireApprovalAlways(t *testing.T) {
 		Steps: []core.PlanStep{{ID: 1, Description: "do something"}},
 	}
 
-	if !a.shouldRequireApproval(plan) {
+	if !a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("PlanApproval=always should always require approval")
 	}
 }
@@ -318,7 +318,7 @@ func TestShouldRequireApprovalNever(t *testing.T) {
 		},
 	}
 
-	if a.shouldRequireApproval(plan) {
+	if a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("PlanApproval=never should never require approval")
 	}
 }
@@ -342,7 +342,7 @@ func TestShouldRequireApprovalAutoSmallSafe(t *testing.T) {
 		},
 	}
 
-	if a.shouldRequireApproval(plan) {
+	if a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("auto mode: 3-step non-destructive plan should NOT require approval")
 	}
 }
@@ -369,7 +369,7 @@ func TestShouldRequireApprovalAutoLargePlan(t *testing.T) {
 		},
 	}
 
-	if !a.shouldRequireApproval(plan) {
+	if !a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("auto mode: 6-step plan should require approval")
 	}
 }
@@ -392,7 +392,7 @@ func TestShouldRequireApprovalAutoDestructiveStep(t *testing.T) {
 		},
 	}
 
-	if !a.shouldRequireApproval(plan) {
+	if !a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("auto mode: plan with 'delete' step should require approval")
 	}
 }
@@ -416,7 +416,7 @@ func TestShouldRequireApprovalAutoNoFalsePositives(t *testing.T) {
 		},
 	}
 
-	if a.shouldRequireApproval(plan) {
+	if a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("auto mode: plan with 'drop-down', 'push notification', 'reset filter' should NOT require approval (word boundary matching)")
 	}
 }
@@ -439,7 +439,7 @@ func TestShouldRequireApprovalAutoVagueTask(t *testing.T) {
 		},
 	}
 
-	if !a.shouldRequireApproval(plan) {
+	if !a.shouldRequireApproval(context.Background(), plan) {
 		t.Error("auto mode: vague task should require approval")
 	}
 }

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -448,6 +448,80 @@ func TestShouldRequireApprovalAutoVagueTask(t *testing.T) {
 // detectSelfSkillTrigger
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Soft-verb / hard-verb behaviour — ideation should NOT route to LONG_TASK
+// ---------------------------------------------------------------------------
+
+func TestRouterSoftVerbsRouteToChat(t *testing.T) {
+	// "give me ideas", "find me suggestions" — soft verbs only, short message.
+	// They must be small-talk-classified so the LLM fallback never fires
+	// (which is where DIVE PLAN got triggered in the original transcript).
+	r := newTestRouter("LONG_TASK") // would mis-classify if it ran
+	cases := []string{
+		"give me some ideas",
+		"suggest a few options",
+		"any recommendations",
+		"tell me about it",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent == IntentLongTask {
+			t.Errorf("Classify(%q) routed to LONG_TASK; soft verbs should stay conversational", input)
+		}
+	}
+}
+
+func TestRouterHardVerbsStillRouteThroughLLM(t *testing.T) {
+	// Hard verbs ("build", "deploy", "refactor") must NOT short-circuit to
+	// chat — they need real classification so production tasks still work.
+	r := newTestRouter("LONG_TASK")
+	cases := []string{
+		"build me a website",
+		"deploy the api to staging",
+		"refactor the auth module",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentLongTask {
+			t.Errorf("Classify(%q) = %s, want LONG_TASK", input, result.Intent)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Freshness auto-route — "find me some AI digest from today" must hit search
+// ---------------------------------------------------------------------------
+
+func TestRouterFreshnessRoutesToSearch(t *testing.T) {
+	r := newTestRouter("ANSWER")
+	cases := []string{
+		"find me some AI digest from today",
+		"what's the latest news on rust",
+		"any updates on the kubernetes release",
+		"what happened today in tech",
+		"give me the latest headlines",
+	}
+	for _, input := range cases {
+		result := r.Classify(context.Background(), input)
+		if result.Intent != IntentToolTask {
+			t.Errorf("Classify(%q) = %s, want TOOL_TASK", input, result.Intent)
+		}
+		if result.ToolName != "search" {
+			t.Errorf("Classify(%q).ToolName = %q, want 'search'", input, result.ToolName)
+		}
+	}
+}
+
+func TestRouterFreshnessKeywordAloneIsNotEnough(t *testing.T) {
+	// Bare time cue without a topic should not auto-route. Tiny inputs stay
+	// in chat.
+	r := newTestRouter("CHAT")
+	result := r.Classify(context.Background(), "today")
+	if result.Intent == IntentToolTask && result.ToolName == "search" {
+		t.Error("bare 'today' should not auto-route to search")
+	}
+}
+
 func TestDetectSelfSkillTrigger(t *testing.T) {
 	cases := []struct {
 		input string

--- a/internal/brain/soul.go
+++ b/internal/brain/soul.go
@@ -32,6 +32,8 @@ IMPORTANT RULES:
 - When asked to do something you cannot do, say clearly that you cannot and explain what you CAN do instead.
 - NEVER claim you completed an action you did not actually execute.
 - If you do not know something, say so. Do not fabricate information, running processes, or system states.
+- Your built-in tools (search, web fetch, time, sysinfo) run without any permission prompt. NEVER tell the user you need their approval, green light, or permission to use a tool. NEVER reference a "CLI dialog", "permission prompt", or "Allow button" — none of those exist in this system. If a tool fails, say what actually failed (timeout, network error, no results) and offer to retry or try a different approach.
+- Do not ask the user to approve casual conversational answers, brainstorming, or explanations. Approval is reserved for plans that change real systems (files, deploys, installs).
 - To send a message to another chat, use [CROSSPOST:chat_id]message[/CROSSPOST] in your response. Only do this when the user explicitly asks and you have the chat ID in your memory.`
 
 // defaultPersonality returns the built-in krill personality.


### PR DESCRIPTION
## Summary
- Replaces the static yes/no approval gate with a regex fast-path + LLM-judged classifier. Accepts casual approvals ("yea", "ok", "alright"), supports a MODIFY outcome that regenerates the plan, and releases control on UNRELATED replies — fixing the loop where the same prompt re-rendered forever.
- Adds a typed user-preference layer (`internal/agent/prefs.go`) so phrases like "no need for approval", "stop asking me to approve", "be terse", "no metaphors" get captured as stable boolean flags backed by `brain.Memory()`. `shouldRequireApproval` reads the flag under "auto" mode while destructive plans still gate.
- Stops forcing plans onto casual asks: `actionVerbs` is split into hard (deploy/install/refactor/build/fix) vs soft (find/give/suggest/brainstorm). Soft verbs alone keep the message in CHAT/ANSWER. The LLM classifier prompt is rewritten so ideation/brainstorming never lands in LONG_TASK.
- Real auto tool dispatch: broadened `searchTriggers` ("find me", "news on", "digest", "today in") and added a freshness auto-route ("today" + ≥3 words → search). The system prompt now explicitly forbids hallucinating CLI permission/approval prompts for built-in tools (the previous behaviour invented a permission gate that doesn't exist).
- Adaptive personality: `maybeAutoEvolveStyle` flips `pref:style_terse` automatically after 3 corrections within an hour. `handleChat` / `handleAnswer` inject `buildStyleDirective` so active prefs become per-turn system messages.

### Behavioural deltas (mapped to the original transcript)
| Transcript moment | New behaviour |
| --- | --- |
| "Give me some ideas" → DIVE PLAN | Soft-verb only, ≤6 words → CHAT/ANSWER. No plan, no approval. |
| "No need for taking my approval" | `pref:no_plan_approval=true` written; future plans skip the gate. |
| "Yea" rejected | Regex now accepts yea/yeah/yep/yup/y/sure/ok/alright/👍. |
| Loop on ambiguous input | UNRELATED releases the pending plan and re-routes; MODIFY regenerates. |
| "find me some AI digest from today" → fake permission | Routed straight to the search skill via freshness heuristic; soul prompt forbids fabricated permission prompts. |

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages green
- [x] 22 new cases in `prefs_test.go` (typed prefs, regex coverage, pending-plan flow, auto-evolve, destructive detection)
- [x] 3 new router test groups (soft vs hard verbs, freshness routing)
- [ ] Manual smoke test: trigger the original transcript flow end-to-end to confirm the agent no longer loops on "yea" / "no need for approval"