### PR TITLE
Fix silent plan failures, add provenance tags, quick-win hardening

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -414,8 +414,14 @@ func diveDaemon() error {
 	}
 
 	child := exec.Command(exe, childArgs...)
-	child.Stdout = out
-	child.Stderr = out
+	// Suppress macOS MallocStackLogging dyld warnings at the source so they
+	// never reach dive.log. Belt-and-suspenders alongside the per-subprocess
+	// env in internal/llm/cli_provider.go.
+	child.Env = append(os.Environ(), "MallocStackLogging=0")
+	// Filter writer drops residual dyld noise lines if any leak through anyway.
+	filtered := newNoiseFilter(out)
+	child.Stdout = filtered
+	child.Stderr = filtered
 	detachCommand(child)
 
 	if err := child.Start(); err != nil {

--- a/cmd/minikrill/log_filter.go
+++ b/cmd/minikrill/log_filter.go
@@ -48,6 +48,24 @@ func (f *noiseFilter) Write(p []byte) (int, error) {
 	return original, nil
 }
 
+// Flush emits any bytes still buffered after the last newline. The daemon
+// process tends to end every line with `\n`, so this is mostly a contract
+// nicety — but if a child exits mid-line (panic, segfault) without a
+// trailing newline, those bytes would otherwise vanish silently.
+func (f *noiseFilter) Flush() error {
+	if f.buf.Len() == 0 {
+		return nil
+	}
+	leftover := f.buf.Bytes()
+	if isNoise(leftover) {
+		f.buf.Reset()
+		return nil
+	}
+	_, err := f.w.Write(leftover)
+	f.buf.Reset()
+	return err
+}
+
 func isNoise(line []byte) bool {
 	for _, pat := range dyldNoisePatterns {
 		if pat.Match(line) {

--- a/cmd/minikrill/log_filter.go
+++ b/cmd/minikrill/log_filter.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"regexp"
+)
+
+// noiseFilter wraps an io.Writer and drops well-known macOS dyld diagnostic
+// lines that have no signal value. Without it, dive.log fills up with
+// "minikrill(NNNN) MallocStackLogging: can't turn off malloc stack logging
+// because it was not enabled." for every subprocess spawn.
+//
+// The filter operates line-by-line. Bytes received without a trailing newline
+// are buffered until the next write so we never split a line mid-pattern.
+type noiseFilter struct {
+	w   io.Writer
+	buf bytes.Buffer
+}
+
+func newNoiseFilter(w io.Writer) *noiseFilter {
+	return &noiseFilter{w: w}
+}
+
+// dyldNoisePatterns lists regexes that match log lines we always want to drop.
+// Add sparingly — anything matched here is silently discarded.
+var dyldNoisePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`MallocStackLogging:`),
+	regexp.MustCompile(`^objc\[\d+\]: Class .* implemented in both`),
+}
+
+func (f *noiseFilter) Write(p []byte) (int, error) {
+	original := len(p)
+	f.buf.Write(p)
+
+	for {
+		idx := bytes.IndexByte(f.buf.Bytes(), '\n')
+		if idx < 0 {
+			break
+		}
+		line := f.buf.Next(idx + 1) // includes '\n'
+		if !isNoise(line) {
+			if _, err := f.w.Write(line); err != nil {
+				return original, err
+			}
+		}
+	}
+	return original, nil
+}
+
+func isNoise(line []byte) bool {
+	for _, pat := range dyldNoisePatterns {
+		if pat.Match(line) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -57,6 +57,7 @@ type KrillAgent struct {
 	subMgr      *SubKrillManager
 	taskStore   *TaskStore
 	taskRunner  *TaskRunner
+	turnFetches *turnFetchLog // per-turn provenance ledger; reset on each ChatFromPlatform call
 	mu          sync.Mutex
 }
 
@@ -88,19 +89,6 @@ func New(cfg config.AgentConfig, llm core.LLMProvider, brain core.Brain, skills 
 		},
 		subMgr: NewSubKrillManager(cfg, llm),
 	}
-}
-
-// SetChannel is kept for platform integrations. Mini Krill intentionally ignores
-// the requested platform channel and stores all turns in one unified channel so
-// users can move between CLI, TUI, Telegram, and Discord without losing context.
-func (a *KrillAgent) SetChannel(channel string) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	if ch := strings.TrimSpace(channel); ch != "" && ch != unifiedConversationChannel {
-		log.Debug("SetChannel called with non-unified channel; using unified channel instead",
-			"requested", ch, "actual", unifiedConversationChannel)
-	}
-	a.channel = unifiedConversationChannel
 }
 
 // SetPlatform is retained for tests that don't go through ChatFromPlatform.
@@ -203,6 +191,9 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 
 	a.platform = platform
 	a.chatID = chatID
+	// Fresh provenance ledger per turn — every reply is checked against URLs
+	// actually fetched during this single ChatFromPlatform invocation.
+	a.turnFetches = newTurnFetchLog()
 
 	if response, handled := a.handleProviderCommand(input); handled {
 		a.saveTurn("user", input)
@@ -698,21 +689,31 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 		enriched = insertBeforeLast(enriched, styleMsg)
 	}
 
+	// Inject provenance instruction so the model self-tags external claims.
+	provMsg := core.Message{Role: "system", Content: ProvenanceInstruction}
+	enriched = insertBeforeLast(enriched, provMsg)
+
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
 		log.Error("LLM chat failed", "error", err)
 		return "This krill's neural link is fuzzy right now. Could you try again?", nil
 	}
 
