### PR TITLE
Owner-gated shared spaces: owner auth + crosspost-leak scrub

### DIFF
--- a/internal/chat/discord.go
+++ b/internal/chat/discord.go
@@ -141,6 +141,14 @@ func (d *DiscordBot) onMessageCreate(ctx context.Context) func(s *discordgo.Sess
 						break
 					}
 				}
+				// Parity with Telegram's isReplyToMe: a reply to the bot's
+				// own message counts as directly addressing it, even without
+				// an explicit @mention.
+				if !addressed && m.ReferencedMessage != nil &&
+					m.ReferencedMessage.Author != nil &&
+					m.ReferencedMessage.Author.ID == s.State.User.ID {
+					addressed = true
+				}
 				if addressed {
 					log.Info("bystander addressed the bot; declining (owner-gated)", "user_id", m.Author.ID, "username", m.Author.Username)
 					if _, err := s.ChannelMessageSend(m.ChannelID, discordBystanderDecline); err != nil {

--- a/internal/chat/discord.go
+++ b/internal/chat/discord.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"sync"
 
 	"github.com/bwmarrin/discordgo"
 
@@ -18,11 +19,20 @@ const discordMaxLen = 2000
 
 // DiscordBot implements core.ChatBot for Discord.
 type DiscordBot struct {
-	session *discordgo.Session
-	handler core.ChatHandler
-	cfg     config.DiscordConfig
-	done    chan struct{}
+	session   *discordgo.Session
+	handler   core.ChatHandler
+	cfg       config.DiscordConfig
+	done      chan struct{}
+	ownerWarn sync.Once // emits the "owner_id unset" hint at most once
 }
+
+// isOwner reports whether id is the configured single owner. Unset ("") →
+// always false → owner-gating off (legacy behaviour).
+func (d *DiscordBot) isOwner(id string) bool {
+	return d.cfg.OwnerID != "" && id == d.cfg.OwnerID
+}
+
+const discordBystanderDecline = "Hey! 🦐 I only take instructions from my owner, so I can't run tasks or remember things for anyone else here."
 
 // NewDiscordBot creates a DiscordBot with the provided config and handler.
 // The session is created but not opened - call Start to connect.
@@ -111,6 +121,36 @@ func (d *DiscordBot) onMessageCreate(ctx context.Context) func(s *discordgo.Sess
 		// Never reply to ourselves.
 		if m.Author.ID == s.State.User.ID {
 			return
+		}
+
+		// Owner authorization (single-owner model). When owner_id is set,
+		// non-owners are bystanders: replied to with a fixed decline only if
+		// they directly @mention the bot, and never routed to the agent — no
+		// tasks, memory writes, or destructive actions from a bystander. Unset
+		// → legacy behaviour with a one-time hint.
+		if !d.isOwner(m.Author.ID) {
+			if d.cfg.OwnerID == "" {
+				d.ownerWarn.Do(func() {
+					log.Warn("discord.owner_id is unset — anyone in a shared server can drive the bot; set discord.owner_id to your Discord user ID for single-owner safety")
+				})
+			} else {
+				addressed := m.GuildID == ""
+				for _, u := range m.Mentions {
+					if u.ID == s.State.User.ID {
+						addressed = true
+						break
+					}
+				}
+				if addressed {
+					log.Info("bystander addressed the bot; declining (owner-gated)", "user_id", m.Author.ID, "username", m.Author.Username)
+					if _, err := s.ChannelMessageSend(m.ChannelID, discordBystanderDecline); err != nil {
+						log.Debug("failed to send bystander decline", "error", err)
+					}
+				} else {
+					log.Debug("bystander message ignored (owner-gated)", "user_id", m.Author.ID)
+				}
+				return
+			}
 		}
 
 		// Guild/channel filter: if configured, only respond in matching contexts.

--- a/internal/chat/owner_gating_test.go
+++ b/internal/chat/owner_gating_test.go
@@ -1,0 +1,68 @@
+package chat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+)
+
+func TestTelegramIsOwner(t *testing.T) {
+	// Unset → owner-gating off: nobody is "the owner", so the caller falls
+	// through to legacy behaviour.
+	off := &TelegramBot{cfg: config.TelegramConfig{}}
+	if off.isOwner(123) {
+		t.Error("unset OwnerID must never report an owner")
+	}
+
+	on := &TelegramBot{cfg: config.TelegramConfig{OwnerID: 42}}
+	if !on.isOwner(42) {
+		t.Error("configured owner must be recognised")
+	}
+	if on.isOwner(43) {
+		t.Error("a non-owner must not be recognised as owner")
+	}
+}
+
+func TestDiscordIsOwner(t *testing.T) {
+	off := &DiscordBot{cfg: config.DiscordConfig{}}
+	if off.isOwner("anyone") {
+		t.Error("unset OwnerID must never report an owner")
+	}
+	on := &DiscordBot{cfg: config.DiscordConfig{OwnerID: "owner#1"}}
+	if !on.isOwner("owner#1") {
+		t.Error("configured owner must be recognised")
+	}
+	if on.isOwner("someone-else") {
+		t.Error("a non-owner must not be recognised as owner")
+	}
+}
+
+func TestScrubCrosspostLiterals(t *testing.T) {
+	// Clean text → untouched, no scrub.
+	if got, did := scrubCrosspostLiterals("just a normal reply"); did || got != "just a normal reply" {
+		t.Errorf("clean text changed: got=%q did=%v", got, did)
+	}
+
+	// Well-formed directives are removed by extractCrossPostDirectives first;
+	// scrub only mops residue. Unclosed header → must not leak the token.
+	got, did := scrubCrosspostLiterals("here you go [CROSSPOST:12345] and the rest")
+	if !did || strings.Contains(got, "CROSSPOST") {
+		t.Errorf("unclosed header leaked: got=%q did=%v", got, did)
+	}
+
+	// Stray closing tag → stripped.
+	got, did = scrubCrosspostLiterals("done[/CROSSPOST]")
+	if !did || strings.Contains(got, "CROSSPOST") {
+		t.Errorf("stray close tag leaked: got=%q did=%v", got, did)
+	}
+
+	// Unterminated header with no closing bracket → cut to end of line, no leak.
+	got, did = scrubCrosspostLiterals("line one\n[CROSSPOST broken here\nline three")
+	if !did || strings.Contains(got, "CROSSPOST") {
+		t.Errorf("unterminated header leaked: got=%q did=%v", got, did)
+	}
+	if !strings.Contains(got, "line one") || !strings.Contains(got, "line three") {
+		t.Errorf("scrub removed too much: got=%q", got)
+	}
+}

--- a/internal/chat/owner_gating_test.go
+++ b/internal/chat/owner_gating_test.go
@@ -65,4 +65,14 @@ func TestScrubCrosspostLiterals(t *testing.T) {
 	if !strings.Contains(got, "line one") || !strings.Contains(got, "line three") {
 		t.Errorf("scrub removed too much: got=%q", got)
 	}
+
+	// Bracket-less close fragment (mirror of the unterminated-header case) →
+	// must not leak the token either.
+	got, did = scrubCrosspostLiterals("keep[/CROSSPOST")
+	if !did || strings.Contains(got, "CROSSPOST") {
+		t.Errorf("bracket-less close leaked: got=%q did=%v", got, did)
+	}
+	if !strings.Contains(got, "keep") {
+		t.Errorf("scrub removed too much: got=%q", got)
+	}
 }

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -38,7 +38,19 @@ type TelegramBot struct {
 	botTurnsMu  sync.Mutex
 	learnFn     LearnFunc            // optional: store group learnings to memory
 	providerMgr core.ProviderControl // optional: runtime model/provider switching
+	ownerWarn   sync.Once            // emits the "owner_id unset" hint at most once
 }
+
+// isOwner reports whether id is the configured single owner. When OwnerID is
+// unset (0) this is always false; callers treat unset as "owner-gating off".
+func (t *TelegramBot) isOwner(id int64) bool {
+	return t.cfg.OwnerID != 0 && id == t.cfg.OwnerID
+}
+
+// bystanderDecline is the only thing a non-owner who directly addresses the
+// bot gets back. It never reaches the agent, so no task/memory/destructive
+// side effects are possible from a bystander.
+const bystanderDecline = "Hey! 🦐 I only take instructions from my owner, so I can't run tasks or remember things for anyone else here — but say hi to them for me."
 
 // NewTelegramBot creates a TelegramBot using the provided config and handler.
 // Returns an error if the token is missing or invalid.
@@ -160,6 +172,35 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 			"username", msg.From.UserName,
 		)
 		return
+	}
+
+	// --- Owner authorization (single-owner model) ---
+	// When owner_id is set, only the owner drives the bot. A bystander in a
+	// shared group/chat is replied to ONLY if they directly address the bot,
+	// with a fixed decline that never reaches the agent — so a stranger can
+	// never trigger tasks, memory writes, or destructive actions. This is the
+	// safety counterpart to "no approval prompts by default". When owner_id is
+	// unset, behaviour is unchanged (legacy) with a one-time hint.
+	if msg.From != nil && !t.isOwner(msg.From.ID) {
+		if t.cfg.OwnerID == 0 {
+			t.ownerWarn.Do(func() {
+				log.Warn("telegram.owner_id is unset — anyone in a shared chat can drive the bot; set telegram.owner_id to your Telegram user ID for single-owner safety")
+			})
+		} else {
+			mentioned := t.isMentioned(msg, botUsername)
+			isReplyToMe := msg.ReplyToMessage != nil &&
+				msg.ReplyToMessage.From != nil &&
+				msg.ReplyToMessage.From.UserName == botUsername
+			if mentioned || isReplyToMe {
+				log.Info("bystander addressed the bot; declining (owner-gated)",
+					"user_id", msg.From.ID, "username", msg.From.UserName)
+				t.sendMessage(chatID, bystanderDecline)
+			} else {
+				log.Debug("bystander message ignored (owner-gated)",
+					"user_id", msg.From.ID, "username", msg.From.UserName)
+			}
+			return
+		}
 	}
 
 	// Handle commands (work in both DMs and groups).
