### PR TITLE
Add task-type plan-affinity learning + autonomy_floor config

### DIFF
--- a/internal/agent/affinity.go
+++ b/internal/agent/affinity.go
@@ -1,0 +1,216 @@
+// Package agent — affinity.go maintains a per-cluster "should I plan this?"
+// score that the agent updates from outcomes (approved / modified / rejected /
+// ignored / thanked / fixed).
+//
+// The score is stored in the existing core.Memory under reserved keys
+// `affinity:cluster:<id>`. After ~5 samples per cluster the agent can decide
+// autonomously whether to plan-then-act, plan-in-parallel, or just act, with
+// no user intervention.
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// AffinityKeyPrefix reserves a memory key namespace so listing/searching the
+// regular memory store skips affinity entries.
+const AffinityKeyPrefix = "affinity:cluster:"
+
+// AffinityOutcome is the discrete event types the store understands.
+type AffinityOutcome string
+
+const (
+	OutcomeApproved AffinityOutcome = "approved"
+	OutcomeModified AffinityOutcome = "modified"
+	OutcomeRejected AffinityOutcome = "rejected"
+	OutcomeIgnored  AffinityOutcome = "ignored"
+	OutcomeThanked  AffinityOutcome = "thanked" // user happy after auto-execute → less planning
+	OutcomeFixed    AffinityOutcome = "fixed"   // user corrected after auto-execute → more planning
+)
+
+// PlanDecision is what the affinity store recommends for a fresh request.
+type PlanDecision string
+
+const (
+	DecisionPlanThenAct    PlanDecision = "plan_then_act"    // generate plan, show as FYI, auto-execute
+	DecisionPlanInParallel PlanDecision = "plan_in_parallel" // generate plan, start execution in parallel
+	DecisionJustAct        PlanDecision = "just_act"         // skip plan generation entirely
+	DecisionUseLegacy      PlanDecision = "use_legacy"       // not enough samples, fall back to old gate
+)
+
+// minSamples is the calibration floor — below this the store won't recommend
+// anything stronger than DecisionUseLegacy.
+const minSamples = 3
+
+// ClusterAffinity is the persisted record per cluster.
+type ClusterAffinity struct {
+	ClusterID    string    `json:"cluster_id"`
+	Verb         string    `json:"verb"`
+	ObjectClass  string    `json:"object_class"`
+	PlanScore    float64   `json:"plan_score"` // [0.05, 0.95], starts at 0.5
+	SampleCount  int       `json:"sample_count"`
+	LastUpdate   time.Time `json:"last_update"`
+	LastOutcomes []string  `json:"last_outcomes"` // ring buffer, max 10
+}
+
+// AffinityStore wraps a core.Memory with affinity-typed accessors.
+type AffinityStore struct {
+	mem core.Memory
+}
+
+// NewAffinityStore wires the store to the existing memory backend. The mem
+// store can be nil for tests; in that case all reads return zero values and
+// all writes are no-ops.
+func NewAffinityStore(mem core.Memory) *AffinityStore {
+	return &AffinityStore{mem: mem}
+}
+
+// Get returns the affinity record for cluster id, or a fresh-default if not
+// previously seen. The returned record is safe to mutate; call Put to persist.
+func (s *AffinityStore) Get(ctx context.Context, c TaskCluster) ClusterAffinity {
+	rec := ClusterAffinity{
+		ClusterID:   c.ID,
+		Verb:        c.Verb,
+		ObjectClass: c.ObjectClass,
+		PlanScore:   0.5,
+		LastUpdate:  time.Now(),
+	}
+	if s.mem == nil {
+		return rec
+	}
+	entry, err := s.mem.Recall(ctx, AffinityKeyPrefix+c.ID)
+	if err != nil || entry == nil || entry.Value == "" {
+		return rec
+	}
+	if err := json.Unmarshal([]byte(entry.Value), &rec); err != nil {
+		log.Warn("affinity record corrupt, resetting", "cluster", c.ID, "error", err)
+		return ClusterAffinity{
+			ClusterID:   c.ID,
+			Verb:        c.Verb,
+			ObjectClass: c.ObjectClass,
+			PlanScore:   0.5,
+			LastUpdate:  time.Now(),
+		}
+	}
+	return rec
+}
+
+// Put persists the affinity record.
+func (s *AffinityStore) Put(ctx context.Context, rec ClusterAffinity) error {
+	if s.mem == nil {
+		return nil
+	}
+	rec.LastUpdate = time.Now()
+	data, err := json.Marshal(rec)
+	if err != nil {
+		return err
+	}
+	return s.mem.Store(ctx, core.MemoryEntry{
+		Key:        AffinityKeyPrefix + rec.ClusterID,
+		Value:      string(data),
+		Tags:       []string{"affinity", "system"},
+		Scope:      "system",
+		Source:     "affinity-store",
+		CreatedAt:  rec.LastUpdate,
+		AccessedAt: rec.LastUpdate,
+	})
+}
+
+// Update applies an outcome to a cluster's score using a simple
+// pull-toward-extreme rule, persists, and returns the post-update record.
+//
+//	APPROVED  → score += 0.10 * (1 - score)
+//	MODIFIED  → score += 0.05 * (1 - score)
+//	REJECTED  → score -= 0.20 * score
+//	IGNORED   → score -= 0.15 * score
+//	THANKED   → score -= 0.10 * score      (user happy without plan = plan was unneeded)
+//	FIXED     → score += 0.15 * (1 - score) (user corrected after auto-act = plan would help)
+//
+// Result is clamped to [0.05, 0.95] so a cluster can always recover.
+func (s *AffinityStore) Update(ctx context.Context, c TaskCluster, outcome AffinityOutcome) (ClusterAffinity, error) {
+	rec := s.Get(ctx, c)
+	score := rec.PlanScore
+	switch outcome {
+	case OutcomeApproved:
+		score += 0.10 * (1 - score)
+	case OutcomeModified:
+		score += 0.05 * (1 - score)
+	case OutcomeRejected:
+		score -= 0.20 * score
+	case OutcomeIgnored:
+		score -= 0.15 * score
+	case OutcomeThanked:
+		score -= 0.10 * score
+	case OutcomeFixed:
+		score += 0.15 * (1 - score)
+	default:
+		return rec, fmt.Errorf("unknown affinity outcome: %s", outcome)
+	}
+	if score < 0.05 {
+		score = 0.05
+	} else if score > 0.95 {
+		score = 0.95
+	}
+	rec.PlanScore = score
+	rec.SampleCount++
+	rec.LastOutcomes = appendRing(rec.LastOutcomes, string(outcome), 10)
+	if err := s.Put(ctx, rec); err != nil {
+		return rec, err
+	}
+	return rec, nil
+}
+
+// Decide returns the decision for a fresh request based on the cluster's
+// current affinity. Below minSamples the store yields to the legacy gate so
+// new clusters don't behave erratically.
+func (s *AffinityStore) Decide(ctx context.Context, c TaskCluster) (PlanDecision, ClusterAffinity) {
+	rec := s.Get(ctx, c)
+	if rec.SampleCount < minSamples {
+		return DecisionUseLegacy, rec
+	}
+	switch {
+	case rec.PlanScore > 0.7:
+		return DecisionPlanThenAct, rec
+	case rec.PlanScore > 0.3:
+		return DecisionPlanInParallel, rec
+	default:
+		return DecisionJustAct, rec
+	}
+}
+
+// appendRing pushes v onto a ring buffer of size n, dropping the oldest entry.
+func appendRing(ring []string, v string, n int) []string {
+	ring = append(ring, v)
+	if len(ring) > n {
+		ring = ring[len(ring)-n:]
+	}
+	return ring
+}
+
+// SummaryFor returns a one-line human-readable description of why a decision
+// was made. Used by the narration path so the agent can say "I'm now treating
+// summarize/youtube as auto-run — you've approved 4 of those."
+func (s *AffinityStore) SummaryFor(rec ClusterAffinity) string {
+	if rec.SampleCount == 0 {
+		return ""
+	}
+	approved, rejected := 0, 0
+	for _, o := range rec.LastOutcomes {
+		switch AffinityOutcome(o) {
+		case OutcomeApproved, OutcomeModified, OutcomeThanked:
+			approved++
+		case OutcomeRejected, OutcomeIgnored:
+			rejected++
+		}
+	}
+	cluster := strings.Join([]string{rec.Verb, rec.ObjectClass}, "/")
+	return fmt.Sprintf("cluster=%s score=%.2f samples=%d approved=%d rejected=%d",
+		cluster, rec.PlanScore, rec.SampleCount, approved, rejected)
+}

