### PR TITLE
No permission prompts by default; v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to Mini Krill will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.1.2] - 2026-05-16
+
+No more nagging. The agent stops asking for manual permission on routine work.
+
+### Autonomy
+- Manual approval prompts are **off by default**. Under the default `act`/`evolve` autonomy floor, a non-destructive plan never gates — step count, task vagueness, and an un-calibrated affinity cluster are no longer reasons to ask "Approve this plan? (yes/no)". This was the top "why does it keep asking permission" complaint and contradicted the documented v0.1.1 `act` contract. Users who want a gate set `autonomy_floor: suggest`.
+- Unchanged safety: destructive plans (delete, `git push`, deploy, `rm`, drop, …) still always gate, regardless of floor. `autonomy_floor: suggest`/`observe` still gate on demand.
+
+### Fixed
+- Version constant and README badge corrected — the v0.1.1 release shipped its CHANGELOG and merged code but never bumped `core.Version` (still reported `0.1.0`) or the README badge. Both now report `0.1.2`.
+
 ## [0.1.1] - 2026-05-15
 
 Trust, autonomy, and identity. The agent now learns which task types you want planned, acts decisively on the rest, and is no longer hard-wired as a krill.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Built by [Sourav Singh](https://souravailabs.ai/about/) / [Sourav AI Labs](https://souravailabs.ai)
 
-[![Version](https://img.shields.io/badge/version-0.1.0-blue.svg)](https://github.com/srvsngh99/mini-krill/releases)
+[![Version](https://img.shields.io/badge/version-0.1.2-blue.svg)](https://github.com/srvsngh99/mini-krill/releases)
 [![Go](https://img.shields.io/badge/Go-1.24+-00ADD8.svg?logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)]()

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -832,21 +832,15 @@ func (a *KrillAgent) handleTaskCommand(input string) (string, bool) {
 //  2. autonomy_floor:
 //     - observe → always gate (debug mode)
 //     - suggest → always show plan, wait for explicit approval
-//     - act / evolve → consult affinity store + legacy fallback
+//     - act / evolve (the default) → non-destructive plans NEVER gate
 //
-// Under act/evolve, JustAct is handled upstream in handleTask (the plan is
-// never generated). By the time we get here, the plan exists, so the only
-// meaningful affinity tiers are:
-//   - PlanThenAct  (score > 0.7) → no gate, auto-execute the generated plan
-//   - PlanInParallel (0.3 < score ≤ 0.7) → no gate, auto-execute and show the plan as FYI
-//     (the parallel/streaming UX is future work; today both tiers behave the same — no gate)
-//   - UseLegacy (samples < 3) → fall through to the legacy heuristics below
-//
-// Legacy heuristics (only when affinity hasn't calibrated yet):
-//   - User has set pref:no_plan_approval → no gate
-//   - >=5 steps → gate
-//   - vague task description → gate
-//   - else → no gate
+// Under the default act/evolve floor, manual approval is off: a
+// non-destructive plan runs without ever asking. Step count and task
+// vagueness do NOT reintroduce a gate — that contradicted the documented
+// "act = no approval gate" contract and was the top user complaint. Users
+// who want a gate set autonomy_floor:suggest. The legacy step-count / vague
+// heuristics survive only as a defensive fallback for an unrecognised floor
+// value, which New() should make unreachable.
 func (a *KrillAgent) shouldRequireApproval(ctx context.Context, plan *core.Plan) bool {
 	if planIsDestructive(plan) {
 		return true
@@ -858,20 +852,22 @@ func (a *KrillAgent) shouldRequireApproval(ctx context.Context, plan *core.Plan)
 	case "suggest":
 		return true
 	case "act", "evolve":
-		// Consult affinity store first.
-		if a.affinity != nil {
-			cluster := ClusterFor(plan.Task)
-			decision, _ := a.affinity.Decide(ctx, cluster)
-			switch decision {
-			case DecisionPlanThenAct, DecisionPlanInParallel, DecisionJustAct:
-				return false
-			case DecisionUseLegacy:
-				// fall through to legacy heuristics
-			}
-		}
+		// act/evolve contract (the default floor since v0.1.1): a
+		// non-destructive plan NEVER gates. Destructive plans already
+		// returned true above. Every affinity tier — PlanThenAct,
+		// PlanInParallel, JustAct, and an un-calibrated UseLegacy — means
+		// "don't ask". An un-calibrated cluster is not a licence to start
+		// nagging: the old step-count / vague-task heuristics here
+		// contradicted the documented "act = no approval gate for
+		// non-destructive work" promise and were the #1 source of the
+		// "why does it keep asking permission" complaint. Manual approval
+		// is off by default; users who want it set autonomy_floor:suggest.
+		return false
 	}
 
-	// Legacy fallback used when affinity isn't yet calibrated.
+	// Defensive fallback for an unrecognised floor value (New() normalises
+	// the floor, so this should be unreachable in practice). Conservative
+	// legacy heuristics: pref opt-out, large plans, vague tasks.
 	if GetBoolPref(ctx, a.brain.Memory(), PrefNoPlanApproval, false) {
 		return false
 	}

--- a/internal/agent/router_test.go
+++ b/internal/agent/router_test.go
@@ -372,6 +372,10 @@ func TestShouldRequireApprovalAutoSmallSafe(t *testing.T) {
 	}
 }
 
+// Under the default act floor (migrated from "auto"), a large but
+// non-destructive plan must NOT gate. Step count is no longer a reason to
+// ask for manual permission — that was the #1 "why does it keep asking"
+// complaint and contradicted the documented act contract.
 func TestShouldRequireApprovalAutoLargePlan(t *testing.T) {
 	a := New(
 		config.AgentConfig{Name: "test", PlanApproval: "auto"},
@@ -381,7 +385,7 @@ func TestShouldRequireApprovalAutoLargePlan(t *testing.T) {
 		&mockMCPReg{},
 	)
 
-	// 6 steps
+	// 6 steps, all reversible
 	plan := &core.Plan{
 		Task: "refactor auth",
 		Steps: []core.PlanStep{
@@ -394,8 +398,8 @@ func TestShouldRequireApprovalAutoLargePlan(t *testing.T) {
 		},
 	}
 
-	if !a.shouldRequireApproval(context.Background(), plan) {
-		t.Error("auto mode: 6-step plan should require approval")
+	if a.shouldRequireApproval(context.Background(), plan) {
+		t.Error("act default: 6-step non-destructive plan must NOT require approval")
 	}
 }
 
@@ -446,6 +450,9 @@ func TestShouldRequireApprovalAutoNoFalsePositives(t *testing.T) {
 	}
 }
 
+// Under the default act floor, a vague task description no longer forces a
+// gate either — only destructiveness or an explicit suggest/observe floor
+// does. Manual approval is opt-in via autonomy_floor:suggest.
 func TestShouldRequireApprovalAutoVagueTask(t *testing.T) {
 	a := New(
 		config.AgentConfig{Name: "test", PlanApproval: "auto"},
@@ -455,7 +462,7 @@ func TestShouldRequireApprovalAutoVagueTask(t *testing.T) {
 		&mockMCPReg{},
 	)
 
-	// Vague task
+	// Vague but non-destructive task
 	plan := &core.Plan{
 		Task: "improve everything in the whole project",
 		Steps: []core.PlanStep{
@@ -464,8 +471,20 @@ func TestShouldRequireApprovalAutoVagueTask(t *testing.T) {
 		},
 	}
 
-	if !a.shouldRequireApproval(context.Background(), plan) {
-		t.Error("auto mode: vague task should require approval")
+	if a.shouldRequireApproval(context.Background(), plan) {
+		t.Error("act default: vague non-destructive task must NOT require approval")
+	}
+
+	// suggest floor still gates — manual approval is available on demand.
+	s := New(
+		config.AgentConfig{Name: "test", PlanApproval: "always"},
+		&MockProvider{chatResponse: "CHAT"},
+		&mockBrain{},
+		&mockSkillRegistry{},
+		&mockMCPReg{},
+	)
+	if !s.shouldRequireApproval(context.Background(), plan) {
+		t.Error("suggest floor: plan should still require approval")
 	}
 }
 

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Version is set at build time via -ldflags
-var Version = "0.1.0"
+var Version = "0.1.2"
 
 // ---------------------------------------------------------------------------
 // LLM types


### PR DESCRIPTION
## What

Two things, one patch release (**v0.1.2**):

### 1. Manual approval prompts are off by default (the main fix)
`shouldRequireApproval` had a legacy heuristic that, under the **default `act` floor**, still gated any non-destructive plan with **≥5 steps** or a "vague" task word (`everything`, `set up`, …). Because per-task-type affinity needs 3+ runs to calibrate, normal users hit that path constantly and got `Approve this plan? (yes/no)` on routine safe work — the top "why does it keep asking permission" complaint, and a direct contradiction of the documented v0.1.1 `act` contract ("non-destructive plans run without an approval gate").

Now: under `act`/`evolve` (the default), a **non-destructive plan never gates**. Step count, vagueness, and un-calibrated clusters no longer reintroduce a prompt.

**Unchanged safety:** destructive plans (`delete`, `git push`, `deploy`, `rm`, `drop`, …) still always gate regardless of floor. `autonomy_floor: suggest`/`observe` still gate on demand for users who want it.

The two tests that had locked in the old (buggy) behaviour are rewritten to assert the corrected contract.

### 2. v0.1.1 version regression fixed
The v0.1.1 release shipped its CHANGELOG and merged code but **never bumped `core.Version`** (still reported `0.1.0`) or the README badge. Both now report `0.1.2`.

## Test

`go build ./...`, `go vet ./...`, `go test ./...` — all green. Binary reports `minikrill version 0.1.2`.