-	a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
-	a.saveTurn("assistant", resp.Content)
+	// Strip any [web:...] tags that don't match a real fetch this turn.
+	cleaned, removed := EnforceProvenance(resp.Content, a.turnFetches)
+	if removed > 0 {
+		log.Warn("stripped fabricated provenance tags", "count", removed)
+	}
+
+	a.appendMessage(core.Message{Role: "assistant", Content: cleaned})
+	a.saveTurn("assistant", cleaned)
 	log.Debug("chat response generated",
 		"tokens_in", resp.PromptTokens,
 		"tokens_out", resp.CompletionTokens,
 		"model", resp.Model,
 	)
 
-	return resp.Content, nil
+	return cleaned, nil
 }
 
 // handleSelfSkill dispatches a self:* skill, either returning its result
@@ -849,8 +850,14 @@ func (a *KrillAgent) handleToolTask(ctx context.Context, input, toolName string)
 	log.Info("direct tool invocation", "tool", toolName)
 	result, err := skill.Execute(ctx, input, a.llm)
 	if err != nil {
+		// Surface the real error to the user. Falling back to chat would let
+		// the LLM hallucinate a "permission denied" or "blocked" excuse —
+		// which is exactly what bug #6 traced from the 2026-05-09/10 sessions.
 		log.Error("tool execution failed", "tool", toolName, "error", err)
-		return a.handleChat(ctx)
+		msg := fmt.Sprintf("Tried %s but it failed: %v", toolName, err)
+		a.appendMessage(core.Message{Role: "assistant", Content: msg})
+		a.saveTurn("assistant", msg)
+		return msg, nil
 	}
 
 	if result == "" {
@@ -864,6 +871,14 @@ func (a *KrillAgent) handleToolTask(ctx context.Context, input, toolName string)
 		return result, nil
 	}
 
+	// Provenance: record every URL the tool surfaced as "actually fetched
+	// this turn" so the post-processor can validate [web:...] tags later.
+	if toolName == "search" || toolName == "web" || toolName == "youtube" || toolName == "research" {
+		for _, u := range extractURLs(result) {
+			a.turnFetches.Record(u)
+		}
+	}
+
 	// For content skills (search, web, youtube, research), wrap through LLM
 	enriched := a.brain.EnrichMessages(a.history)
 	toolCtx := core.Message{
@@ -871,6 +886,7 @@ func (a *KrillAgent) handleToolTask(ctx context.Context, input, toolName string)
 		Content: fmt.Sprintf("Here are the results from the %s tool. Use them to answer the user's question:\n\n%s", toolName, result),
 	}
 	enriched = insertBeforeLast(enriched, toolCtx)
+	enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: ProvenanceInstruction})
 	resp, err := a.llm.Chat(ctx, enriched)
 	if err != nil {
 		// Fallback: return raw tool output
@@ -878,9 +894,29 @@ func (a *KrillAgent) handleToolTask(ctx context.Context, input, toolName string)
 		a.saveTurn("assistant", result)
 		return result, nil
 	}
-	a.appendMessage(core.Message{Role: "assistant", Content: resp.Content})
-	a.saveTurn("assistant", resp.Content)
-	return resp.Content, nil
+	cleaned, removed := EnforceProvenance(resp.Content, a.turnFetches)
+	if removed > 0 {
+		log.Warn("stripped fabricated provenance tags", "count", removed, "tool", toolName)
+	}
+	a.appendMessage(core.Message{Role: "assistant", Content: cleaned})
+	a.saveTurn("assistant", cleaned)
+	return cleaned, nil
+}
+
+// extractURLs pulls bare URLs from arbitrary text using the same pattern as
+// the router. Used by the provenance bookkeeper to record which URLs a tool
+// surfaced this turn.
+func extractURLs(s string) []string {
+	matches := urlPattern.FindAllString(s, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	// Strip trailing punctuation that often glues onto URLs in prose.
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		out = append(out, strings.TrimRight(m, ").,;:\"'"))
+	}
+	return out
 }
 
 // handleDiagnose answers error/debugging questions directly with a diagnostic focus.
@@ -1113,6 +1149,57 @@ func memoryKey(s string) string {
 	return key
 }
 
+// looksLikeCorrection returns true when a short, negative-leading user message
+// looks like a real correction rather than a redirection ("nope, do X instead"
+// is redirection — the negative is a discourse marker, not dissatisfaction).
+//
+// Rules: previous assistant turn must be a substantive response (>30 chars and
+// not a greeting), the message must be ≤8 words, and it must not contain a
+// forward verb that signals a fresh request.
+func (a *KrillAgent) looksLikeCorrection(lower string) bool {
+	corrections := []string{"no", "nah", "nope", "not what i", "that's not right", "don't"}
+	hit := false
+	for _, c := range corrections {
+		if containsWord(lower, c) {
+			hit = true
+			break
+		}
+	}
+	if !hit {
+		return false
+	}
+
+	// Need a previous assistant message that's actually a response.
+	var lastAssistant string
+	for i := len(a.history) - 1; i >= 0; i-- {
+		if a.history[i].Role == "assistant" {
+			lastAssistant = a.history[i].Content
+			break
+		}
+	}
+	if len(lastAssistant) < 30 {
+		return false
+	}
+	llower := strings.ToLower(strings.TrimSpace(lastAssistant))
+	for _, greet := range []string{"hi", "hello", "hey", "greetings", "what's up", "buddy"} {
+		if strings.HasPrefix(llower, greet) {
+			return false
+		}
+	}
+
+	// Forward verbs signal "do X instead" — redirection, not correction.
+	forwardVerbs := []string{"find", "search", "show", "get", "give", "tell", "explain",
+		"build", "make", "do", "fix", "check", "look", "send", "write"}
+	for _, v := range forwardVerbs {
+		if containsWord(lower, v) {
+			return false
+		}
+	}
+
+	// Short and negative-leading is a real correction.
+	return len(strings.Fields(lower)) <= 8
+}
+
 // recordFeedback silently stores interaction signals for adaptive personality evolution.
 // Runs in background goroutine - never blocks the response.
 func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
