### PR TITLE
Closed-loop learning: post-turn THANKED/FIXED, #16, reservation guard

### DIFF
--- a/internal/agent/affinity.go
+++ b/internal/agent/affinity.go
@@ -20,8 +20,10 @@ import (
 )
 
 // AffinityKeyPrefix reserves a memory key namespace so listing/searching the
-// regular memory store skips affinity entries.
-const AffinityKeyPrefix = "affinity:cluster:"
+// regular memory store skips affinity entries. It aliases the shared core
+// constant so the brain-side reservation guard and this writer can never
+// drift apart.
+const AffinityKeyPrefix = core.ReservedAffinityPrefix
 
 // AffinityOutcome is the discrete event types the store understands.
 type AffinityOutcome string
@@ -131,7 +133,7 @@ func (s *AffinityStore) Put(ctx context.Context, rec ClusterAffinity) error {
 		Value:      string(data),
 		Tags:       []string{"affinity", "system"},
 		Scope:      "system",
-		Source:     "affinity-store",
+		Source:     core.AffinitySource,
 		CreatedAt:  rec.LastUpdate,
 		AccessedAt: rec.LastUpdate,
 	})

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -61,6 +61,7 @@ type KrillAgent struct {
 	turnFetches       *turnFetchLog  // per-turn provenance ledger; reset on each ChatFromPlatform call
 	affinity          *AffinityStore // task-type plan-affinity learner
 	pendingClstr      TaskCluster    // cluster while a plan is awaiting approval
+	lastAutoRun       TaskCluster    // cluster of the most recent auto-executed (un-gated) turn, awaiting a post-turn THANKED/FIXED verdict from the user's next message
 	cachedEmojiStyle  string         // cached read of cfg.Brain.EmojiStyle; refreshed on /emoji
 	cachedOverlayDirs []string       // cached overlay directives; invalidated on /persona writes
 	cachedOverlayInit bool           // true once cachedOverlayDirs has been loaded at least once
@@ -217,6 +218,15 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 	// Fresh provenance ledger per turn — every reply is checked against URLs
 	// actually fetched during this single ChatFromPlatform invocation.
 	a.turnFetches = newTurnFetchLog()
+
+	// Closed-loop learning: if the previous turn auto-executed (no approval
+	// gate), this message is the user's implicit verdict on it. Silence /
+	// continuation / praise → THANKED (the plan was unneeded, drift toward
+	// just-act); a correction → FIXED (a plan would have helped, drift back
+	// toward planning). This restores symmetric affinity drift — before this,
+	// a cluster could graduate to auto-run but never fall back, so a cluster
+	// that started producing bad output stayed auto-run forever.
+	a.creditPostTurn(input)
 
 	if response, handled := a.handleProviderCommand(input); handled {
 		a.saveTurn("user", input)
@@ -570,6 +580,43 @@ func (a *KrillAgent) creditOutcome(ctx context.Context, cluster TaskCluster, out
 	return flipped
 }
 
+// creditPostTurn observes the user's first message after an auto-executed
+// (un-gated) turn and credits the cluster THANKED or FIXED. It is the missing
+// half of the affinity loop: the approval path already credits APPROVED /
+// MODIFIED / REJECTED, but an auto-run produces no explicit verdict, so
+// without this a calibrated cluster's score could only ever rise — a cluster
+// that started producing bad output would stay auto-run forever.
+//
+// Must be called at the very top of ChatFromPlatform, before history gets the
+// new user message appended, so lastAssistantBefore resolves to the auto-run
+// response rather than one we are about to generate. The credit runs in a
+// goroutine (like recordFeedback) so it never blocks the response.
+func (a *KrillAgent) creditPostTurn(input string) {
+	cluster := a.lastAutoRun
+	if cluster.ID == "" {
+		return
+	}
+	a.lastAutoRun = TaskCluster{} // consume — exactly one verdict per auto-run
+	prev := lastAssistantBefore(a.history, len(a.history)-1)
+	outcome := postTurnOutcome(input, prev)
+	log.Debug("post-turn affinity signal", "cluster", cluster.String(), "outcome", outcome)
+	go a.creditOutcome(context.Background(), cluster, outcome)
+}
+
+// postTurnOutcome classifies the user's first message after an auto-run.
+// Pure function so the classification is unit-testable without the async
+// credit path: a correction against the auto-run's response → FIXED
+// (planning would have helped), anything else — praise, a follow-up, a new
+// topic, even a slash command — → THANKED (no complaint = plan was unneeded).
+// THANKED is a weak nudge (-0.10*score); a real correction (+0.15) pulls back
+// harder, which is the safe asymmetry.
+func postTurnOutcome(input, prevAssistant string) AffinityOutcome {
+	if looksLikeCorrection(strings.ToLower(input), prevAssistant) {
+		return OutcomeFixed
+	}
+	return OutcomeThanked
+}
+
 // appendAffinityNarration formats the one-line transition note. Caller decides
 // whether to invoke (based on the bool returned by creditOutcome). Issue #30:
 // autonomy without narrated learning is a black box.
@@ -682,6 +729,7 @@ func (a *KrillAgent) handleTask(ctx context.Context, input string) (string, erro
 	if a.affinity != nil && (a.cfg.AutonomyFloor == "act" || a.cfg.AutonomyFloor == "evolve") {
 		if decision, _ := a.affinity.Decide(ctx, cluster); decision == DecisionJustAct {
 			log.Info("affinity says skip plan, answering directly", "cluster", cluster.String())
+			a.lastAutoRun = cluster // un-gated → next message is the verdict
 			return a.handleAnswer(ctx)
 		}
 	}
@@ -720,6 +768,7 @@ func (a *KrillAgent) handleTask(ctx context.Context, input string) (string, erro
 	}
 
 	log.Info("auto-executing plan", "task", input, "steps", len(plan.Steps), "cluster", cluster.String())
+	a.lastAutoRun = cluster // un-gated execution → the user's next message credits THANKED/FIXED
 
 	// On timeout-sensitive platforms, run in background if task has multiple steps
 	if a.shouldRunInBackground(plan) {
@@ -1471,7 +1520,16 @@ func memoryKey(s string) string {
 // not a greeting), the message must be ≤8 words, and it must not contain a
 // forward verb that signals a fresh request.
 func looksLikeCorrection(lower, prevAssistant string) bool {
-	corrections := []string{"no", "nah", "nope", "not what i", "that's not right", "don't"}
+	// Normalise the iOS/Android curly apostrophe so "doesn’t" matches the
+	// straight-quote contraction list below (containsWord treats ' as a word
+	// char, so the apostrophe form must be canonical first).
+	lower = strings.ReplaceAll(lower, "’", "'")
+	// #16: the negative side was asymmetric — it caught "don't" but not the
+	// other contracted negatives, so genuine corrections like "that doesn't
+	// work" / "no it didn't" were under-counted and never credited FIXED.
+	corrections := []string{"no", "nah", "nope", "not what i", "that's not right",
+		"don't", "doesn't", "didn't", "isn't", "aren't", "wasn't", "weren't",
+		"hasn't", "haven't", "won't", "wouldn't", "shouldn't", "can't", "couldn't"}
 	hit := false
 	for _, c := range corrections {
 		if containsWord(lower, c) {

--- a/internal/agent/closedloop_test.go
+++ b/internal/agent/closedloop_test.go
@@ -1,0 +1,81 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// validPrev is a realistic prior assistant turn: long enough and not a
+// greeting, so looksLikeCorrection's guards don't short-circuit.
+const validPrev = "Here is the summary you asked for about the project status today."
+
+// #16: the negative correction trigger was asymmetric — it caught "don't"
+// but not the other contracted negatives, so genuine corrections went
+// uncredited. These must now all register as corrections.
+func TestLooksLikeCorrection_ContractionAsymmetry(t *testing.T) {
+	corrections := []string{
+		"that doesn't work",
+		"no it didn't",
+		"that isn't right",
+		"this wasn't what i meant",
+		"that won't help",
+		"that shouldn't happen",
+		"that can't be right",
+		"nope that doesn’t work", // curly apostrophe (iOS/Android)
+		"don't",                  // original behaviour preserved
+	}
+	for _, c := range corrections {
+		if !looksLikeCorrection(c, validPrev) {
+			t.Errorf("looksLikeCorrection(%q) = false, want true", c)
+		}
+	}
+
+	// Redirection, not correction: a forward verb after the negative means
+	// "do X instead", which must NOT be counted as a correction.
+	redirections := []string{
+		"no just find me the digest",
+		"nope, show me the other one",
+	}
+	for _, r := range redirections {
+		if looksLikeCorrection(r, validPrev) {
+			t.Errorf("looksLikeCorrection(%q) = true, want false (redirection)", r)
+		}
+	}
+
+	// Guard intact: too-short prior assistant turn is never a correction.
+	if looksLikeCorrection("that doesn't work", "ok") {
+		t.Error("correction against a <30-char prior turn should be false")
+	}
+}
+
+func TestPostTurnOutcome(t *testing.T) {
+	if got := postTurnOutcome("thanks, that's perfect", validPrev); got != OutcomeThanked {
+		t.Errorf("praise → %v, want THANKED", got)
+	}
+	if got := postTurnOutcome("can you also add a test?", validPrev); got != OutcomeThanked {
+		t.Errorf("neutral follow-up → %v, want THANKED", got)
+	}
+	if got := postTurnOutcome("no that doesn't work", validPrev); got != OutcomeFixed {
+		t.Errorf("correction → %v, want FIXED", got)
+	}
+}
+
+// creditPostTurn must consume lastAutoRun exactly once: the next message is
+// the verdict, and a later message must not re-credit a stale cluster.
+func TestCreditPostTurn_ConsumesLastAutoRun(t *testing.T) {
+	a := newTestAgent("CHAT")
+	a.lastAutoRun = TaskCluster{ID: "abc123", Verb: "summarize", ObjectClass: "url"}
+	a.history = []core.Message{{Role: "assistant", Content: validPrev}}
+
+	a.creditPostTurn("thanks!")
+	if a.lastAutoRun.ID != "" {
+		t.Fatalf("lastAutoRun should be consumed, still %q", a.lastAutoRun.ID)
+	}
+
+	// No auto-run pending → must be a no-op (no panic, nothing to credit).
+	a.creditPostTurn("and another thing")
+	if a.lastAutoRun.ID != "" {
+		t.Fatalf("creditPostTurn with no pending auto-run must stay empty")
+	}
+}

--- a/internal/brain/memory.go
+++ b/internal/brain/memory.go
@@ -60,6 +60,13 @@ func (m *FileMemory) Store(_ context.Context, entry core.MemoryEntry) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Reserved-namespace guard: only the affinity store may write under the
+	// affinity:cluster: prefix. A user typing `/remember affinity:cluster:abc
+	// = junk` would otherwise overwrite a learned plan-affinity record.
+	if strings.HasPrefix(entry.Key, core.ReservedAffinityPrefix) && entry.Source != core.AffinitySource {
+		return fmt.Errorf("%w: %q", core.ErrReservedKey, entry.Key)
+	}
+
 	// Set timestamps if not already set
 	now := time.Now().UTC()
 	if entry.CreatedAt.IsZero() {

--- a/internal/brain/memory_reserved_test.go
+++ b/internal/brain/memory_reserved_test.go
@@ -1,0 +1,59 @@
+package brain
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// The affinity:cluster: namespace is reserved. Only writes stamped with
+// Source == core.AffinitySource (the affinity store itself) may land there;
+// any other writer — most importantly a user typing
+// `/remember affinity:cluster:abc = junk` — must be refused so a learned
+// plan-affinity record can't be corrupted.
+func TestStore_ReservedAffinityPrefix(t *testing.T) {
+	dir := t.TempDir()
+	mem, err := NewFileMemory(dir, 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory: %v", err)
+	}
+	ctx := context.Background()
+	key := core.ReservedAffinityPrefix + "deadbeef"
+
+	// 1. Non-affinity writer is refused with the sentinel.
+	err = mem.Store(ctx, core.MemoryEntry{
+		Key:    key,
+		Value:  "junk",
+		Source: "user-explicit",
+	})
+	if !errors.Is(err, core.ErrReservedKey) {
+		t.Fatalf("user write to reserved key: got err=%v, want ErrReservedKey", err)
+	}
+	if got, _ := mem.Recall(ctx, key); got != nil {
+		t.Fatalf("refused write must not persist; found %+v", got)
+	}
+
+	// 2. The affinity store's own writes are exempt.
+	if err := mem.Store(ctx, core.MemoryEntry{
+		Key:    key,
+		Value:  `{"plan_score":0.8}`,
+		Source: core.AffinitySource,
+	}); err != nil {
+		t.Fatalf("affinity-store write to reserved key should succeed, got %v", err)
+	}
+	got, err := mem.Recall(ctx, key)
+	if err != nil || got == nil || got.Value != `{"plan_score":0.8}` {
+		t.Fatalf("affinity write should persist; got=%+v err=%v", got, err)
+	}
+
+	// 3. A normal key with an arbitrary source is unaffected.
+	if err := mem.Store(ctx, core.MemoryEntry{
+		Key:    "pref:style_terse",
+		Value:  "true",
+		Source: "user-explicit",
+	}); err != nil {
+		t.Fatalf("normal key write should succeed, got %v", err)
+	}
+}

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -5,11 +5,27 @@ package core
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
 // Version is set at build time via -ldflags
 var Version = "0.1.2"
+
+// ReservedAffinityPrefix namespaces per-task-type plan-affinity records in the
+// memory store. Only the affinity store itself (Source == AffinitySource) may
+// write keys under this prefix; any other writer is refused with
+// ErrReservedKey so a stray `/remember affinity:cluster:... = junk` cannot
+// corrupt a learned record.
+const ReservedAffinityPrefix = "affinity:cluster:"
+
+// AffinitySource is the MemoryEntry.Source the affinity store stamps on its
+// own writes. It is the sole exemption from the ReservedAffinityPrefix guard.
+const AffinitySource = "affinity-store"
+
+// ErrReservedKey is returned by Memory.Store when a caller other than the
+// owning subsystem tries to write into a reserved key namespace.
+var ErrReservedKey = errors.New("memory: key uses a reserved namespace")
 
 // ---------------------------------------------------------------------------
 // LLM types


### PR DESCRIPTION
First PR of the v0.1.3 cycle (per ~/.claude/plans/mini-krill-v012-cycle.md). Scoped to the **closed-loop learning core** — the load-bearing deferred item from the PR #33 review.

## Why

The affinity learner was one-directional. The approval path credits APPROVED/MODIFIED/REJECTED, but an **auto-run produces no verdict**, so once a cluster crossed `minSamples` its score could only ever rise. A cluster that started producing bad output would stay auto-run forever — no path back to "plan first".

## What

1. **Post-turn THANKED/FIXED callback.** New `KrillAgent.lastAutoRun` records the cluster whenever a turn executes un-gated (auto-exec, affinity JustAct skip, background submit). The user's *next* message is the implicit verdict, classified at the top of `ChatFromPlatform`:
   - correction against the auto-run's response → **FIXED** (planning would have helped, `+0.15`)
   - anything else — praise, follow-up, new topic, slash command → **THANKED** (no complaint = plan unneeded, `-0.10`)

   Asymmetric on purpose: a real correction pulls back harder than a neutral follow-up nudges down. Restores symmetric affinity drift.

2. **#16 correction-trigger asymmetry.** `looksLikeCorrection` caught `"don't"` but not `doesn't`/`didn't`/`isn't`/`wasn't`/`won't`/`can't`/… so genuine corrections were under-counted and never credited FIXED. Extended the contraction list (word-bounded via existing `containsWord`) and added curly-apostrophe (’) normalisation for phone keyboards. The redirection guard (forward-verb → not a correction) is unchanged.

3. **AffinityKeyPrefix reservation guard.** `FileMemory.Store` now refuses writes under `affinity:cluster:` unless `Source == core.AffinitySource`, so `/remember affinity:cluster:... = junk` can't corrupt a learned record. Introduces shared `core.ReservedAffinityPrefix` / `core.AffinitySource` / `core.ErrReservedKey` so the writer and the guard can't drift apart.

## Scope note

Episodic memory (#29/D6) and user-state (#37) — the other two PR A items in the plan — are split into a focused follow-up PR to keep this one reviewable; these three are tightly cohesive (they all close the affinity loop) and self-contained.

## Test

New: contraction asymmetry + redirection guard, post-turn outcome classification, `lastAutoRun` single-consume, reservation guard (refuse / exempt / unaffected). `go build ./...`, `go vet ./...`, `go test ./...` all green.