### PR TITLE
Episodic memory + user-state (#29/D6, #37)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -62,6 +62,7 @@ type KrillAgent struct {
 	affinity          *AffinityStore // task-type plan-affinity learner
 	pendingClstr      TaskCluster    // cluster while a plan is awaiting approval
 	lastAutoRun       TaskCluster    // cluster of the most recent auto-executed (un-gated) turn, awaiting a post-turn THANKED/FIXED verdict from the user's next message
+	lastTurnAt        time.Time      // wall-clock of the previous turn; a large gap marks a session boundary for episodic consolidation
 	cachedEmojiStyle  string         // cached read of cfg.Brain.EmojiStyle; refreshed on /emoji
 	cachedOverlayDirs []string       // cached overlay directives; invalidated on /persona writes
 	cachedOverlayInit bool           // true once cachedOverlayDirs has been loaded at least once
@@ -227,6 +228,27 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 	// a cluster could graduate to auto-run but never fall back, so a cluster
 	// that started producing bad output stayed auto-run forever.
 	a.creditPostTurn(input)
+
+	// Session-boundary episodic consolidation (#29 / D6): a long gap since the
+	// previous turn means the prior session ended. Summarise it asynchronously
+	// now so the *next* greeting can reference it. The consolidator dedupes
+	// and no-ops on thin sessions, so an over-eager trigger is harmless.
+	now := time.Now()
+	if !a.lastTurnAt.IsZero() && now.Sub(a.lastTurnAt) > sessionGap {
+		if eb, ok := a.brain.(episodicBrain); ok {
+			ch := a.channel
+			go func() { _ = eb.ConsolidateEpisode(context.Background(), ch) }()
+		}
+	}
+	a.lastTurnAt = now
+
+	// Model the user as a stateful agent (#37): refresh focus / mood /
+	// last-seen from this message. Async — the file write never blocks the
+	// reply, and a slightly stale read next turn is acceptable for context.
+	if mem := a.brain.Memory(); mem != nil {
+		in := input
+		go updateUserState(context.Background(), mem, in)
+	}
 
 	if response, handled := a.handleProviderCommand(input); handled {
 		a.saveTurn("user", input)
@@ -578,6 +600,19 @@ func (a *KrillAgent) creditOutcome(ctx context.Context, cluster TaskCluster, out
 		return false
 	}
 	return flipped
+}
+
+// sessionGap is how long without a turn marks the previous session as ended,
+// triggering an episodic summary of it.
+const sessionGap = 30 * time.Minute
+
+// episodicBrain is the optional capability the agent uses for cross-session
+// memory (#29 / D6). It's a local interface satisfied by *brain.KrillBrain
+// via a type assertion, so the agent keeps depending only on core — never on
+// the brain package — and test mock brains transparently no-op.
+type episodicBrain interface {
+	ConsolidateEpisode(ctx context.Context, channel string) error
+	LatestEpisode(ctx context.Context, maxAge time.Duration) (string, error)
 }
 
 // creditPostTurn observes the user's first message after an auto-executed
@@ -982,6 +1017,22 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 		enriched = insertBeforeLast(enriched, memoryMsg)
 	}
 
+	// Cross-session continuity (#29 / D6): surface the most recent episode if
+	// it's fresh enough to still be relevant. Capped at 7 days so the agent
+	// references "last session" but never a stale month-old summary.
+	if eb, ok := a.brain.(episodicBrain); ok {
+		if ep, _ := eb.LatestEpisode(ctx, 7*24*time.Hour); ep != "" {
+			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: ep})
+		}
+	}
+
+	// User-as-agent state (#37): focus / mood / recency, read-only context.
+	if mem := a.brain.Memory(); mem != nil {
+		if line := loadUserState(ctx, mem).contextLine(); line != "" {
+			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: line})
+		}
+	}
+
 	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
 		styleMsg := core.Message{Role: "system", Content: styleDirective}
 		enriched = insertBeforeLast(enriched, styleMsg)
@@ -1321,6 +1372,22 @@ func (a *KrillAgent) handleAnswer(ctx context.Context) (string, error) {
 			Content: "Known user preferences:\n\n" + memoryCtx,
 		}
 		enriched = insertBeforeLast(enriched, memoryMsg)