@@ -1142,15 +1229,14 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 		}
 	}
 
-	// Correction signals - user is correcting, not angry
-	if signal == "" {
-		corrections := []string{"no", "nah", "nope", "not what i", "that's not right", "don't"}
-		for _, c := range corrections {
-			if containsWord(lower, c) {
-				signal = "correction"
-				break
-			}
-		}
+	// Correction signals - user is correcting, not redirecting.
+	// "Nope just find me AI digest" *starts* with a negative but immediately
+	// pivots to a forward ask — that's redirection, not correction. We only
+	// count a correction when (a) the previous assistant turn was a real
+	// response (not a greeting), (b) the user message is short, and (c) the
+	// user message contains no follow-up "do this instead" verb.
+	if signal == "" && a.looksLikeCorrection(lower) {
+		signal = "correction"
 	}
 
 	// Engagement signals
@@ -1246,7 +1332,6 @@ func (a *KrillAgent) maybeAutoEvolveStyle(ctx context.Context, latestKey, latest
 		SetBoolPref(ctx, mem, PrefStyleTerse, true)
 	}
 }
-
 
 // saveTurn persists a single turn to the durable conversation store.
 // Runs inline (not goroutine) to ensure ordering.

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -227,6 +227,12 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 		a.maybeStoreUserPreference(ctx, input)
 	}
 
+	// Snapshot the assistant turn the user is reacting to BEFORE any handler
+	// runs and appends its own assistant response. This is what
+	// recordFeedback's correction-classifier needs — without it, the scan
+	// would land on the response we are about to generate.
+	prevAssistant := lastAssistantBefore(a.history, len(a.history)-1)
+
 	// --- Phase 3: Classify intent via multi-intent router ---
 	route := a.router.Classify(ctx, input)
 	log.Debug("intent classified", "input_preview", truncate(input, 50), "intent", route.Intent)
@@ -261,7 +267,7 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 
 	// --- Phase 5: Learn from interaction (adaptive personality) ---
 	if err == nil && a.brain.Memory() != nil {
-		go a.recordFeedback(context.Background(), input, response)
+		go a.recordFeedback(context.Background(), input, response, prevAssistant)
 	}
 
 	return response, err