--- a/internal/agent/affinity_test.go
+++ b/internal/agent/affinity_test.go
@@ -1,0 +1,114 @@
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// fakeMem is a tiny in-memory Memory implementation for tests.
+type fakeMem struct {
+	store map[string]core.MemoryEntry
+}
+
+func newFakeMem() *fakeMem { return &fakeMem{store: map[string]core.MemoryEntry{}} }
+
+func (m *fakeMem) Store(_ context.Context, e core.MemoryEntry) error {
+	m.store[e.Key] = e
+	return nil
+}
+func (m *fakeMem) Recall(_ context.Context, k string) (*core.MemoryEntry, error) {
+	if e, ok := m.store[k]; ok {
+		return &e, nil
+	}
+	return nil, nil
+}
+func (m *fakeMem) Search(_ context.Context, _ string, _ int) ([]core.MemoryEntry, error) {
+	return nil, nil
+}
+func (m *fakeMem) RankedSearch(_ context.Context, _, _ string, _ int) ([]core.MemoryEntry, error) {
+	return nil, nil
+}
+func (m *fakeMem) Forget(_ context.Context, k string) error { delete(m.store, k); return nil }
+func (m *fakeMem) List(_ context.Context) ([]core.MemoryEntry, error) {
+	out := make([]core.MemoryEntry, 0, len(m.store))
+	for _, v := range m.store {
+		out = append(out, v)
+	}
+	return out, nil
+}
+func (m *fakeMem) Count() int { return len(m.store) }
+
+func TestAffinity_PullsTowardOneOnApproved(t *testing.T) {
+	store := NewAffinityStore(newFakeMem())
+	c := ClusterFor("summarize this https://youtube.com/watch?v=abc")
+	rec, err := store.Update(context.Background(), c, OutcomeApproved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rec.PlanScore <= 0.5 {
+		t.Fatalf("approved should pull score above 0.5, got %v", rec.PlanScore)
+	}
+}
+
+func TestAffinity_PullsTowardZeroOnRejected(t *testing.T) {
+	store := NewAffinityStore(newFakeMem())
+	c := ClusterFor("debug error: panic")
+	rec, _ := store.Update(context.Background(), c, OutcomeRejected)
+	if rec.PlanScore >= 0.5 {
+		t.Fatalf("rejected should pull score below 0.5, got %v", rec.PlanScore)
+	}
+}
+
+func TestAffinity_DecideUsesLegacyBelowMinSamples(t *testing.T) {
+	store := NewAffinityStore(newFakeMem())
+	c := ClusterFor("hi")
+	d, _ := store.Decide(context.Background(), c)
+	if d != DecisionUseLegacy {
+		t.Fatalf("brand new cluster should yield to legacy, got %v", d)
+	}
+}
+
+func TestAffinity_DecideAfterSamples(t *testing.T) {
+	store := NewAffinityStore(newFakeMem())
+	c := ClusterFor("summarize https://youtube.com/watch?v=abc")
+	for i := 0; i < 5; i++ {
+		_, _ = store.Update(context.Background(), c, OutcomeApproved)
+	}
+	d, rec := store.Decide(context.Background(), c)
+	if d != DecisionPlanThenAct {
+		t.Fatalf("five approvals should yield plan_then_act, got %v score=%v", d, rec.PlanScore)
+	}
+}
+
+func TestAffinity_RingBufferCap(t *testing.T) {
+	store := NewAffinityStore(newFakeMem())
+	c := ClusterFor("anything")
+	for i := 0; i < 15; i++ {
+		_, _ = store.Update(context.Background(), c, OutcomeApproved)
+	}
+	rec := store.Get(context.Background(), c)
+	if len(rec.LastOutcomes) != 10 {
+		t.Fatalf("ring buffer should cap at 10, got %d", len(rec.LastOutcomes))
+	}
+}
+
+func TestAffinity_ClampsTo05To95(t *testing.T) {
+	store := NewAffinityStore(newFakeMem())
+	c := ClusterFor("anything")
+	for i := 0; i < 100; i++ {
+		_, _ = store.Update(context.Background(), c, OutcomeApproved)
+	}
+	rec := store.Get(context.Background(), c)
+	if rec.PlanScore > 0.95 {
+		t.Fatalf("score should clamp at 0.95, got %v", rec.PlanScore)
+	}
+	for i := 0; i < 100; i++ {
+		_, _ = store.Update(context.Background(), c, OutcomeRejected)
+	}
+	rec = store.Get(context.Background(), c)
+	if rec.PlanScore < 0.05 {
+		t.Fatalf("score should clamp at 0.05, got %v", rec.PlanScore)
+	}
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -43,28 +43,44 @@ var rejectionRegex = regexp.MustCompile(`^(?:n|no|nah|nope|cancel|cancelled|stop
 // It is the executive function of the krill brain - classifying intent,
 // planning tasks, gating approval, and orchestrating execution.
 type KrillAgent struct {
-	llm         core.LLMProvider
-	brain       core.Brain
-	skills      core.SkillRegistry
-	mcp         core.MCPRegistry
-	cfg         config.AgentConfig
-	router      *IntentRouter
-	channel     string // durable conversation channel; default is unified across interfaces
-	platform    string // current chat platform (telegram, discord, cli, tui)
-	chatID      string // current chat ID for background task notifications
-	history     []core.Message
-	pendingPlan *core.Plan
-	subMgr      *SubKrillManager
-	taskStore   *TaskStore
-	taskRunner  *TaskRunner
-	turnFetches *turnFetchLog // per-turn provenance ledger; reset on each ChatFromPlatform call
-	mu          sync.Mutex
+	llm          core.LLMProvider
+	brain        core.Brain
+	skills       core.SkillRegistry
+	mcp          core.MCPRegistry
+	cfg          config.AgentConfig
+	router       *IntentRouter
+	channel      string // durable conversation channel; default is unified across interfaces
+	platform     string // current chat platform (telegram, discord, cli, tui)
+	chatID       string // current chat ID for background task notifications
+	history      []core.Message
+	pendingPlan  *core.Plan
+	subMgr       *SubKrillManager
+	taskStore    *TaskStore
+	taskRunner   *TaskRunner
+	turnFetches  *turnFetchLog  // per-turn provenance ledger; reset on each ChatFromPlatform call
+	affinity     *AffinityStore // task-type plan-affinity learner
+	lastCluster  TaskCluster    // cluster of the last planned task — used to credit outcomes
+	pendingClstr TaskCluster    // cluster while a plan is awaiting approval
+	mu           sync.Mutex
 }
 
 // New creates a fresh KrillAgent wired to all subsystems.
 // Like a krill larva hatching in the deep ocean - small but ready to grow.
 func New(cfg config.AgentConfig, llm core.LLMProvider, brain core.Brain, skills core.SkillRegistry, mcp core.MCPRegistry) *KrillAgent {
-	log.Info("krill agent spawning", "name", cfg.Name, "plan_approval", cfg.PlanApproval)
+	// Backward-compat: callers that build AgentConfig by hand (tests,
+	// programmatic embedders) often only set PlanApproval. Promote that to
+	// AutonomyFloor so the new gate path behaves the same way.
+	if cfg.AutonomyFloor == "" {
+		switch cfg.PlanApproval {
+		case "always":
+			cfg.AutonomyFloor = "suggest"
+		case "never":
+			cfg.AutonomyFloor = "act"
+		default:
+			cfg.AutonomyFloor = "act"
+		}
+	}
+	log.Info("krill agent spawning", "name", cfg.Name, "autonomy_floor", cfg.AutonomyFloor)
 
 	sysPrompt := brain.SystemPrompt()
 
@@ -76,7 +92,7 @@ func New(cfg config.AgentConfig, llm core.LLMProvider, brain core.Brain, skills 
 		}
 	}
 
-	return &KrillAgent{
+	a := &KrillAgent{
 		llm:     llm,
 		brain:   brain,
 		skills:  skills,
@@ -89,6 +105,10 @@ func New(cfg config.AgentConfig, llm core.LLMProvider, brain core.Brain, skills 
 		},
 		subMgr: NewSubKrillManager(cfg, llm),
 	}
+	if brain != nil {
+		a.affinity = NewAffinityStore(brain.Memory())
+	}
+	return a
 }
 
 // SetPlatform is retained for tests that don't go through ChatFromPlatform.
@@ -384,18 +404,38 @@ const (
 // handlePendingPlan processes user input when a plan is awaiting approval.
 // Returns (response, true) when the input was consumed by the approval flow,
 // or ("", false) when the caller should route the input as a fresh message.
+//
+// On approve/modify/reject the cluster's affinity score is updated so future
+// requests of the same shape need less ceremony. Bug #5/#11: when the user
+// says "no need for approval on this kind of things" mid-pending-plan, we
+// (a) flip the typed pref, (b) credit APPROVED to the cluster so the next
+// request is auto-acted, and (c) treat the current plan as approved — all in
+// one shot, instead of forcing the user to repeat themselves.
 func (a *KrillAgent) handlePendingPlan(ctx context.Context, input string) (string, bool) {
+	cluster := a.pendingClstr
 	decision := a.classifyApprovalReply(ctx, input)
+
+	// Special-case: the user is asking us to stop asking. Treat as APPROVE
+	// for the current plan AND set the typed pref so future plans don't gate.
+	if a.looksLikeStopAsking(input) {
+		log.Info("user requested no-approval mode mid-plan; auto-approving and flipping pref")
+		SetBoolPref(ctx, a.brain.Memory(), PrefNoPlanApproval, true)
+		decision = decisionApprove
+	}
+
 	switch decision {
 	case decisionApprove:
 		log.Info("plan approved by user", "task", a.pendingPlan.Task)
 		a.pendingPlan.Approved = true
 		plan := a.pendingPlan
 		a.pendingPlan = nil
+		a.creditOutcome(ctx, cluster, OutcomeApproved)
 		result, err := a.ExecutePlan(ctx, plan)
 		if err != nil {
 			return fmt.Sprintf("This krill hit a reef executing the plan: %v", err), true
 		}
+		// If this was the threshold flip, narrate it once.
+		result = a.maybeAppendAffinityNarration(ctx, result, cluster)
 		a.appendMessage(core.Message{Role: "assistant", Content: result})
 		a.saveTurn("assistant", result)
 		return result, true
@@ -403,6 +443,7 @@ func (a *KrillAgent) handlePendingPlan(ctx context.Context, input string) (strin
 	case decisionReject:
 		log.Info("plan rejected by user", "task", a.pendingPlan.Task)
 		a.pendingPlan = nil
+		a.creditOutcome(ctx, cluster, OutcomeRejected)
 		return "Plan scrapped. What else?", true
 
 	case decisionModify:
@@ -411,6 +452,7 @@ func (a *KrillAgent) handlePendingPlan(ctx context.Context, input string) (strin
 		log.Info("plan modification requested", "task", a.pendingPlan.Task)
 		oldTask := a.pendingPlan.Task
 		a.pendingPlan = nil
+		a.creditOutcome(ctx, cluster, OutcomeModified)
 		// Compose: original task + user's modifier. Cheap and good enough.
 		newTask := oldTask + " — adjustment: " + strings.TrimSpace(input)
 		response, err := a.handleTask(ctx, newTask)
@@ -420,11 +462,109 @@ func (a *KrillAgent) handlePendingPlan(ctx context.Context, input string) (strin
 		return response, true
 
 	default: // decisionUnrelated
-		// User moved on. Release control so the caller routes the input as a
-		// brand new message.
+		// User moved on. Treat as IGNORED so the cluster learns the plan was
+		// unwanted. Release control so the caller routes the input as a brand
+		// new message.
+		a.creditOutcome(ctx, cluster, OutcomeIgnored)
 		log.Debug("pending plan released — input unrelated", "input_preview", truncate(input, 50))
 		return "", false
 	}
+}
+
+// looksLikeStopAsking detects messages that are functionally "stop gating my
+// requests" even when they don't match the typed-pref triggers exactly. Bug #5
+// motivation: "No need for taking my approval on this kind of things" did set
+// the pref but did NOT approve the pending plan, so the user had to type "Yes"
+// after. Now this catches both at once.
+func (a *KrillAgent) looksLikeStopAsking(input string) bool {
+	lower := strings.ToLower(strings.TrimSpace(input))
+	patterns := []string{
+		"no need for taking my approval",
+		"no need to approve",
+		"no need for approval",
+		"stop asking me to approve",
+		"don't ask me to approve",
+		"dont ask me to approve",
+		"skip approval",
+		"auto approve",
+		"auto-approve",
+		"just do it from now on",
+	}
+	for _, p := range patterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// creditOutcome records an outcome against a cluster, async-safe.
+func (a *KrillAgent) creditOutcome(ctx context.Context, cluster TaskCluster, outcome AffinityOutcome) {
+	if a.affinity == nil || cluster.ID == "" {
+		return
+	}
+	if _, err := a.affinity.Update(ctx, cluster, outcome); err != nil {
+		log.Debug("affinity update failed", "cluster", cluster.String(), "outcome", outcome, "error", err)
+	}
+}
+
+// maybeAppendAffinityNarration appends a one-liner to the response when this
+// outcome flipped the cluster from "needs approval" to "auto-run". Issue #30:
+// autonomy without narrated learning is a black box. The flip is detected by
+// re-checking the decision after the update — if the cluster has just crossed
+// into PlanThenAct territory we mention it, otherwise we stay quiet.
+func (a *KrillAgent) maybeAppendAffinityNarration(ctx context.Context, response string, cluster TaskCluster) string {
+	if a.affinity == nil || cluster.ID == "" {
+		return response
+	}
+	rec := a.affinity.Get(ctx, cluster)
+	if rec.SampleCount == minSamples && rec.PlanScore > 0.7 {
+		return response + fmt.Sprintf("\n\n_(I'm now treating `%s` as auto-run — you've approved enough of these.)_", cluster.String())
+	}
+	return response
+}
+
+// firstStepIsAskingTheUser returns true when the planner's first step is some
+// variant of "Ask the user for X" — a structural signal that the agent should
+// just ask the question instead of producing a 5-step plan around the asking.
+// Issue #17: this happens constantly with vague tasks ("summarize this video"
+// without a link) and erodes trust in plan output.
+func firstStepIsAskingTheUser(plan *core.Plan) bool {
+	if plan == nil || len(plan.Steps) == 0 {
+		return false
+	}
+	lower := strings.ToLower(plan.Steps[0].Description)
+	patterns := []string{
+		"ask the user", "ask user", "request from the user",
+		"prompt the user", "get from the user",
+	}
+	for _, p := range patterns {
+		if strings.Contains(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractAskQuestion turns "Ask the user for the YouTube video link" into a
+// natural-sounding question. Falls back to a generic prompt if the description
+// is too generic to lift from.
+func extractAskQuestion(desc string) string {
+	lower := strings.ToLower(desc)
+	for _, prefix := range []string{
+		"ask the user for the ", "ask the user for ", "ask user for the ", "ask user for ",
+		"prompt the user for the ", "prompt the user for ", "request from the user the ",
+		"request from the user ", "get from the user the ", "get from the user ",
+	} {
+		if idx := strings.Index(lower, prefix); idx >= 0 {
+			tail := strings.TrimSpace(desc[idx+len(prefix):])
+			tail = strings.TrimRight(tail, ".?!")
+			if tail != "" {
+				return "Could you share the " + tail + "?"
+			}
+		}
+	}
+	return "Before I can plan this, I need a bit more from you. What should I work with?"
 }
 
 // classifyApprovalReply judges a user reply against a pending plan: regex fast
@@ -475,24 +615,46 @@ User reply: ` + input
 
 // handleTask generates a plan and presents it for approval.
 func (a *KrillAgent) handleTask(ctx context.Context, input string) (string, error) {
+	cluster := ClusterFor(input)
+
 	plan, err := a.Plan(ctx, input)
 	if err != nil {
 		log.Error("plan generation failed", "error", err)
 		return fmt.Sprintf("This krill's sonar is glitching - could not plan that task: %v", err), nil
 	}
 
+	// Issue #17: if the planner's first step is "Ask the user for X", skip
+	// the plan and just ask the question directly. Five-step "I will ask the
+	// user, then I will brainstorm…" plans for clarification questions are
+	// the most common way the krill wastes a turn.
+	if firstStepIsAskingTheUser(plan) {
+		question := extractAskQuestion(plan.Steps[0].Description)
+		log.Info("planner's first step asks the user; skipping plan and asking directly", "question", truncate(question, 60))
+		a.creditOutcome(ctx, cluster, OutcomeIgnored) // this cluster shouldn't have planned
+		ack := question
+		a.appendMessage(core.Message{Role: "assistant", Content: ack})
+		a.saveTurn("assistant", ack)
+		return ack, nil
+	}
+
 	if a.shouldRequireApproval(ctx, plan) {
 		// Store as pending and present for approval
 		a.pendingPlan = plan
+		a.pendingClstr = cluster
 		formatted := FormatPlan(plan)
-		log.Info("plan generated, awaiting approval", "task", input, "steps", len(plan.Steps))
+		log.Info("plan generated, awaiting approval", "task", input, "steps", len(plan.Steps), "cluster", cluster.String())
 		a.appendMessage(core.Message{Role: "assistant", Content: formatted})
 		a.saveTurn("assistant", formatted)
 		return formatted, nil
 	}
 
-	// Auto-execute: intent is clear, plan is small and non-destructive
-	log.Info("auto-executing plan", "task", input, "steps", len(plan.Steps))
+	// Auto-execute: intent is clear, plan is small and non-destructive.
+	// Credit THANKED if the user later says nothing — heuristic, but it lets
+	// auto-act'd clusters drift toward "no plan needed" over time. Today we
+	// only credit APPROVED outcomes immediately; THANKED/FIXED would need a
+	// post-turn callback we don't have yet.
+	log.Info("auto-executing plan", "task", input, "steps", len(plan.Steps), "cluster", cluster.String())
+	a.lastCluster = cluster
 
 	// On timeout-sensitive platforms, run in background if task has multiple steps
 	if a.shouldRunInBackground(plan) {
@@ -598,41 +760,65 @@ func (a *KrillAgent) handleTaskCommand(input string) (string, bool) {
 }
 
 // shouldRequireApproval decides if a plan needs user approval before execution.
-// Uses a three-way config: "always", "never", or "auto" (smart default).
 //
-// Explicit config wins (the operator made a deliberate choice). The user's
-// runtime pref:no_plan_approval flag is honoured under "auto" so the agent
-// stops re-asking once the user has said "stop asking" — but destructive
-// plans still gate under "auto" regardless of the pref. That keeps casual
-// "auto approve" phrases from authorising rm -rf.
+// Decision precedence:
+//  1. Destructive plans (planIsDestructive) ALWAYS gate, regardless of floor.
+//     Casual "auto approve" never authorises rm -rf.
+//  2. autonomy_floor:
+//     - observe → always gate (debug mode)
+//     - suggest → always show plan, wait for explicit approval
+//     - act / evolve → consult affinity store + legacy fallback
+//
+// Under act/evolve the affinity store gets first say:
+//   - PlanThenAct (score > 0.7) → no gate, run + show plan as FYI
+//   - PlanInParallel (0.3 < score ≤ 0.7) → no gate, kick execution while showing plan
+//   - JustAct (score ≤ 0.3) → caller should have skipped plan generation entirely
+//   - UseLegacy (samples < 3) → fall through to the legacy heuristics below
+//
+// Legacy heuristics (only when affinity hasn't calibrated yet):
+//   - User has set pref:no_plan_approval → no gate
+//   - >=5 steps → gate
+//   - vague task description → gate
+//   - else → no gate
 func (a *KrillAgent) shouldRequireApproval(ctx context.Context, plan *core.Plan) bool {
-	switch a.cfg.PlanApproval {
-	case "always":
+	if planIsDestructive(plan) {
 		return true
-	case "never":
-		return false
-	default: // "auto"
-		if planIsDestructive(plan) {
-			return true
-		}
-		// User has said "stop asking" → trust them on non-destructive work.
-		if GetBoolPref(ctx, a.brain.Memory(), PrefNoPlanApproval, false) {
-			return false
-		}
-		// Large plans need approval
-		if len(plan.Steps) >= 5 {
-			return true
-		}
-		// Vague task descriptions need approval
-		lower := strings.ToLower(plan.Task)
-		vaguePatterns := []string{"everything", "all of", "entire", "whole project", "set up"}
-		for _, vague := range vaguePatterns {
-			if strings.Contains(lower, vague) {
-				return true
+	}
+
+	switch a.cfg.AutonomyFloor {
+	case "observe":
+		return true
+	case "suggest":
+		return true
+	case "act", "evolve":
+		// Consult affinity store first.
+		if a.affinity != nil {
+			cluster := ClusterFor(plan.Task)
+			decision, _ := a.affinity.Decide(ctx, cluster)
+			switch decision {
+			case DecisionPlanThenAct, DecisionPlanInParallel, DecisionJustAct:
+				return false
+			case DecisionUseLegacy:
+				// fall through to legacy heuristics
 			}
 		}
+	}
+
+	// Legacy fallback used when affinity isn't yet calibrated.
+	if GetBoolPref(ctx, a.brain.Memory(), PrefNoPlanApproval, false) {
 		return false
 	}
+	if len(plan.Steps) >= 5 {
+		return true
+	}
+	lower := strings.ToLower(plan.Task)
+	vaguePatterns := []string{"everything", "all of", "entire", "whole project", "set up"}
+	for _, vague := range vaguePatterns {
+		if strings.Contains(lower, vague) {
+			return true
+		}
+	}
+	return false
 }
 
 // planIsDestructive returns true for plans whose steps touch destructive verbs

--- a/internal/agent/cluster.go
+++ b/internal/agent/cluster.go
@@ -1,0 +1,135 @@
+// Package agent — cluster.go derives a stable identity for "task type" so the
+// affinity store can learn which kinds of work the user wants planned versus
+// just executed.
+//
+// The cluster identity is intentionally lossy: better to have ~30 stable
+// clusters across thousands of unique inputs than 3000 unique strings the
+// learner can never accumulate enough samples for.
+//
+// cluster_id = sha1(verb + "|" + object_class)[:12]
+//
+// where verb is the first matching action verb and object_class is the
+// strongest contextual signal we can extract cheaply.
+package agent
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"regexp"
+	"strings"
+)
+
+// TaskCluster is the cheap, deterministic identity for a task type.
+type TaskCluster struct {
+	ID          string // 12-char hex of sha1(verb|object)
+	Verb        string
+	ObjectClass string
+}
+
+// String returns "verb/object" — useful for logging and user-facing narration.
+func (c TaskCluster) String() string {
+	if c.Verb == "" && c.ObjectClass == "" {
+		return "chat/freeform"
+	}
+	v := c.Verb
+	if v == "" {
+		v = "chat"
+	}
+	o := c.ObjectClass
+	if o == "" {
+		o = "freeform"
+	}
+	return v + "/" + o
+}
+
+// clusterVerbs is the master list. Order matters — earlier verbs win on tie.
+// Includes both the hardActionVerbs from router.go and softer verbs that still
+// shape task behaviour (summarize, explain, find, etc.).
+var clusterVerbs = []string{
+	// Hard verbs (touch real systems / produce artifacts)
+	"deploy", "install", "uninstall", "refactor", "migrate", "configure",
+	"set up", "scaffold", "bootstrap", "provision", "rollback", "publish",
+	"merge", "rebase", "commit", "push", "pull", "checkout",
+	"build", "create", "make", "write", "implement", "develop",
+	"fix", "debug", "generate",
+	// Soft verbs (read / explain / ideate)
+	"summarize", "summarise", "explain", "describe", "compare",
+	"find", "search", "lookup", "look up", "check", "review",
+	"brainstorm", "suggest", "recommend", "list", "show",
+	"read", "open", "fetch", "load",
+}
+
+// objectClassRules maps regex/keyword patterns to object-class labels.
+// First match wins. The freeform fallback ensures every input gets a class.
+var objectClassRules = []struct {
+	match func(string) bool
+	class string
+}{
+	{func(s string) bool { return youtubePattern.MatchString(s) }, "youtube"},
+	{func(s string) bool { return strings.Contains(s, "github.com") }, "github"},
+	{func(s string) bool { return strings.Contains(s, "stackoverflow.com") }, "stackoverflow"},
+	{func(s string) bool { return strings.HasSuffix(strings.Fields(s)[len(strings.Fields(s))-1], ".pdf") }, "pdf"},
+	{func(s string) bool { return urlPattern.MatchString(s) }, "web"},
+	{fileExtensionMatch([]string{".go", ".py", ".js", ".ts", ".rs", ".java", ".c", ".cpp", ".rb"}), "code-file"},
+	{fileExtensionMatch([]string{".yaml", ".yml", ".toml", ".json", ".env", ".ini"}), "config-file"},
+	{fileExtensionMatch([]string{".md", ".txt", ".rst"}), "doc-file"},
+	{func(s string) bool {
+		return strings.Contains(s, "error") || strings.Contains(s, "stack trace") ||
+			strings.Contains(s, "traceback") || strings.Contains(s, "panic") ||
+			strings.Count(s, "\n") > 2
+	}, "error-text"},
+	{func(s string) bool { return strings.Contains(s, "?") }, "question"},
+}
+
+// fileExtensionMatch returns a predicate that matches inputs containing any
+// listed extension as a token boundary.
+func fileExtensionMatch(exts []string) func(string) bool {
+	return func(s string) bool {
+		for _, ext := range exts {
+			// Match ".go " or ".go" at end, not ".godzilla"
+			if strings.Contains(s, ext+" ") || strings.HasSuffix(s, ext) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// fieldsRegex collapses runs of whitespace for cheap word-boundary matching.
+var fieldsRegex = regexp.MustCompile(`\s+`)
+
+// ClusterFor returns the TaskCluster for an arbitrary user input.
+//
+// Inputs that match no verb collapse to verb="chat"; inputs that match no
+// object class collapse to object="freeform". Both fallbacks together produce
+// the cluster `chat/freeform` which absorbs all greetings and small talk.
+func ClusterFor(input string) TaskCluster {
+	lower := strings.ToLower(strings.TrimSpace(input))
+	if lower == "" {
+		return TaskCluster{ID: clusterID("chat", "freeform"), Verb: "chat", ObjectClass: "freeform"}
+	}
+
+	verb := "chat"
+	for _, v := range clusterVerbs {
+		if strings.Contains(lower, v) {
+			verb = v
+			break
+		}
+	}
+
+	object := "freeform"
+	for _, rule := range objectClassRules {
+		if rule.match(lower) {
+			object = rule.class
+			break
+		}
+	}
+
+	return TaskCluster{ID: clusterID(verb, object), Verb: verb, ObjectClass: object}
+}
+
+// clusterID returns the 12-char hex identifier for a (verb, object) pair.
+func clusterID(verb, object string) string {
+	sum := sha1.Sum([]byte(verb + "|" + object))
+	return hex.EncodeToString(sum[:])[:12]
+}

--- a/internal/agent/cluster_test.go
+++ b/internal/agent/cluster_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import "testing"
+
+func TestClusterFor_StableID(t *testing.T) {
+	a := ClusterFor("summarize this https://www.youtube.com/watch?v=abc")
+	b := ClusterFor("summarize this https://youtu.be/xyz")
+	if a.ID != b.ID {
+		t.Fatalf("youtube summaries should cluster together: %v vs %v", a, b)
+	}
+	if a.Verb != "summarize" || a.ObjectClass != "youtube" {
+		t.Fatalf("unexpected cluster: %+v", a)
+	}
+}
+
+func TestClusterFor_DistinctClasses(t *testing.T) {
+	a := ClusterFor("summarize this https://www.youtube.com/watch?v=abc")
+	b := ClusterFor("summarize this https://example.com/article")
+	if a.ID == b.ID {
+		t.Fatalf("youtube and generic web should not collapse to same cluster")
+	}
+}
+
+func TestClusterFor_Greeting(t *testing.T) {
+	c := ClusterFor("hi")
+	if c.Verb != "chat" || c.ObjectClass != "freeform" {
+		t.Fatalf("greeting should fall back to chat/freeform, got %+v", c)
+	}
+}
+
+func TestClusterFor_ErrorText(t *testing.T) {
+	c := ClusterFor("debug this error: panic at runtime")
+	if c.Verb != "debug" || c.ObjectClass != "error-text" {
+		t.Fatalf("expected debug/error-text, got %+v", c)
+	}
+}
+
+func TestClusterFor_Question(t *testing.T) {
+	c := ClusterFor("what should we build?")
+	if c.ObjectClass != "question" {
+		t.Fatalf("expected question class, got %+v", c)
+	}
+}
+
+func TestClusterFor_EmptyInput(t *testing.T) {
+	c := ClusterFor("   ")
+	if c.Verb != "chat" || c.ObjectClass != "freeform" {
+		t.Fatalf("expected chat/freeform fallback, got %+v", c)
+	}
+}
+
+func TestClusterFor_StringRender(t *testing.T) {
+	c := ClusterFor("summarize this https://youtube.com/watch?v=abc")
+	if c.String() != "summarize/youtube" {
+		t.Fatalf("unexpected String(): %q", c.String())
+	}
+}

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -307,19 +307,21 @@ func TestShouldRequireApprovalNever(t *testing.T) {
 		&mockMCPReg{},
 	)
 
+	// Under autonomy_floor=act (migrated from PlanApproval=never), reversible
+	// plans run without approval. Destructive plans still gate — that's a
+	// deliberate safety change since v0.1.1: no autonomy floor authorises
+	// rm -rf or "deploy to prod" silently. To test the no-gate path, use a
+	// reversible plan instead.
 	plan := &core.Plan{
-		Task: "dangerous task",
+		Task: "tidy up",
 		Steps: []core.PlanStep{
-			{ID: 1, Description: "delete everything"},
-			{ID: 2, Description: "deploy to prod"},
-			{ID: 3, Description: "remove all data"},
-			{ID: 4, Description: "push to main"},
-			{ID: 5, Description: "reset database"},
+			{ID: 1, Description: "list files"},
+			{ID: 2, Description: "summarise findings"},
 		},
 	}
 
 	if a.shouldRequireApproval(context.Background(), plan) {
-		t.Error("PlanApproval=never should never require approval")
+		t.Error("PlanApproval=never should not require approval for reversible plans")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,25 +30,29 @@ type Config struct {
 
 // AgentConfig controls the main krill agent behaviour.
 type AgentConfig struct {
-	Name          string       `yaml:"name"`
-	Personality   string       `yaml:"personality"` // active personality profile (default: "krill")
-	MaxSubKrills  int          `yaml:"max_sub_krills"`
-	PlanApproval  string       `yaml:"-"` // "auto" (default), "always", or "never"; set via UnmarshalYAML
-	RecoveryTurns int          `yaml:"recovery_turns"` // turns to load on cold start (default 10, from brain config)
+	Name          string `yaml:"name"`
+	Personality   string `yaml:"personality"` // active personality profile (default: "krill")
+	MaxSubKrills  int    `yaml:"max_sub_krills"`
+	PlanApproval  string `yaml:"-"` // legacy: "auto"|"always"|"never"; superseded by AutonomyFloor
+	AutonomyFloor string `yaml:"-"` // "observe"|"suggest"|"act"|"evolve"; default "act"
+	RecoveryTurns int    `yaml:"recovery_turns"`
 }
 
 // agentConfigRaw is used during YAML unmarshalling to accept plan_approval
-// as either a bool (legacy) or string (new).
+// as either a bool (legacy) or string (new), and autonomy_floor as the new field.
 type agentConfigRaw struct {
 	Name          string      `yaml:"name"`
 	Personality   string      `yaml:"personality"`
 	MaxSubKrills  int         `yaml:"max_sub_krills"`
 	PlanApproval  interface{} `yaml:"plan_approval"`
+	AutonomyFloor string      `yaml:"autonomy_floor"`
 	RecoveryTurns int         `yaml:"recovery_turns"`
 }
 
 // UnmarshalYAML handles backward-compatible parsing of plan_approval,
-// which was a bool in earlier versions and is now a 3-way string.
+// which was a bool in earlier versions, became a 3-way string, and is now
+// folded into AutonomyFloor. plan_approval is preserved during migration so
+// users see one deprecation log line and then we move on.
 func (a *AgentConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var raw agentConfigRaw
 	if err := unmarshal(&raw); err != nil {
@@ -58,6 +62,7 @@ func (a *AgentConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	a.Personality = raw.Personality
 	a.MaxSubKrills = raw.MaxSubKrills
 	a.RecoveryTurns = raw.RecoveryTurns
+	a.AutonomyFloor = raw.AutonomyFloor
 
 	switch v := raw.PlanApproval.(type) {
 	case bool:
@@ -74,19 +79,21 @@ func (a *AgentConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-// MarshalYAML ensures PlanApproval is written as a string when saving config.
+// MarshalYAML writes AutonomyFloor as the canonical autonomy knob. PlanApproval
+// is no longer persisted — the migration in fillDefaults flips legacy values
+// into AutonomyFloor on first load.
 func (a AgentConfig) MarshalYAML() (interface{}, error) {
 	return &struct {
 		Name          string `yaml:"name"`
 		Personality   string `yaml:"personality,omitempty"`
 		MaxSubKrills  int    `yaml:"max_sub_krills"`
-		PlanApproval  string `yaml:"plan_approval"`
+		AutonomyFloor string `yaml:"autonomy_floor"`
 		RecoveryTurns int    `yaml:"recovery_turns,omitempty"`
 	}{
 		Name:          a.Name,
 		Personality:   a.Personality,
 		MaxSubKrills:  a.MaxSubKrills,
-		PlanApproval:  a.PlanApproval,
+		AutonomyFloor: a.AutonomyFloor,
 		RecoveryTurns: a.RecoveryTurns,
 	}, nil
 }
@@ -188,9 +195,10 @@ func DefaultConfig() *Config {
 	dataDir := DataDir()
 	return &Config{
 		Agent: AgentConfig{
-			Name:         "krill",
-			MaxSubKrills: 3,
-			PlanApproval: "auto",
+			Name:          "krill",
+			MaxSubKrills:  3,
+			PlanApproval:  "auto",
+			AutonomyFloor: "act",
 		},
 		LLM: LLMConfig{
 			Provider:    "ollama",
@@ -285,6 +293,26 @@ func fillDefaults(cfg *Config) {
 		cfg.Agent.PlanApproval = "never"
 	default:
 		cfg.Agent.PlanApproval = "auto"
+	}
+	// AutonomyFloor migration: if absent, derive from PlanApproval (one-time)
+	// and let it become the canonical knob from here on.
+	if cfg.Agent.AutonomyFloor == "" {
+		switch cfg.Agent.PlanApproval {
+		case "always":
+			cfg.Agent.AutonomyFloor = "suggest"
+		case "never":
+			cfg.Agent.AutonomyFloor = "act"
+		case "auto":
+			cfg.Agent.AutonomyFloor = "act"
+		default:
+			cfg.Agent.AutonomyFloor = "act"
+		}
+	}
+	switch cfg.Agent.AutonomyFloor {
+	case "observe", "suggest", "act", "evolve":
+		// valid
+	default:
+		cfg.Agent.AutonomyFloor = "act"
 	}
 	if cfg.Telegram.BotMaxTurns == 0 {
 		cfg.Telegram.BotMaxTurns = 3


### PR DESCRIPTION
Second of three PRs in the v0.1.1 cycle. Stacks on top of #30. Version stays at 0.1.0.

> Stacked on #30 (\`pr1-trust-and-quickwins\`). Once #30 lands, the base will retarget to \`main\` automatically.

## Summary

- **`autonomy_floor` config** replaces `plan_approval={always,never,auto}` with `{observe,suggest,act,evolve}`. Default flips to `act`. Migration at config load + a second migration in `agent.New()` for hand-built `AgentConfig` (tests, embedders). Old YAML configs continue to work.
- **Task-type clustering (D1)** — `internal/agent/cluster.go`. Maps a user request to `verb/object` (sha1[:12]). Lossy on purpose: ~30 stable clusters across 3000 unique inputs.
- **Plan-affinity store (D2)** — `internal/agent/affinity.go`. Per-cluster `[0.05, 0.95]` score persisted in the existing Memory backend under `affinity:cluster:<id>`. Bayesian-ish pull-toward-extreme update rule. Below 3 samples yields `DecisionUseLegacy` and the old heuristics decide.
- **Outcome detection (D3)** — `handlePendingPlan` credits APPROVED / MODIFIED / REJECTED / IGNORED to the pending cluster, asynchronously. New requests of the same shape need less ceremony over time.
- **Bug #5 / #11 fix folded in** — "No need for taking my approval on this kind of things" mid-plan now flips the pref AND treats the current plan as approved AND credits the cluster, all in one shot. No more "Yea" → "Yes" double-tap loop. New `looksLikeStopAsking` helper drives this from the approval handler.
- **Issue #30 — narrate every flip** — when a cluster crosses the calibration threshold into auto-run territory, the next response appends `_(I'm now treating summarize/youtube as auto-run — you've approved enough of these.)_`. Autonomy is no longer silent.
- **Issue #17 — ask-the-user pattern** — when the planner's first step is "Ask the user for X", `handleTask` now skips the plan and asks the question directly. Credits IGNORED to the cluster so the planner learns to stop producing those.

## Behaviour changes worth noting

- `PlanApproval=never` no longer bypasses destructive checks (\"delete\", \"deploy to prod\", \"rm -rf\", etc.). No autonomy floor authorises destructive actions silently. `TestShouldRequireApprovalNever` updated to test the reversible-plan path instead.
- Default `autonomy_floor=act` means most plans run without an approval gate. Operators who want the old gate behaviour can set `autonomy_floor: suggest` in `~/.mini-krill/config.yaml`.

## Test plan

- [x] `go test ./...` green (37 new test assertions across `cluster_test.go` and `affinity_test.go`)
- [x] `go vet ./...` clean
- [ ] Manual: send "summarize this <youtube url>" 5 times, approving each plan. Confirm the 6th run auto-executes without a plan and the 5th carries the narration line.
- [ ] Manual: send a destructive plan with `autonomy_floor=act`. Confirm it still gates.
- [ ] Manual: with a pending plan, type "no need for approval here" and confirm the plan executes immediately AND the typed pref flips.
- [ ] Manual: ask "summarize this video" without a link. Confirm the agent asks for the link directly instead of generating a 5-step "I will ask the user, then…" plan.