+	}
+
+	// Cross-session continuity (#29 / D6): surface the most recent episode if
+	// it's fresh enough to still be relevant. Capped at 7 days so the agent
+	// references "last session" but never a stale month-old summary.
+	if eb, ok := a.brain.(episodicBrain); ok {
+		if ep, _ := eb.LatestEpisode(ctx, 7*24*time.Hour); ep != "" {
+			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: ep})
+		}
+	}
+
+	// User-as-agent state (#37): focus / mood / recency, read-only context.
+	if mem := a.brain.Memory(); mem != nil {
+		if line := loadUserState(ctx, mem).contextLine(); line != "" {
+			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: line})
+		}
 	}
 
 	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -62,7 +62,6 @@ type KrillAgent struct {
 	affinity          *AffinityStore // task-type plan-affinity learner
 	pendingClstr      TaskCluster    // cluster while a plan is awaiting approval
 	lastAutoRun       TaskCluster    // cluster of the most recent auto-executed (un-gated) turn, awaiting a post-turn THANKED/FIXED verdict from the user's next message
-	lastTurnAt        time.Time      // wall-clock of the previous turn; a large gap marks a session boundary for episodic consolidation
 	cachedEmojiStyle  string         // cached read of cfg.Brain.EmojiStyle; refreshed on /emoji
 	cachedOverlayDirs []string       // cached overlay directives; invalidated on /persona writes
 	cachedOverlayInit bool           // true once cachedOverlayDirs has been loaded at least once
@@ -230,17 +229,19 @@ func (a *KrillAgent) ChatFromPlatform(ctx context.Context, platform, chatID, inp
 	a.creditPostTurn(input)
 
 	// Session-boundary episodic consolidation (#29 / D6): a long gap since the
-	// previous turn means the prior session ended. Summarise it asynchronously
-	// now so the *next* greeting can reference it. The consolidator dedupes
-	// and no-ops on thin sessions, so an over-eager trigger is harmless.
-	now := time.Now()
-	if !a.lastTurnAt.IsZero() && now.Sub(a.lastTurnAt) > sessionGap {
-		if eb, ok := a.brain.(episodicBrain); ok {
+	// prior turn means the previous session ended. The gap is measured against
+	// the *persisted* last turn, not an in-memory field, so a session that
+	// ended by the process exiting still consolidates when a later process
+	// resumes — the headline cross-session case. The consolidator dedupes and
+	// no-ops on thin sessions, so an over-eager trigger is harmless.
+	if eb, ok := a.brain.(episodicBrain); ok {
+		if store := a.brain.ConversationStore(); store != nil {
 			ch := a.channel
-			go func() { _ = eb.ConsolidateEpisode(context.Background(), ch) }()
+			if last, err := store.LastActivity(ch); err == nil && !last.IsZero() && time.Since(last) > sessionGap {
+				go func() { _ = eb.ConsolidateEpisode(context.Background(), ch) }()
+			}
 		}
 	}
-	a.lastTurnAt = now
 
 	// Model the user as a stateful agent (#37): refresh focus / mood /
 	// last-seen from this message. Async — the file write never blocks the
@@ -613,6 +614,26 @@ const sessionGap = 30 * time.Minute
 type episodicBrain interface {
 	ConsolidateEpisode(ctx context.Context, channel string) error
 	LatestEpisode(ctx context.Context, maxAge time.Duration) (string, error)
+}
+
+// injectSessionContext appends the cross-session episode (#29 / D6) and the
+// user-as-agent state line (#37) as read-only, point-in-time system messages.
+// Shared by handleChat and handleAnswer so the two context assemblies cannot
+// drift — the duplicated-context-assembly risk #35 fixed elsewhere. The
+// episode is capped at 7 days so the agent references "last session" but
+// never a stale month-old summary.
+func (a *KrillAgent) injectSessionContext(ctx context.Context, enriched []core.Message) []core.Message {
+	if eb, ok := a.brain.(episodicBrain); ok {
+		if ep, _ := eb.LatestEpisode(ctx, 7*24*time.Hour); ep != "" {
+			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: ep})
+		}
+	}
+	if mem := a.brain.Memory(); mem != nil {
+		if line := loadUserState(ctx, mem).contextLine(); line != "" {
+			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: line})
+		}
+	}
+	return enriched
 }
 
 // creditPostTurn observes the user's first message after an auto-executed
@@ -1017,21 +1038,7 @@ func (a *KrillAgent) handleChat(ctx context.Context) (string, error) {
 		enriched = insertBeforeLast(enriched, memoryMsg)
 	}
 
-	// Cross-session continuity (#29 / D6): surface the most recent episode if
-	// it's fresh enough to still be relevant. Capped at 7 days so the agent
-	// references "last session" but never a stale month-old summary.
-	if eb, ok := a.brain.(episodicBrain); ok {
-		if ep, _ := eb.LatestEpisode(ctx, 7*24*time.Hour); ep != "" {
-			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: ep})
-		}
-	}
-
-	// User-as-agent state (#37): focus / mood / recency, read-only context.
-	if mem := a.brain.Memory(); mem != nil {
-		if line := loadUserState(ctx, mem).contextLine(); line != "" {
-			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: line})
-		}
-	}
+	enriched = a.injectSessionContext(ctx, enriched)
 
 	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
 		styleMsg := core.Message{Role: "system", Content: styleDirective}
@@ -1374,21 +1381,7 @@ func (a *KrillAgent) handleAnswer(ctx context.Context) (string, error) {
 		enriched = insertBeforeLast(enriched, memoryMsg)
 	}
 