@@ -1153,10 +1159,15 @@ func memoryKey(s string) string {
 // looks like a real correction rather than a redirection ("nope, do X instead"
 // is redirection — the negative is a discourse marker, not dissatisfaction).
 //
+// prevAssistant is the assistant turn the user is reacting to — captured by
+// the caller BEFORE the current handler appended its own response. Without
+// that snapshot, the scan would walk the latest assistant entry, which is
+// the response we just generated for this very correction.
+//
 // Rules: previous assistant turn must be a substantive response (>30 chars and
 // not a greeting), the message must be ≤8 words, and it must not contain a
 // forward verb that signals a fresh request.
-func (a *KrillAgent) looksLikeCorrection(lower string) bool {
+func looksLikeCorrection(lower, prevAssistant string) bool {
 	corrections := []string{"no", "nah", "nope", "not what i", "that's not right", "don't"}
 	hit := false
 	for _, c := range corrections {
@@ -1169,18 +1180,10 @@ func (a *KrillAgent) looksLikeCorrection(lower string) bool {
 		return false
 	}
 
-	// Need a previous assistant message that's actually a response.
-	var lastAssistant string
-	for i := len(a.history) - 1; i >= 0; i-- {
-		if a.history[i].Role == "assistant" {
-			lastAssistant = a.history[i].Content
-			break
-		}
-	}
-	if len(lastAssistant) < 30 {
+	if len(prevAssistant) < 30 {
 		return false
 	}
-	llower := strings.ToLower(strings.TrimSpace(lastAssistant))
+	llower := strings.ToLower(strings.TrimSpace(prevAssistant))
 	for _, greet := range []string{"hi", "hello", "hey", "greetings", "what's up", "buddy"} {
 		if strings.HasPrefix(llower, greet) {
 			return false
@@ -1200,9 +1203,28 @@ func (a *KrillAgent) looksLikeCorrection(lower string) bool {
 	return len(strings.Fields(lower)) <= 8
 }
 
+// lastAssistantBefore returns the most recent assistant message in history at
+// or before index `before`. Returns "" if none. Used to snapshot the prior
+// assistant turn before a handler appends a fresh response.
+func lastAssistantBefore(history []core.Message, before int) string {
+	if before >= len(history) {
+		before = len(history) - 1
+	}
+	for i := before; i >= 0; i-- {
+		if history[i].Role == "assistant" {
+			return history[i].Content
+		}
+	}
+	return ""
+}
+
 // recordFeedback silently stores interaction signals for adaptive personality evolution.
 // Runs in background goroutine - never blocks the response.
-func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
+//
+// prevAssistant is the assistant turn the user is reacting to, snapshotted by
+// ChatFromPlatform before the current handler ran. Required for the
+// correction-vs-redirection classifier below.
+func (a *KrillAgent) recordFeedback(_ context.Context, input, response, prevAssistant string) {
 	lower := strings.ToLower(input)
 
 	// Detect sentiment signals
@@ -1235,7 +1257,7 @@ func (a *KrillAgent) recordFeedback(_ context.Context, input, response string) {
 	// count a correction when (a) the previous assistant turn was a real
 	// response (not a greeting), (b) the user message is short, and (c) the
 	// user message contains no follow-up "do this instead" verb.
-	if signal == "" && a.looksLikeCorrection(lower) {
+	if signal == "" && looksLikeCorrection(lower, prevAssistant) {
 		signal = "correction"
 	}
 

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -251,14 +251,6 @@ func TestAgentApproveAndExecute(t *testing.T) {
 	}
 }
 
-func TestSetChannelUsesUnifiedChannel(t *testing.T) {
-	a := newTestAgent("hello")
-	a.SetChannel("telegram")
-	if a.channel != unifiedConversationChannel {
-		t.Fatalf("channel = %q, want %q", a.channel, unifiedConversationChannel)
-	}
-}
-
 func TestProviderCommandModel(t *testing.T) {
 	a := newProviderControlTestAgent()
 	resp, err := a.Chat(context.Background(), "/model")

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -88,8 +88,12 @@ func FormatPlan(plan *core.Plan) string {
 		}
 		b.WriteString(fmt.Sprintf("  %d. %s %s\n", step.ID, icon, step.Description))
 
-		// Show output for completed or failed steps
-		if step.Output != "" && (step.Status == "done" || step.Status == "failed") {
+		// Show output for completed, failed, blocked, or need_input steps.
+		// blocked/need_input carry the most user-relevant signal (what's
+		// missing) — without them in this list the formatter swallows the
+		// "needs the URL" message and shows only a [?] icon.
+		if step.Output != "" && (step.Status == "done" || step.Status == "failed" ||
+			step.Status == "blocked" || step.Status == "need_input") {
 			// Indent step output for readability
 			lines := strings.Split(step.Output, "\n")
 			for _, line := range lines {
@@ -232,10 +236,13 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 // genuinely can't run the step (missing input, missing tool, etc). Returns
 // "need_input", "blocked", or "" (proceed normally).
 //
-// Heuristics on the prose are also applied as a safety net — older models
-// don't always honour the explicit token but tend to write recognisable
-// "cannot execute this step yet" prose. Better to over-detect blockers than
-// to mark hallucinated success as a real outcome.
+// `NEED_INPUT:` / `BLOCKED:` are the durable contract — substring-matched
+// anywhere in the output. The prose heuristics are a safety net for older
+// models that don't honour the tokens; they are deliberately anchored to the
+// start of the trimmed output (or any line in the first ~5 lines) so a
+// legitimate paragraph that quotes a refusal mid-prose ("Draft email: please
+// send the user a confirmation") doesn't trip them. A whole-step refusal
+// almost always opens with the refusal phrase — that's the shape we want.
 func detectStepBlocker(output string) string {
 	upper := strings.ToUpper(output)
 	if strings.Contains(upper, "NEED_INPUT:") {
@@ -244,23 +251,31 @@ func detectStepBlocker(output string) string {
 	if strings.Contains(upper, "BLOCKED:") {
 		return "blocked"
 	}
-	lower := strings.ToLower(output)
-	needInputPhrases := []string{
+	needInputPrefixes := []string{
 		"cannot execute this step yet",
 		"can't execute this step yet",
 		"can't execute this yet",
 		"cannot execute this yet",
 		"no source material was provided",
 		"no url was provided",
-		"please send the",
 		"i still need",
-		"still no",
+		"please send the video",
+		"please send the url",
+		"please send the link",
 		"send the video link",
 		"send the url",
 	}
-	for _, p := range needInputPhrases {
-		if strings.Contains(lower, p) {
-			return "need_input"
+	// Check the first 5 lines: a refusal typically opens the step.
+	lines := strings.Split(output, "\n")
+	if len(lines) > 5 {
+		lines = lines[:5]
+	}
+	for _, line := range lines {
+		l := strings.ToLower(strings.TrimSpace(line))
+		for _, p := range needInputPrefixes {
+			if strings.HasPrefix(l, p) {
+				return "need_input"
+			}
 		}
 	}
 	return ""

--- a/internal/agent/planner.go
+++ b/internal/agent/planner.go
@@ -14,11 +14,13 @@ import (
 
 // statusIcons maps plan step statuses to display indicators.
 var statusIcons = map[string]string{
-	"pending": "[ ]",
-	"running": "[~]",
-	"done":    "[x]",
-	"failed":  "[!]",
-	"skipped": "[-]",
+	"pending":    "[ ]",
+	"running":    "[~]",
+	"done":       "[x]",
+	"failed":     "[!]",
+	"skipped":    "[-]",
+	"blocked":    "[?]",
+	"need_input": "[?]",
 }
 
 // GeneratePlan asks the LLM to decompose a task into concrete, actionable steps.
@@ -141,13 +143,23 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 		step.Status = "running"
 		log.Debug("executing step", "step_id", step.ID, "description", truncate(step.Description, 60))
 
-		// Build context from previous step outputs
+		// Build per-step context. The original user task always leads — the
+		// previous bug was that step 1 had no "Previous context" entry, so the
+		// LLM hallucinated "no link was provided" even when the link was right
+		// there in the user's message. Threading plan.Task ensures every step
+		// can see the original input.
 		var contextStr string
+		var b strings.Builder
+		b.WriteString("Original user request:\n")
+		b.WriteString(plan.Task)
+		b.WriteString("\n\n")
 		if len(previousOutputs) > 0 {
-			contextStr = "Previous context:\n" + strings.Join(previousOutputs, "\n---\n")
+			b.WriteString("Previous step outputs:\n")
+			b.WriteString(strings.Join(previousOutputs, "\n---\n"))
 		} else {
-			contextStr = "This is the first step."
+			b.WriteString("This is the first step. Use the original user request above as your input.")
 		}
+		contextStr = b.String()
 
 		// Try tool-assisted execution: ask LLM what tool to call
 		stepOutput, err := executeStepWithTools(ctx, step, contextStr, toolbox, toolDescriptions, llm, brain)
@@ -161,6 +173,26 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 			continue
 		}
 
+		// Honour structured "I can't do this" signals from the LLM. Without
+		// these, a step that the LLM admitted it couldn't run was logged as
+		// done — the source of the "5/5 steps succeeded" gaslighting.
+		switch detectStepBlocker(stepOutput) {
+		case "need_input":
+			step.Status = "need_input"
+			step.Output = stepOutput
+			results.WriteString(fmt.Sprintf("Step %d [?] %s\n  Needs input: %s\n\n", step.ID, step.Description, stepOutput))
+			previousOutputs = append(previousOutputs, fmt.Sprintf("Step %d NEEDS_INPUT: %s", step.ID, stepOutput))
+			log.Info("step needs input", "step_id", step.ID)
+			continue
+		case "blocked":
+			step.Status = "blocked"
+			step.Output = stepOutput
+			results.WriteString(fmt.Sprintf("Step %d [?] %s\n  Blocked: %s\n\n", step.ID, step.Description, stepOutput))
+			previousOutputs = append(previousOutputs, fmt.Sprintf("Step %d BLOCKED: %s", step.ID, stepOutput))
+			log.Info("step blocked", "step_id", step.ID)
+			continue
+		}
+
 		step.Status = "done"
 		step.Output = stepOutput
 		previousOutputs = append(previousOutputs, fmt.Sprintf("Step %d: %s", step.ID, stepOutput))
@@ -168,14 +200,16 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 		log.Debug("step completed", "step_id", step.ID)
 	}
 
-	// Tally results
-	done, failed := 0, 0
+	// Tally results — only "done" counts as success.
+	done, failed, blocked := 0, 0, 0
 	for _, s := range plan.Steps {
 		switch s.Status {
 		case "done":
 			done++
 		case "failed":
 			failed++
+		case "blocked", "need_input":
+			blocked++
 		}
 	}
 
@@ -183,11 +217,53 @@ func ExecutePlanSteps(ctx context.Context, plan *core.Plan, llm core.LLMProvider
 	if failed > 0 {
 		summary += fmt.Sprintf(" (%d hit reefs)", failed)
 	}
+	if blocked > 0 {
+		summary += fmt.Sprintf(" (%d need input)", blocked)
+	}
 	summary += " ---"
 	results.WriteString(summary)
 
-	log.Info("plan execution complete", "task", plan.Task, "done", done, "failed", failed)
+	log.Info("plan execution complete", "task", plan.Task, "done", done, "failed", failed, "blocked", blocked)
 	return results.String(), nil
+}
+
+// detectStepBlocker scans an LLM step output for explicit "I cannot proceed"
+// markers. The planner prompt instructs the model to emit these tokens when it
+// genuinely can't run the step (missing input, missing tool, etc). Returns
+// "need_input", "blocked", or "" (proceed normally).
+//
+// Heuristics on the prose are also applied as a safety net — older models
+// don't always honour the explicit token but tend to write recognisable
+// "cannot execute this step yet" prose. Better to over-detect blockers than
+// to mark hallucinated success as a real outcome.
+func detectStepBlocker(output string) string {
+	upper := strings.ToUpper(output)
+	if strings.Contains(upper, "NEED_INPUT:") {
+		return "need_input"
+	}
+	if strings.Contains(upper, "BLOCKED:") {
+		return "blocked"
+	}
+	lower := strings.ToLower(output)
+	needInputPhrases := []string{
+		"cannot execute this step yet",
+		"can't execute this step yet",
+		"can't execute this yet",
+		"cannot execute this yet",
+		"no source material was provided",
+		"no url was provided",
+		"please send the",
+		"i still need",
+		"still no",
+		"send the video link",
+		"send the url",
+	}
+	for _, p := range needInputPhrases {
+		if strings.Contains(lower, p) {
+			return "need_input"
+		}
+	}
+	return ""
 }
 
 // executeStepWithTools handles a single plan step by asking the LLM if a tool
@@ -212,7 +288,10 @@ func executeStepWithTools(ctx context.Context, step *core.PlanStep, contextStr s
 			"If you need to use a tool, respond with EXACTLY this format:\n"+
 			"TOOL_CALL: tool_name\n"+
 			"ARGS: {\"key\": \"value\"}\n\n"+
-			"If no tool is needed, provide your analysis directly.",
+			"If no tool is needed, provide your analysis directly.\n\n"+
+			"If you genuinely cannot proceed because input or tools are missing, "+
+			"respond with one line starting with NEED_INPUT: <what you need> "+
+			"or BLOCKED: <why>. Do not fabricate progress.",
 		step.Description, contextStr, toolDescriptions,
 	)
 
@@ -450,4 +529,3 @@ func parsePlanResponse(task, response string) *core.Plan {
 
 	return plan
 }
-

--- a/internal/agent/provenance.go
+++ b/internal/agent/provenance.go
@@ -1,0 +1,123 @@
+// Package agent — provenance.go enforces source-honesty on assistant replies.
+//
+// The agent has no introspective sense of where its own claims came from.
+// Without an external check, it can (and has — see PR #1 audit, turn 34 and
+// turn 131) cite URLs it never fetched and reference search results that
+// never ran. This file installs a lightweight post-processor that:
+//
+//  1. Asks the model to tag external claims with [web:url], [mem:key],
+//     [trained], or [guess].
+//  2. After generation, scans the reply for [web:...] tags and verifies that
+//     a matching tool call actually ran in the same turn.
+//  3. Strips unmatched tags and prepends a one-line warning so the user knows
+//     a citation was fabricated.
+//
+// The verification is deliberately cheap and pessimistic — false positives
+// (real fetches that the bookkeeper missed) cause a small disclaimer; false
+// negatives let a fabrication slip through. We bias toward disclaiming.
+package agent
+
+import (
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// ProvenanceInstruction is the system-prompt addendum that asks the model to
+// tag external claims. Injected by callers who care about provenance — chat
+// and answer paths primarily.
+const ProvenanceInstruction = `For any factual claim you draw from outside this conversation, append a bracket tag at the end of the sentence:
+[web:<url>] for content from the search/web/youtube tools you used this turn
+[mem:<key>] for content from your memory store
+[trained] for general knowledge from your training
+[guess] for reasoning beyond available evidence
+Do not invent [web:...] tags for sources you did not actually fetch.`
+
+// turnFetchLog records URLs the agent actually fetched during a single turn.
+// The post-processor consults this when deciding whether a [web:...] tag in
+// the reply is honest.
+type turnFetchLog struct {
+	mu   sync.Mutex
+	urls map[string]bool
+}
+
+func newTurnFetchLog() *turnFetchLog {
+	return &turnFetchLog{urls: make(map[string]bool)}
+}
+
+// Record marks a URL as fetched this turn. Call from any tool-call site that
+// touched the web (search, web fetch, youtube transcript, etc.).
+func (t *turnFetchLog) Record(url string) {
+	if t == nil || url == "" {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.urls[normalizeURL(url)] = true
+}
+
+// Contains returns true if url was recorded as fetched this turn.
+func (t *turnFetchLog) Contains(url string) bool {
+	if t == nil {
+		return false
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.urls[normalizeURL(url)]
+}
+
+// webTagPattern matches [web:<url>] occurrences in assistant output.
+var webTagPattern = regexp.MustCompile(`\[web:([^\]]+)\]`)
+
+// EnforceProvenance scans response text for [web:...] tags and verifies each
+// against the turn's fetch log. Unmatched tags are stripped and the response
+// is prepended with a one-line warning. Returns the cleaned response and the
+// number of fabricated tags removed.
+func EnforceProvenance(response string, log *turnFetchLog) (string, int) {
+	if response == "" {
+		return response, 0
+	}
+	matches := webTagPattern.FindAllStringSubmatchIndex(response, -1)
+	if len(matches) == 0 {
+		return response, 0
+	}
+
+	var b strings.Builder
+	last := 0
+	fabricated := 0
+	for _, m := range matches {
+		// m = [start, end, urlStart, urlEnd]
+		start, end := m[0], m[1]
+		url := response[m[2]:m[3]]
+		b.WriteString(response[last:start])
+		if log.Contains(url) {
+			// Honest cite — keep the tag.
+			b.WriteString(response[start:end])
+		} else {
+			// Fabricated cite — drop the tag entirely.
+			fabricated++
+		}
+		last = end
+	}
+	b.WriteString(response[last:])
+	cleaned := b.String()
+
+	if fabricated > 0 {
+		warn := "⚠ This response cited sources I did not actually fetch this turn. Tag(s) removed.\n\n"
+		cleaned = warn + cleaned
+	}
+	return cleaned, fabricated
+}
+
+// normalizeURL canonicalises a URL for comparison. Strips trailing slash,
+// protocol, and a leading "www." so a recorded "https://example.com/" matches
+// a tag of "[web:example.com]".
+func normalizeURL(u string) string {
+	s := strings.TrimSpace(u)
+	s = strings.TrimSuffix(s, "/")
+	for _, prefix := range []string{"https://", "http://", "//"} {
+		s = strings.TrimPrefix(s, prefix)
+	}
+	s = strings.TrimPrefix(s, "www.")
+	return strings.ToLower(s)
+}

--- a/internal/agent/provenance_test.go
+++ b/internal/agent/provenance_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEnforceProvenance_KeepsHonestTag(t *testing.T) {
 	log := newTurnFetchLog()
@@ -20,10 +23,10 @@ func TestEnforceProvenance_StripsFabricatedTag(t *testing.T) {
 	if removed != 1 {
 		t.Fatalf("removed = %d, want 1", removed)
 	}
-	if !contains(got, "⚠") {
+	if !strings.Contains(got, "⚠") {
 		t.Fatalf("expected warning prefix, got: %q", got)
 	}
-	if contains(got, "[web:") {
+	if strings.Contains(got, "[web:") {
 		t.Fatalf("fabricated tag should be stripped, got: %q", got)
 	}
 }
@@ -35,10 +38,10 @@ func TestEnforceProvenance_MixedTags(t *testing.T) {
 	if removed != 1 {
 		t.Fatalf("removed = %d, want 1", removed)
 	}
-	if !contains(got, "[web:real.com/x]") {
+	if !strings.Contains(got, "[web:real.com/x]") {
 		t.Fatalf("honest tag should remain, got: %q", got)
 	}
-	if contains(got, "fake.com") {
+	if strings.Contains(got, "fake.com") {
 		t.Fatalf("fabricated tag should be gone, got: %q", got)
 	}
 }
@@ -63,17 +66,4 @@ func TestNormalizeURL(t *testing.T) {
 			t.Errorf("normalizeURL(%q) = %q, want %q", in, got, want)
 		}
 	}
-}
-
-func contains(haystack, needle string) bool {
-	return len(haystack) >= len(needle) && (haystack == needle || (len(needle) > 0 && stringIndex(haystack, needle) >= 0))
-}
-
-func stringIndex(s, substr string) int {
-	for i := 0; i+len(substr) <= len(s); i++ {
-		if s[i:i+len(substr)] == substr {
-			return i
-		}
-	}
-	return -1
 }

--- a/internal/agent/provenance_test.go
+++ b/internal/agent/provenance_test.go
@@ -1,0 +1,79 @@
+package agent
+
+import "testing"
+
+func TestEnforceProvenance_KeepsHonestTag(t *testing.T) {
+	log := newTurnFetchLog()
+	log.Record("https://example.com/article")
+	got, removed := EnforceProvenance("Stocks rallied today [web:example.com/article].", log)
+	if removed != 0 {
+		t.Fatalf("removed = %d, want 0", removed)
+	}
+	if got != "Stocks rallied today [web:example.com/article]." {
+		t.Fatalf("kept tag mangled response: %q", got)
+	}
+}
+
+func TestEnforceProvenance_StripsFabricatedTag(t *testing.T) {
+	log := newTurnFetchLog()
+	got, removed := EnforceProvenance("Karpathy said X [web:youtube.com/abc].", log)
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if !contains(got, "⚠") {
+		t.Fatalf("expected warning prefix, got: %q", got)
+	}
+	if contains(got, "[web:") {
+		t.Fatalf("fabricated tag should be stripped, got: %q", got)
+	}
+}
+
+func TestEnforceProvenance_MixedTags(t *testing.T) {
+	log := newTurnFetchLog()
+	log.Record("https://real.com/x")
+	got, removed := EnforceProvenance("A [web:real.com/x] and B [web:fake.com/y].", log)
+	if removed != 1 {
+		t.Fatalf("removed = %d, want 1", removed)
+	}
+	if !contains(got, "[web:real.com/x]") {
+		t.Fatalf("honest tag should remain, got: %q", got)
+	}
+	if contains(got, "fake.com") {
+		t.Fatalf("fabricated tag should be gone, got: %q", got)
+	}
+}
+
+func TestEnforceProvenance_NoTagsNoWarn(t *testing.T) {
+	log := newTurnFetchLog()
+	in := "Just a normal reply with no tags."
+	got, removed := EnforceProvenance(in, log)
+	if removed != 0 || got != in {
+		t.Fatalf("expected passthrough, got %q removed=%d", got, removed)
+	}
+}
+
+func TestNormalizeURL(t *testing.T) {
+	cases := map[string]string{
+		"https://www.Example.com/path/": "example.com/path",
+		"http://example.com":            "example.com",
+		"www.example.com":               "example.com",
+	}
+	for in, want := range cases {
+		if got := normalizeURL(in); got != want {
+			t.Errorf("normalizeURL(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || (len(needle) > 0 && stringIndex(haystack, needle) >= 0))
+}
+
+func stringIndex(s, substr string) int {
+	for i := 0; i+len(substr) <= len(s); i++ {
+		if s[i:i+len(substr)] == substr {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/agent/router.go
+++ b/internal/agent/router.go
@@ -139,12 +139,22 @@ var searchTriggers = []string{
 	"current price of", "price of", "stock price",
 }
 
-// freshnessKeywords pair a topic with a time-cue. When both are present we
-// route to the search tool automatically — the user wants up-to-date info,
-// not whatever the model remembers.
+// freshnessKeywords pair a topic with a time-cue. When both are present (along
+// with an externalInfoNouns hit) we route to the search tool automatically —
+// the user wants up-to-date info, not whatever the model remembers.
 var freshnessKeywords = []string{
 	"today", "this week", "this month", "right now", "latest", "current",
 	"recent", "just announced", "breaking", "as of now", "live",
+}
+
+// externalInfoNouns are nouns that, paired with a freshness keyword, strongly
+// suggest the user wants fresh external information (search territory). Without
+// one of these the freshness word might be incidental ("the current state of
+// my plan", "right now I'm thinking…").
+var externalInfoNouns = []string{
+	"news", "update", "updates", "release", "version", "price", "stock",
+	"announcement", "event", "headlines", "digest", "article", "blog",
+	"trend", "trends", "happening",
 }
 
 // sysInfoTriggers route directly to the sysinfo skill.
@@ -230,10 +240,12 @@ func (r *IntentRouter) Classify(ctx context.Context, input string) RouteResult {
 	if matchesAny(lower, searchTriggers) {
 		return RouteResult{Intent: IntentToolTask, ToolName: "search"}
 	}
-	// Freshness auto-route: a time cue ("today", "latest") plus a topic noun
-	// nearly always means "go search the web". Catches things like
-	// "find me some AI digest from today" that don't match an explicit search trigger.
-	if matchesAny(lower, freshnessKeywords) && len(strings.Fields(lower)) >= 3 {
+	// Freshness auto-route: a time cue ("today", "latest") AND a noun-phrase
+	// suggesting external info nearly always means "go search the web".
+	// Catches "find me some AI digest from today" without misfiring on
+	// "what's the current state of my plan" or "right now I'm thinking…".
+	if matchesAny(lower, freshnessKeywords) && matchesAny(lower, externalInfoNouns) &&
+		len(strings.Fields(lower)) >= 3 {
 		return RouteResult{Intent: IntentToolTask, ToolName: "search"}
 	}
 	// URL detection: YouTube vs generic web

--- a/internal/llm/cli_provider.go
+++ b/internal/llm/cli_provider.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -95,7 +96,7 @@ func (p *CLIProvider) Available(ctx context.Context) bool {
 func (p *CLIProvider) runCodex(ctx context.Context, model, prompt string) ([]byte, error) {
 	args := []string{
 		"exec",
-		"--full-auto",
+		"--sandbox", "workspace-write",
 		"--skip-git-repo-check",
 		"--ephemeral",
 		"--color", "never",
@@ -126,6 +127,11 @@ func runCLI(ctx context.Context, name string, args []string, stdin string) ([]by
 	if stdin != "" {
 		cmd.Stdin = strings.NewReader(stdin)
 	}
+
+	// Suppress macOS dyld MallocStackLogging warnings at the source. The flag
+	// is leaked into every Go-spawned subprocess on dev machines and pollutes
+	// dive.log with thousands of "can't turn off malloc stack logging" lines.
+	cmd.Env = append(os.Environ(), "MallocStackLogging=0")
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/internal/plugin/builtins.go
+++ b/internal/plugin/builtins.go
@@ -124,8 +124,10 @@ func (s *timeSkill) Execute(_ context.Context, _ string, _ core.LLMProvider) (st
 
 type webSearchSkill struct{}
 
-func (s *webSearchSkill) Name() string        { return "search" }
-func (s *webSearchSkill) Description() string { return "Search the web via DuckDuckGo (no API key needed)" }
+func (s *webSearchSkill) Name() string { return "search" }
+func (s *webSearchSkill) Description() string {
+	return "Search the web via DuckDuckGo (no API key needed)"
+}
 
 func (s *webSearchSkill) Execute(ctx context.Context, input string, llm core.LLMProvider) (string, error) {
 	if strings.TrimSpace(input) == "" {
@@ -134,7 +136,9 @@ func (s *webSearchSkill) Execute(ctx context.Context, input string, llm core.LLM
 
 	results, err := duckduckgoSearch(ctx, input)
 	if err != nil {
-		return fmt.Sprintf("Search failed: %v", err), nil
+		// Return a real error so callers know to surface this verbatim
+		// instead of letting the LLM invent a "permission denied" story.
+		return "", fmt.Errorf("web search failed: %w", err)
 	}
 	if len(results) == 0 {
 		return fmt.Sprintf("No results found for: %s", input), nil
@@ -192,6 +196,10 @@ func duckduckgoSearch(ctx context.Context, query string) ([]searchResult, error)
 		return nil, fmt.Errorf("search request failed: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("search returned HTTP %d", resp.StatusCode)
+	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
First of three PRs in the v0.1.1 cycle. Trust + quick wins. Version stays at 0.1.0.

## Summary

- **Plan execution honesty (#2 / #3 / #4)** — `executeStepWithTools` now sees the original user task on every step. Step 1 used to have only "Previous context" which was empty, so the LLM hallucinated "no link was provided" then the executor logged it `done`. Plus new `NEED_INPUT:` / `BLOCKED:` step statuses (with prose-heuristic fallback) so an LLM that admits it cannot proceed is recorded as such, not as success. Tally line now reports blocked steps separately.
- **Provenance tags (D5)** — new `internal/agent/provenance.go` + tests. Chat and tool-task LLM calls inject a `ProvenanceInstruction` system message asking the model to tag external claims `[web:url] / [mem:key] / [trained] / [guess]`. After generation, `EnforceProvenance` strips any `[web:...]` tag whose URL was not actually fetched this turn and prepends a one-line warning. Per-turn fetch ledger lives on the agent and resets in `ChatFromPlatform`.
- **Search-tool error surfacing (#6)** — `webSearchSkill.Execute` returns real Go errors instead of swallowing them into a string with nil error. `handleToolTask` no longer falls through to plain chat on tool failure (which let the LLM fabricate a "WebSearch needs your green light" excuse) — it shows the actual error.
- **D7 quick wins** — `MallocStackLogging=0` env var on every spawned subprocess + a `noiseFilter` writer wrapping `dive.log` (kills ~3.6k noise lines per long session); codex `--full-auto` → `--sandbox workspace-write` (#8); `SetChannel` no-op deleted (#13); `recordFeedback` correction-trigger tightened so "Nope just find me X" counts as redirection, not dissatisfaction (#14); freshness-keyword router match now requires a co-occurring external-info noun so "what's the current state of my plan" no longer trips a web search (#15).

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] New `EnforceProvenance` tests cover honest tag, fabricated tag, mixed, and no-tags-passthrough
- [ ] Manual: re-feed `summarize this <youtube>` and confirm Step 1 no longer says "no link provided"
- [ ] Manual: trigger a search failure (DDG 429 or no network) and confirm the response shows the real error rather than a hallucinated permission UI
- [ ] Manual: tail `dive.log` after a 30-min session and confirm no `MallocStackLogging` lines appear