@@ -312,6 +353,12 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 
 	// Check for cross-channel message directives in the response
 	resp, crossTargets := extractCrossPostDirectives(resp)
+	// #22: belt-and-braces — strip any malformed/unclosed CROSSPOST literal
+	// that the parser left behind so the raw token never reaches the user.
+	if scrubbed, did := scrubCrosspostLiterals(resp); did {
+		log.Warn("stripped residual CROSSPOST literal from response", "chat_id", chatID)
+		resp = scrubbed
+	}
 	for _, ct := range crossTargets {
 		targetID, parseErr := strconv.ParseInt(ct.ChatID, 10, 64)
 		if parseErr != nil {
@@ -992,6 +1039,39 @@ func extractCrossPostDirectives(text string) (string, []crossPostTarget) {
 		text = text[:start] + text[end+len("[/CROSSPOST]"):]
 	}
 	return strings.TrimSpace(text), targets
+}
+
+// scrubCrosspostLiterals removes any residual [CROSSPOST...] / [/CROSSPOST]
+// literal that survived extractCrossPostDirectives — e.g. an opening tag with
+// no matching close, or a stray closing tag. #22: without this, a malformed
+// directive leaks the raw token straight into the user's chat. Returns the
+// cleaned text and whether anything was stripped (for logging).
+func scrubCrosspostLiterals(text string) (string, bool) {
+	if !strings.Contains(text, "[CROSSPOST") && !strings.Contains(text, "[/CROSSPOST]") {
+		return text, false
+	}
+	cleaned := text
+	// Drop any "[CROSSPOST:...]" header fragment, then any bare close tag.
+	for {
+		s := strings.Index(cleaned, "[CROSSPOST")
+		if s == -1 {
+			break
+		}
+		e := strings.Index(cleaned[s:], "]")
+		if e == -1 {
+			// Unterminated header — cut from the marker to end of line.
+			nl := strings.IndexByte(cleaned[s:], '\n')
+			if nl == -1 {
+				cleaned = cleaned[:s]
+			} else {
+				cleaned = cleaned[:s] + cleaned[s+nl:]
+			}
+			continue
+		}
+		cleaned = cleaned[:s] + cleaned[s+e+1:]
+	}
+	cleaned = strings.ReplaceAll(cleaned, "[/CROSSPOST]", "")
+	return strings.TrimSpace(cleaned), true
 }
 
 // SendToChat sends a message to a specific chat ID. Enables cross-channel messaging.

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -181,26 +181,36 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 	// never trigger tasks, memory writes, or destructive actions. This is the
 	// safety counterpart to "no approval prompts by default". When owner_id is
 	// unset, behaviour is unchanged (legacy) with a one-time hint.
-	if msg.From != nil && !t.isOwner(msg.From.ID) {
-		if t.cfg.OwnerID == 0 {
-			t.ownerWarn.Do(func() {
-				log.Warn("telegram.owner_id is unset — anyone in a shared chat can drive the bot; set telegram.owner_id to your Telegram user ID for single-owner safety")
-			})
-		} else {
-			mentioned := t.isMentioned(msg, botUsername)
-			isReplyToMe := msg.ReplyToMessage != nil &&
-				msg.ReplyToMessage.From != nil &&
-				msg.ReplyToMessage.From.UserName == botUsername
-			if mentioned || isReplyToMe {
-				log.Info("bystander addressed the bot; declining (owner-gated)",
-					"user_id", msg.From.ID, "username", msg.From.UserName)
-				t.sendMessage(chatID, bystanderDecline)
-			} else {
-				log.Debug("bystander message ignored (owner-gated)",
-					"user_id", msg.From.ID, "username", msg.From.UserName)
-			}
-			return
+	if t.cfg.OwnerID == 0 {
+		t.ownerWarn.Do(func() {
+			log.Warn("telegram.owner_id is unset — anyone in a shared chat can drive the bot; set telegram.owner_id to your Telegram user ID for single-owner safety")
+		})
+	} else if msg.From == nil || !t.isOwner(msg.From.ID) {
+		// Bystander. msg.From == nil (linked-channel auto-forwards,
+		// sender_chat/anonymous posts) is classified here explicitly so the
+		// gate is the single authoritative boundary — the safety property
+		// must not depend on an incidental downstream nil-deref + recover.
+		mentioned := t.isMentioned(msg, botUsername)
+		isReplyToMe := msg.ReplyToMessage != nil &&
+			msg.ReplyToMessage.From != nil &&
+			msg.ReplyToMessage.From.UserName == botUsername
+		var uid int64
+		var uname string
+		if msg.From != nil {
+			uid, uname = msg.From.ID, msg.From.UserName
 		}
+		if mentioned || isReplyToMe {
+			log.Info("bystander addressed the bot; declining (owner-gated)",
+				"user_id", uid, "username", uname)
+			// The decline deliberately bypasses bot-to-bot turn accounting:
+			// it's a single fixed reply that never reaches the agent, so it
+			// cannot drive a conversational loop.
+			t.sendMessage(chatID, bystanderDecline)
+		} else {
+			log.Debug("bystander message ignored (owner-gated)",
+				"user_id", uid, "username", uname)
+		}
+		return
 	}
 
 	// Handle commands (work in both DMs and groups).
@@ -1047,7 +1057,7 @@ func extractCrossPostDirectives(text string) (string, []crossPostTarget) {
 // directive leaks the raw token straight into the user's chat. Returns the
 // cleaned text and whether anything was stripped (for logging).
 func scrubCrosspostLiterals(text string) (string, bool) {
-	if !strings.Contains(text, "[CROSSPOST") && !strings.Contains(text, "[/CROSSPOST]") {
+	if !strings.Contains(text, "[CROSSPOST") && !strings.Contains(text, "[/CROSSPOST") {
 		return text, false
 	}
 	cleaned := text
@@ -1071,6 +1081,10 @@ func scrubCrosspostLiterals(text string) (string, bool) {
 		cleaned = cleaned[:s] + cleaned[s+e+1:]
 	}
 	cleaned = strings.ReplaceAll(cleaned, "[/CROSSPOST]", "")
+	// Also drop a bracket-less close fragment (e.g. "[/CROSSPOST" with no
+	// trailing ']'); after the full-tag replace above, any residue is the
+	// unterminated mirror of the header case handled in the loop.
+	cleaned = strings.ReplaceAll(cleaned, "[/CROSSPOST", "")
 	return strings.TrimSpace(cleaned), true
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,13 @@ type TelegramConfig struct {
 	Token       string  `yaml:"token"`
 	AllowedIDs  []int64 `yaml:"allowed_ids"`
 	BotMaxTurns int     `yaml:"bot_max_turns"` // max bot-to-bot exchanges before waiting for human (0=unlimited, default 3)
+	// OwnerID is the single owner's Telegram user ID. When non-zero, only the
+	// owner can drive the bot: anyone else in a shared group/chat is a
+	// bystander whose messages never reach the agent (no tasks, memory
+	// writes, or destructive actions). 0 = unset = legacy behaviour (all
+	// allowed), with a one-time startup hint to set it for shared-group
+	// safety. Single-owner model.
+	OwnerID int64 `yaml:"owner_id"`
 }
 
 // DiscordConfig for the Discord bot integration.
@@ -138,6 +145,9 @@ type DiscordConfig struct {
 	Token     string `yaml:"token"`
 	GuildID   string `yaml:"guild_id"`
 	ChannelID string `yaml:"channel_id"`
+	// OwnerID is the single owner's Discord user ID (snowflake string). Same
+	// semantics as TelegramConfig.OwnerID; "" = unset = legacy behaviour.
+	OwnerID string `yaml:"owner_id"`
 }
 
 // OllamaConfig for local Ollama management.


### PR DESCRIPTION
Third PR of the v0.1.3 cycle. Implements the **single-owner safety keystone** plus the small crosspost-leak fix. Owner identification via explicit config field (your chosen option).

## Owner authorization (#24, the keystone)

New `telegram.owner_id` / `discord.owner_id` config fields. When set, **only the owner drives the bot**. A non-owner in a shared group/server is a *bystander*:
- replied to with a fixed decline **only** if they directly @mention or reply-to the bot,
- their message **never reaches the agent** — so a stranger can't trigger tasks, memory writes, or destructive actions.

This is the safety counterpart to "no approval prompts by default" (#34): un-gated auto-execution is only safe if a stranger can't drive it. Enforced at the Telegram/Discord boundary with a pure `isOwner` classifier, so no authority flag has to thread through the agent.

**Backward compatible:** `owner_id` unset = current behaviour, with a one-time startup WARN recommending it for shared-group safety. Existing solo setups keep working untouched.

## #22 — crosspost-leak scrub

`scrubCrosspostLiterals` strips any residual `[CROSSPOST:..]` / `[/CROSSPOST]` literal the directive parser leaves behind on a malformed/unclosed directive, so the raw token never leaks into the user's chat.

## Deliberately deferred (with reasons)

These plan items are **not** in this PR — rushing them in a shared multi-session repo would be irresponsible, and two are riskier than the audit implied:

- **Per-space context scoping (#24 storage side)** — the plan's own Risk #2: changing the default `unified` channel breaks existing cross-interface continuity; needs a migration + `/recall across` opt-in. Wants its own focused PR.
- **E3.1 reply-to capture** — needs a new persisted `platform_msgid.jsonl` + GC; medium build, no safety urgency.
- **#9 Telegram backoff** — the audit described a "hardcoded 3s retry"; the code actually uses the library's `GetUpdatesChan`, so real backoff means replacing the live polling loop — an invasive refactor, not a contained change.

These are re-parked in `~/.claude/plans/mini-krill-v012-cycle.md`.

## Test
`isOwner` set/unset (Telegram + Discord), crosspost scrub (clean / unclosed-header / stray-close / unterminated). `go build`/`vet`/`test ./...` all green.