-	// Cross-session continuity (#29 / D6): surface the most recent episode if
-	// it's fresh enough to still be relevant. Capped at 7 days so the agent
-	// references "last session" but never a stale month-old summary.
-	if eb, ok := a.brain.(episodicBrain); ok {
-		if ep, _ := eb.LatestEpisode(ctx, 7*24*time.Hour); ep != "" {
-			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: ep})
-		}
-	}
-
-	// User-as-agent state (#37): focus / mood / recency, read-only context.
-	if mem := a.brain.Memory(); mem != nil {
-		if line := loadUserState(ctx, mem).contextLine(); line != "" {
-			enriched = insertBeforeLast(enriched, core.Message{Role: "system", Content: line})
-		}
-	}
+	enriched = a.injectSessionContext(ctx, enriched)
 
 	if styleDirective := buildStyleDirective(ctx, a.brain.Memory()); styleDirective != "" {
 		styleMsg := core.Message{Role: "system", Content: styleDirective}

--- a/internal/agent/userstate.go
+++ b/internal/agent/userstate.go
@@ -1,0 +1,126 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// userState models the user as a stateful agent rather than a stateless
+// prompt source (#37): what they're working on, what they last asked, the
+// mood they last expressed, and when they were last seen. It is injected
+// read-only into chat context so replies land in the right register — e.g.
+// not opening a 7-step plan when a "you there?" arrives at 1am.
+//
+// Like episodic memory and long-term memory, this is point-in-time, not live
+// truth: it is stamped with LastSeen and surfaced with that caveat so a stale
+// focus area can't masquerade as current reality.
+type userState struct {
+	FocusArea   string    `json:"focus_area"`   // coarse area of work, from the task cluster's object class
+	LastCluster string    `json:"last_cluster"` // verb/object of the last task-shaped request
+	LastMood    string    `json:"last_mood"`    // positive | negative | neutral, from light sentiment on the last message
+	LastSeen    time.Time `json:"last_seen"`
+}
+
+// userStateKey is a normal (non-reserved) memory key; sanitizeKey maps ':' to
+// '_' on disk, and Recall round-trips through the same sanitiser.
+const userStateKey = "userstate:current"
+
+func loadUserState(ctx context.Context, mem core.Memory) userState {
+	var us userState
+	if mem == nil {
+		return us
+	}
+	e, err := mem.Recall(ctx, userStateKey)
+	if err != nil || e == nil || e.Value == "" {
+		return us
+	}
+	if err := json.Unmarshal([]byte(e.Value), &us); err != nil {
+		log.Debug("userstate: corrupt record, resetting", "error", err)
+		return userState{}
+	}
+	return us
+}
+
+func saveUserState(ctx context.Context, mem core.Memory, us userState) {
+	if mem == nil {
+		return
+	}
+	data, err := json.Marshal(us)
+	if err != nil {
+		return
+	}
+	now := time.Now()
+	if err := mem.Store(ctx, core.MemoryEntry{
+		Key:        userStateKey,
+		Value:      string(data),
+		Tags:       []string{"userstate", "system"},
+		Scope:      "system",
+		Source:     "reflection",
+		CreatedAt:  now,
+		AccessedAt: now,
+	}); err != nil {
+		log.Debug("userstate: store failed", "error", err)
+	}
+}
+
+// lightMood is a deliberately cheap sentiment read — no LLM call on every
+// turn. Mirrors the positive/negative keyword sets recordFeedback uses; any
+// ambiguity falls through to neutral.
+func lightMood(input string) string {
+	lower := strings.ToLower(input)
+	for _, p := range []string{"thanks", "thank you", "great", "perfect", "awesome", "love it", "nice", "good job", "brilliant"} {
+		if containsWord(lower, p) {
+			return "positive"
+		}
+	}
+	for _, n := range []string{"wrong", "terrible", "useless", "bad", "broken", "annoying", "frustrated", "stupid"} {
+		if containsWord(lower, n) {
+			return "negative"
+		}
+	}
+	return "neutral"
+}
+
+// updateUserState refreshes and persists the record from the current message.
+// Called once per turn; runs synchronously off the hot path only for the
+// in-memory update — persistence is the caller's choice (we go via a
+// goroutine in ChatFromPlatform so the file write never blocks the reply).
+func updateUserState(ctx context.Context, mem core.Memory, input string) {
+	us := loadUserState(ctx, mem)
+	c := ClusterFor(input)
+	if c.ID != "" {
+		us.LastCluster = c.String()
+		if c.ObjectClass != "" {
+			us.FocusArea = c.ObjectClass
+		}
+	}
+	us.LastMood = lightMood(input)
+	us.LastSeen = time.Now()
+	saveUserState(ctx, mem, us)
+}
+
+// contextLine renders the state as one inject-ready, explicitly point-in-time
+// system line, or "" when there's nothing useful yet.
+func (us userState) contextLine() string {
+	if us.LastSeen.IsZero() {
+		return ""
+	}
+	parts := []string{}
+	if us.FocusArea != "" {
+		parts = append(parts, "focus="+us.FocusArea)
+	}
+	if us.LastCluster != "" {
+		parts = append(parts, "last task="+us.LastCluster)
+	}
+	if us.LastMood != "" {
+		parts = append(parts, "mood="+us.LastMood)
+	}
+	parts = append(parts, fmt.Sprintf("last seen ~%s ago", time.Since(us.LastSeen).Round(time.Minute)))
+	return "User context (read-only, point-in-time — do not state it back unless relevant): " + strings.Join(parts, ", ") + "."
+}

--- a/internal/agent/userstate.go
+++ b/internal/agent/userstate.go
@@ -92,6 +92,11 @@ func lightMood(input string) string {
 // in-memory update — persistence is the caller's choice (we go via a
 // goroutine in ChatFromPlatform so the file write never blocks the reply).
 func updateUserState(ctx context.Context, mem core.Memory, input string) {
+	// Load-modify-save across two independently-locked FileMemory ops from an
+	// async goroutine: two near-simultaneous turns can lose an update. This is
+	// a deliberate, accepted trade-off — the record is read-only context, not
+	// behavioural state, so a momentarily stale focus/mood is harmless and not
+	// worth a cross-store transaction.
 	us := loadUserState(ctx, mem)
 	c := ClusterFor(input)
 	if c.ID != "" {

--- a/internal/agent/userstate_test.go
+++ b/internal/agent/userstate_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestLightMood(t *testing.T) {
+	cases := map[string]string{
+		"thanks, that's perfect":     "positive",
+		"this is broken and useless": "negative",
+		"run the parser on main.go":  "neutral",
+		"":                           "neutral",
+	}
+	for in, want := range cases {
+		if got := lightMood(in); got != want {
+			t.Errorf("lightMood(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestUserState_RoundTripAndContextLine(t *testing.T) {
+	mem := newFakeMemory()
+	ctx := context.Background()
+
+	// Nothing stored yet → empty context line.
+	if line := loadUserState(ctx, mem).contextLine(); line != "" {
+		t.Fatalf("fresh user state should yield no context line, got %q", line)
+	}
+
+	updateUserState(ctx, mem, "thanks! now summarize https://example.com/post")
+
+	us := loadUserState(ctx, mem)
+	if us.LastMood != "positive" {
+		t.Errorf("mood = %q, want positive", us.LastMood)
+	}
+	if us.LastCluster == "" || us.FocusArea == "" {
+		t.Errorf("cluster/focus should be populated, got cluster=%q focus=%q", us.LastCluster, us.FocusArea)
+	}
+	if us.LastSeen.IsZero() {
+		t.Error("LastSeen must be set")
+	}
+
+	line := loadUserState(ctx, mem).contextLine()
+	if !strings.Contains(line, "read-only") || !strings.Contains(line, "mood=positive") {
+		t.Fatalf("context line should be point-in-time framed and carry mood, got %q", line)
+	}
+}
+
+// updateUserState must tolerate a nil memory (headless / test paths).
+func TestUserState_NilMemorySafe(t *testing.T) {
+	updateUserState(context.Background(), nil, "anything")
+	if line := loadUserState(context.Background(), nil).contextLine(); line != "" {
+		t.Fatalf("nil memory must yield empty context line, got %q", line)
+	}
+}

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -1,10 +1,12 @@
 package brain
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
@@ -19,6 +21,7 @@ type KrillBrain struct {
 	soul        *core.Soul
 	personality *core.Personality
 	heartbeat   *KrillHeartbeat
+	llm         core.LLMProvider
 	cfg         config.BrainConfig
 }
 
@@ -63,6 +66,7 @@ func New(cfg config.BrainConfig, llm core.LLMProvider) (*KrillBrain, error) {
 		soul:        soul,
 		personality: personality,
 		heartbeat:   hb,
+		llm:         llm,
 		cfg:         cfg,
 	}
 
@@ -104,6 +108,25 @@ func (b *KrillBrain) GetPersonality() *core.Personality {
 // GetSoul returns the krill's soul configuration.
 func (b *KrillBrain) GetSoul() *core.Soul {
 	return b.soul
+}
+
+// episodic builds a consolidator over this brain's stores. Cheap to construct
+// per call (just wires three pointers) so there's no lifecycle to manage.
+func (b *KrillBrain) episodic() *Episodic {
+	return NewEpisodic(b.memory, b.ConversationStore(), b.llm)
+}
+
+// ConsolidateEpisode summarises the recent session on `channel` into a stored
+// episode. Satisfies the agent's optional episodicBrain interface (#29 / D6).
+func (b *KrillBrain) ConsolidateEpisode(ctx context.Context, channel string) error {
+	_, err := b.episodic().Consolidate(ctx, channel)
+	return err
+}
+
+// LatestEpisode returns the most recent episode younger than maxAge as an
+// inject-ready, point-in-time context line, or "" when none qualifies.
+func (b *KrillBrain) LatestEpisode(ctx context.Context, maxAge time.Duration) (string, error) {
+	return b.episodic().Latest(ctx, maxAge)
 }
 
 // SystemPrompt returns the soul's system prompt string.

--- a/internal/brain/conversations.go
+++ b/internal/brain/conversations.go
@@ -127,6 +127,44 @@ func (s *ConversationStore) LoadRecent(channel string, n int) ([]core.Message, e
 	return recent, nil
 }
 
+// LastActivity returns the timestamp of the most recent turn on channel, or
+// the zero time if the channel has no turns. Single pass, no message-slice
+// allocation; this is what lets episodic consolidation measure the
+// session-boundary gap across process restarts.
+func (s *ConversationStore) LastActivity(channel string) (time.Time, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	f, err := os.Open(s.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return time.Time{}, nil
+		}
+		return time.Time{}, fmt.Errorf("open conversations store: %w", err)
+	}
+	defer f.Close()
+
+	var last time.Time
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		var turn conversationTurn
+		if err := json.Unmarshal(scanner.Bytes(), &turn); err != nil {
+			continue
+		}
+		if turn.Channel != channel {
+			continue
+		}
+		if turn.Timestamp.After(last) {
+			last = turn.Timestamp
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return time.Time{}, fmt.Errorf("read conversations store: %w", err)
+	}
+	return last, nil
+}
+
 func (s *ConversationStore) Close() error { return nil }
 
 // Search returns turns matching a substring or time predicate. query is

--- a/internal/brain/conversations_test.go
+++ b/internal/brain/conversations_test.go
@@ -70,6 +70,32 @@ func TestLoadRecentEmpty(t *testing.T) {
 	}
 }
 
+func TestLastActivity(t *testing.T) {
+	store := newTestStore(t)
+
+	// Empty store / unknown channel → zero time, no error.
+	if ts, err := store.LastActivity("cli"); err != nil || !ts.IsZero() {
+		t.Fatalf("empty store: ts=%v err=%v, want zero/nil", ts, err)
+	}
+
+	before := time.Now()
+	_ = store.SaveTurn("cli", "user", "first")
+	_ = store.SaveTurn("tg", "user", "other channel")
+	_ = store.SaveTurn("cli", "assistant", "last on cli")
+	after := time.Now()
+
+	ts, err := store.LastActivity("cli")
+	if err != nil {
+		t.Fatalf("LastActivity: %v", err)
+	}
+	if ts.Before(before) || ts.After(after) {
+		t.Fatalf("LastActivity = %v, want within [%v,%v]", ts, before, after)
+	}
+	if ts2, _ := store.LastActivity("absent"); !ts2.IsZero() {
+		t.Fatalf("unknown channel must be zero time, got %v", ts2)
+	}
+}
+
 func TestChannelIsolation(t *testing.T) {
 	store := newTestStore(t)
 

--- a/internal/brain/episodic.go
+++ b/internal/brain/episodic.go
@@ -3,6 +3,7 @@ package brain
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -32,6 +33,18 @@ const (
 	// The agent only calls Consolidate after a >30min activity gap, so this is
 	// a belt-and-braces guard against a greeting burst minting duplicates.
 	episodeDedupeWindow = 25 * time.Minute
+	// episodeLatestKey is a single rolling pointer the consolidator overwrites
+	// with the newest episode. latestEntry reads it by exact key, so "most
+	// recent episode" never depends on Search iteration order.
+	// FileMemory.Search("episode_", N) returns the *oldest* N matches —
+	// os.ReadDir is lexical and episode keys are monotonic episode_<unixMilli>
+	// — so a Search+max scan silently picked the newest-of-the-oldest-N and
+	// cross-session continuity died (and dedupe broke) past N episodes.
+	episodeLatestKey = "episode:latest"
+	// maxEpisodeHistory bounds the episode_* namespace. FileMemory accepts a
+	// maxMem but never enforces it, so without an explicit prune the namespace
+	// grows without limit.
+	maxEpisodeHistory = 50
 )
 
 // NewEpisodic wires the consolidator. Any nil dependency disables it (every
@@ -102,8 +115,43 @@ func (e *Episodic) Consolidate(ctx context.Context, channel string) (*core.Memor
 	if err := e.mem.Store(ctx, entry); err != nil {
 		return nil, fmt.Errorf("episodic: store: %w", err)
 	}
+	// Overwrite the rolling pointer so latestEntry/dedupe stay correct no
+	// matter how many episodes accumulate.
+	ptr := entry
+	ptr.Key = episodeLatestKey
+	if err := e.mem.Store(ctx, ptr); err != nil {
+		return nil, fmt.Errorf("episodic: store latest pointer: %w", err)
+	}
+	e.pruneHistory(ctx)
 	log.Info("episodic: session summarised", "channel", channel, "turns", len(turns))
 	return &entry, nil
+}
+
+// pruneHistory keeps only the newest maxEpisodeHistory episode_* entries so
+// the namespace can't grow without limit. The episode:latest pointer is a
+// distinct key and is never pruned. Best-effort: a failed prune must not fail
+// consolidation.
+func (e *Episodic) pruneHistory(ctx context.Context) {
+	entries, err := e.mem.Search(ctx, "episode_", 0) // limit 0 = unbounded
+	if err != nil {
+		log.Debug("episodic: prune skipped", "error", err)
+		return
+	}
+	hist := entries[:0] // in-place filter; episode:latest has no episode_ prefix
+	for _, en := range entries {
+		if strings.HasPrefix(en.Key, "episode_") && hasTag(en.Tags, episodeTag) {
+			hist = append(hist, en)
+		}
+	}
+	if len(hist) <= maxEpisodeHistory {
+		return
+	}
+	sort.Slice(hist, func(i, j int) bool { return hist[i].CreatedAt.After(hist[j].CreatedAt) })
+	for _, en := range hist[maxEpisodeHistory:] {
+		if err := e.mem.Forget(ctx, en.Key); err != nil {
+			log.Debug("episodic: prune entry failed", "key", en.Key, "error", err)
+		}
+	}
 }
 
 // Latest returns the most recent episode younger than maxAge as a ready-to-
@@ -119,26 +167,34 @@ func (e *Episodic) Latest(ctx context.Context, maxAge time.Duration) (string, er
 	if maxAge > 0 && time.Since(latest.CreatedAt) > maxAge {
 		return "", nil
 	}
-	age := time.Since(latest.CreatedAt).Round(time.Hour)
-	return fmt.Sprintf("Latest episode (read-only, point-in-time from ~%s ago — verify before relying on it): %s", age, latest.Value), nil
+	return fmt.Sprintf("Latest episode (read-only, point-in-time from ~%s ago — verify before relying on it): %s", humanizeAge(time.Since(latest.CreatedAt)), latest.Value), nil
 }
 
-// latestEntry returns the newest episode-tagged MemoryEntry, or nil.
+// latestEntry returns the newest episode via the rolling pointer, or nil.
+// Deliberately an O(1) exact-key read, not a Search scan: FileMemory.Search
+// returns the *oldest* matches (see episodeLatestKey), so a scan would strand
+// continuity and break dedupe once episodes outnumber the scan limit.
 func (e *Episodic) latestEntry(ctx context.Context) (*core.MemoryEntry, error) {
-	entries, err := e.mem.Search(ctx, "episode_", 50)
-	if err != nil {
+	en, err := e.mem.Recall(ctx, episodeLatestKey)
+	if err != nil || en == nil {
 		return nil, err
 	}
-	var best *core.MemoryEntry
-	for i := range entries {
-		if !hasTag(entries[i].Tags, episodeTag) {
-			continue
-		}
-		if best == nil || entries[i].CreatedAt.After(best.CreatedAt) {
-			best = &entries[i]
-		}
+	return en, nil
+}
+
+// humanizeAge renders a coarse, human age ("40m", "3h", "2d"). Round(time.Hour)
+// printed "~0s ago" for any episode under 30 minutes old.
+func humanizeAge(d time.Duration) string {
+	switch {
+	case d < time.Minute:
+		return "moments"
+	case d < time.Hour:
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh", int(d.Hours()))
+	default:
+		return fmt.Sprintf("%dd", int(d.Hours()/24))
 	}
-	return best, nil
 }
 
 func hasTag(tags []string, want string) bool {

--- a/internal/brain/episodic.go
+++ b/internal/brain/episodic.go
@@ -1,0 +1,151 @@
+package brain
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+)
+
+// Episodic produces one-paragraph summaries of a finished session ("episodes")
+// and surfaces the most recent one on the next greeting, so the agent picks up
+// where it left off instead of starting cold. #29 / D6.
+//
+// An episode is an ordinary MemoryEntry tagged "episode"; it is a point-in-time
+// reflection, never live state — the same discipline long-term memory uses, so
+// a stale episode can't be mistaken for current reality.
+type Episodic struct {
+	mem   core.Memory
+	store core.ConversationStore
+	llm   core.LLMProvider
+}
+
+const (
+	episodeTag = "episode"
+	// minEpisodeTurns: below this a "session" is too thin to be worth a
+	// summary (a lone greeting that got no reply, etc).
+	minEpisodeTurns = 4
+	// episodeDedupeWindow: never produce a second episode within this window.
+	// The agent only calls Consolidate after a >30min activity gap, so this is
+	// a belt-and-braces guard against a greeting burst minting duplicates.
+	episodeDedupeWindow = 25 * time.Minute
+)
+
+// NewEpisodic wires the consolidator. Any nil dependency disables it (every
+// method becomes a safe no-op), which keeps tests and headless modes simple.
+func NewEpisodic(mem core.Memory, store core.ConversationStore, llm core.LLMProvider) *Episodic {
+	return &Episodic{mem: mem, store: store, llm: llm}
+}
+
+func (e *Episodic) enabled() bool {
+	return e != nil && e.mem != nil && e.store != nil && e.llm != nil
+}
+
+// Consolidate summarises the recent turns on `channel` into a single episode
+// MemoryEntry and stores it. It is a no-op (nil, nil) when disabled, when the
+// session is too thin, or when a fresh episode already exists inside the
+// dedupe window.
+func (e *Episodic) Consolidate(ctx context.Context, channel string) (*core.MemoryEntry, error) {
+	if !e.enabled() {
+		return nil, nil
+	}
+	if recent, _ := e.latestEntry(ctx); recent != nil && time.Since(recent.CreatedAt) < episodeDedupeWindow {
+		log.Debug("episodic: skipping, fresh episode within dedupe window")
+		return nil, nil
+	}
+
+	turns, err := e.store.LoadRecent(channel, 80)
+	if err != nil {
+		return nil, fmt.Errorf("episodic: load turns: %w", err)
+	}
+	if len(turns) < minEpisodeTurns {
+		return nil, nil
+	}
+
+	var b strings.Builder
+	for _, m := range turns {
+		who := "User"
+		if m.Role == "assistant" {
+			who = "Krill"
+		}
+		b.WriteString(who)
+		b.WriteString(": ")
+		b.WriteString(m.Content)
+		b.WriteString("\n")
+	}
+
+	resp, err := e.llm.Chat(ctx, []core.Message{
+		{Role: "system", Content: "Summarise this session in ONE short paragraph (3-4 sentences, plain text, no preamble or bullet points). State: what the user wanted, what was actually done, and what is still unresolved or pending. Be concrete; name specifics over generalities."},
+		{Role: "user", Content: b.String()},
+	}, core.WithTemperature(0.2), core.WithMaxTokens(280))
+	if err != nil {
+		return nil, fmt.Errorf("episodic: summarise: %w", err)
+	}
+	summary := strings.TrimSpace(resp.Content)
+	if summary == "" {
+		return nil, nil
+	}
+
+	now := time.Now()
+	entry := core.MemoryEntry{
+		Key:        fmt.Sprintf("episode_%d", now.UnixMilli()),
+		Value:      summary,
+		Tags:       []string{episodeTag, "system"},
+		Scope:      "system",
+		Source:     "reflection",
+		CreatedAt:  now,
+		AccessedAt: now,
+	}
+	if err := e.mem.Store(ctx, entry); err != nil {
+		return nil, fmt.Errorf("episodic: store: %w", err)
+	}
+	log.Info("episodic: session summarised", "channel", channel, "turns", len(turns))
+	return &entry, nil
+}
+
+// Latest returns the most recent episode younger than maxAge as a ready-to-
+// inject, clearly point-in-time context line, or "" when none qualifies.
+func (e *Episodic) Latest(ctx context.Context, maxAge time.Duration) (string, error) {
+	if !e.enabled() {
+		return "", nil
+	}
+	latest, err := e.latestEntry(ctx)
+	if err != nil || latest == nil {
+		return "", err
+	}
+	if maxAge > 0 && time.Since(latest.CreatedAt) > maxAge {
+		return "", nil
+	}
+	age := time.Since(latest.CreatedAt).Round(time.Hour)
+	return fmt.Sprintf("Latest episode (read-only, point-in-time from ~%s ago — verify before relying on it): %s", age, latest.Value), nil
+}
+
+// latestEntry returns the newest episode-tagged MemoryEntry, or nil.
+func (e *Episodic) latestEntry(ctx context.Context) (*core.MemoryEntry, error) {
+	entries, err := e.mem.Search(ctx, "episode_", 50)
+	if err != nil {
+		return nil, err
+	}
+	var best *core.MemoryEntry
+	for i := range entries {
+		if !hasTag(entries[i].Tags, episodeTag) {
+			continue
+		}
+		if best == nil || entries[i].CreatedAt.After(best.CreatedAt) {
+			best = &entries[i]
+		}
+	}
+	return best, nil
+}
+
+func hasTag(tags []string, want string) bool {
+	for _, t := range tags {
+		if t == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/brain/episodic_test.go
+++ b/internal/brain/episodic_test.go
@@ -1,0 +1,95 @@
+package brain
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+func newEpisodicFixture(t *testing.T) (*Episodic, *FileMemory, *ConversationStore) {
+	t.Helper()
+	mem, err := NewFileMemory(t.TempDir(), 100)
+	if err != nil {
+		t.Fatalf("NewFileMemory: %v", err)
+	}
+	store, err := NewConversationStore(filepath.Join(t.TempDir(), "conv.jsonl"))
+	if err != nil {
+		t.Fatalf("NewConversationStore: %v", err)
+	}
+	return NewEpisodic(mem, store, &mockLLM{}), mem, store
+}
+
+func TestEpisodic_ConsolidateAndLatest(t *testing.T) {
+	e, _, store := newEpisodicFixture(t)
+	ctx := context.Background()
+
+	// Thin session → no episode.
+	_ = store.SaveTurn("cli", "user", "hi")
+	if ep, err := e.Consolidate(ctx, "cli"); err != nil || ep != nil {
+		t.Fatalf("thin session should not consolidate, got ep=%v err=%v", ep, err)
+	}
+
+	// A real session → one episode.
+	for _, p := range [][2]string{
+		{"user", "help me ship the parser"},
+		{"assistant", "drafted a plan"},
+		{"user", "run it"},
+		{"assistant", "done, tests pass"},
+	} {
+		_ = store.SaveTurn("cli", p[0], p[1])
+	}
+	ep, err := e.Consolidate(ctx, "cli")
+	if err != nil || ep == nil {
+		t.Fatalf("real session should consolidate, got ep=%v err=%v", ep, err)
+	}
+	if !hasTag(ep.Tags, episodeTag) || ep.Value == "" {
+		t.Fatalf("episode must be tagged and non-empty: %+v", ep)
+	}
+
+	// Dedupe: a second call inside the window must no-op.
+	if ep2, err := e.Consolidate(ctx, "cli"); err != nil || ep2 != nil {
+		t.Fatalf("dedupe window should suppress second episode, got ep=%v err=%v", ep2, err)
+	}
+
+	// Latest within maxAge returns the summary, point-in-time framed.
+	line, err := e.Latest(ctx, 7*24*time.Hour)
+	if err != nil || line == "" {
+		t.Fatalf("Latest should return the fresh episode, got %q err=%v", line, err)
+	}
+
+	// Latest outside maxAge returns nothing.
+	if line, _ := e.Latest(ctx, time.Nanosecond); line != "" {
+		t.Fatalf("episode older than maxAge must be filtered, got %q", line)
+	}
+}
+
+func TestEpisodic_DisabledIsNoOp(t *testing.T) {
+	var e *Episodic // nil receiver
+	if ep, err := e.Consolidate(context.Background(), "cli"); ep != nil || err != nil {
+		t.Fatalf("nil Episodic must no-op, got ep=%v err=%v", ep, err)
+	}
+	e2 := NewEpisodic(nil, nil, nil)
+	if line, err := e2.Latest(context.Background(), time.Hour); line != "" || err != nil {
+		t.Fatalf("disabled Episodic.Latest must be empty, got %q err=%v", line, err)
+	}
+}
+
+func TestEpisodic_LatestPicksNewest(t *testing.T) {
+	e, mem, _ := newEpisodicFixture(t)
+	ctx := context.Background()
+	old := core.MemoryEntry{Key: "episode_1", Value: "old session", Tags: []string{episodeTag}, Source: "reflection", CreatedAt: time.Now().Add(-3 * time.Hour)}
+	recent := core.MemoryEntry{Key: "episode_2", Value: "recent session", Tags: []string{episodeTag}, Source: "reflection", CreatedAt: time.Now().Add(-1 * time.Hour)}
+	_ = mem.Store(ctx, old)
+	_ = mem.Store(ctx, recent)
+	line, err := e.Latest(ctx, 7*24*time.Hour)
+	if err != nil || line == "" {
+		t.Fatalf("Latest err=%v line=%q", err, line)
+	}
+	if !strings.Contains(line, "recent session") {
+		t.Fatalf("Latest should pick the newest episode, got %q", line)
+	}
+}

--- a/internal/brain/episodic_test.go
+++ b/internal/brain/episodic_test.go
@@ -2,6 +2,7 @@ package brain
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -78,18 +79,82 @@ func TestEpisodic_DisabledIsNoOp(t *testing.T) {
 	}
 }
 
-func TestEpisodic_LatestPicksNewest(t *testing.T) {
-	e, mem, _ := newEpisodicFixture(t)
+// TestEpisodic_LatestSurvivesManyEpisodes is the regression for the round-1
+// review: latestEntry used Search("episode_", 50), which returns the *oldest*
+// 50 (ReadDir is lexical, episode_<unixMilli> is monotonic), so once history
+// exceeded the scan limit Latest returned the newest-of-the-oldest-50 — stale
+// — and the dedupe guard broke with it. The rolling episode:latest pointer
+// makes "newest" an O(1) exact-key read, independent of history size, and
+// pruning bounds the namespace.
+func TestEpisodic_LatestSurvivesManyEpisodes(t *testing.T) {
+	e, mem, store := newEpisodicFixture(t)
 	ctx := context.Background()
-	old := core.MemoryEntry{Key: "episode_1", Value: "old session", Tags: []string{episodeTag}, Source: "reflection", CreatedAt: time.Now().Add(-3 * time.Hour)}
-	recent := core.MemoryEntry{Key: "episode_2", Value: "recent session", Tags: []string{episodeTag}, Source: "reflection", CreatedAt: time.Now().Add(-1 * time.Hour)}
-	_ = mem.Store(ctx, old)
-	_ = mem.Store(ctx, recent)
+
+	// Seed far more than the old scan limit, all old, lexically-ascending
+	// keys. The pre-fix code would only ever see these.
+	base := time.Now().Add(-30 * 24 * time.Hour)
+	for i := 0; i < 60; i++ {
+		_ = mem.Store(ctx, core.MemoryEntry{
+			Key:       fmt.Sprintf("episode_%013d", i),
+			Value:     "stale session",
+			Tags:      []string{episodeTag, "system"},
+			Source:    "reflection",
+			CreatedAt: base.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	// A real, current session consolidates a fresh episode.
+	for _, p := range [][2]string{
+		{"user", "wire up the new exporter"},
+		{"assistant", "drafted it"},
+		{"user", "ship it"},
+		{"assistant", "shipped, green"},
+	} {
+		_ = store.SaveTurn("cli", p[0], p[1])
+	}
+	ep, err := e.Consolidate(ctx, "cli")
+	if err != nil || ep == nil {
+		t.Fatalf("Consolidate err=%v ep=%v", err, ep)
+	}
+
+	// Latest must return the just-made episode, not one of the 60 stale ones.
 	line, err := e.Latest(ctx, 7*24*time.Hour)
 	if err != nil || line == "" {
 		t.Fatalf("Latest err=%v line=%q", err, line)
 	}
-	if !strings.Contains(line, "recent session") {
-		t.Fatalf("Latest should pick the newest episode, got %q", line)
+	if strings.Contains(line, "stale session") {
+		t.Fatalf("Latest returned a stale episode despite >50 in history: %q", line)
+	}
+	if !strings.Contains(line, ep.Value) {
+		t.Fatalf("Latest should surface the newest episode %q, got %q", ep.Value, line)
+	}
+
+	// The episode_* namespace must be bounded (pointer key is excluded).
+	hist, _ := mem.Search(ctx, "episode_", 0)
+	n := 0
+	for _, en := range hist {
+		if strings.HasPrefix(en.Key, "episode_") {
+			n++
+		}
+	}
+	if n > maxEpisodeHistory {
+		t.Fatalf("history not pruned: %d > %d", n, maxEpisodeHistory)
+	}
+}
+
+func TestHumanizeAge(t *testing.T) {
+	cases := []struct {
+		d    time.Duration
+		want string
+	}{
+		{30 * time.Second, "moments"},
+		{45 * time.Minute, "45m"},
+		{3 * time.Hour, "3h"},
+		{50 * time.Hour, "2d"},
+	}
+	for _, c := range cases {
+		if got := humanizeAge(c.d); got != c.want {
+			t.Errorf("humanizeAge(%s) = %q, want %q", c.d, got, c.want)
+		}
 	}
 }

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -147,6 +147,10 @@ type ConversationStore interface {
 	SaveTurn(channel, role, content string) error
 	LoadRecent(channel string, n int) ([]Message, error)
 	Search(channel, query string, since, until time.Time, limit int) ([]Message, error)
+	// LastActivity reports the timestamp of the most recent stored turn for
+	// channel (zero time if none). Persisted, so a session-boundary gap can
+	// be measured across process restarts rather than from in-memory state.
+	LastActivity(channel string) (time.Time, error)
 	Close() error
 }
 


### PR DESCRIPTION
Second PR of the v0.1.3 cycle. Follows #35 (now merged); rebased onto current `main`. Completes the remaining two PR A items from the plan, split out so #35 stayed reviewable.

## Episodic memory (#29 / D6) — `internal/brain/episodic.go`
On a **>30 min activity gap** the agent asynchronously summarises the prior session into one episode `MemoryEntry` (tag `episode`, `Source: reflection`). The most recent episode **<7 days old** is injected into chat/answer context as an explicitly **point-in-time, read-only** line, so the agent resumes context instead of starting cold — without mistaking a stale summary for live state (same discipline long-term memory uses).

- Dedupes (25 min window), no-ops on thin sessions (<4 turns), safe no-op when any dependency is nil.
- Wired through `*brain.KrillBrain` + a **local `episodicBrain` interface** in agent (type assertion), so the agent still depends only on `core` — never the `brain` package — and mock brains transparently no-op.

## User-state (#37) — `internal/agent/userstate.go`
Models the user as a stateful agent: focus area, last task cluster, light keyword mood, last-seen. Persisted to a normal memory key, refreshed async each turn, injected read-only + point-in-time into chat context. Behavioural gating is deliberately **not** included — read-only context only, to avoid risk; routing already handles greeting-vs-task.

## Test
Episodic: consolidate / dedupe / thin-session / disabled-no-op, `Latest` maxAge filter + newest-pick. User-state: `lightMood`, round-trip + framing, nil-memory safety. `go build`/`vet`/`test ./...` all green.