### PR TITLE
Provider honesty + secret-match hardening; v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,31 @@
 All notable changes to Mini Krill will be documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.1.3] - 2026-05-16
+
+Closed-loop learning, cross-session memory, single-owner safety, and an honest provider catalog. The v0.1.3 cycle (PRs A, A2, B, C).
+
+### Closed-loop learning (PR A)
+- Post-turn THANKED/FIXED callback. The affinity learner was one-directional — an auto-run produced no verdict, so a calibrated cluster's score could only ever rise and a cluster that started producing bad output stayed auto-run forever. The user's next message after an un-gated turn is now the verdict: a correction credits FIXED (drift back toward planning), anything else credits THANKED. Restores symmetric drift; closes the freeze flagged in the PR #33 review.
+- #16: `looksLikeCorrection` caught `"don't"` but not `doesn't`/`didn't`/`isn't`/`wasn't`/`won't`/`can't`/… so real corrections went uncredited. Extended the contraction list (word-bounded) plus curly-apostrophe normalisation.
+- `affinity:cluster:` is now a reserved memory namespace: `FileMemory.Store` refuses writes there unless they come from the affinity store, so `/remember` can't corrupt a learned record.
+
+### Cross-session memory & user-state (PR A2)
+- Episodic memory (#29 / D6): on a >30 min activity gap the prior session is summarised into one episode; the most recent episode <7 days old is injected into chat context as an explicitly point-in-time, read-only line so the agent resumes instead of starting cold.
+- User-state (#37): focus area, last task cluster, light mood, last-seen — persisted and injected read-only as point-in-time context.
+
+### Single-owner safety (PR B)
+- New `telegram.owner_id` / `discord.owner_id`. When set, only the owner drives the bot; a bystander in a shared group/server is replied to with a fixed decline only if they directly address the bot, and their message never reaches the agent — no tasks, memory writes, or destructive actions from a stranger. The safety counterpart to "no approval prompts by default". Unset = legacy behaviour with a one-time hint.
+- #22: residual `[CROSSPOST:..]` literals from a malformed directive are scrubbed so the raw token never leaks into chat.
+
+### Provider honesty & hardening (PR C)
+- #23: removed the fabricated Codex model catalog (`gpt-5.5`, `gpt-5.4`, …). Those IDs don't exist and picking one failed ~90s later. Codex now advertises only `auto`, delegating model choice to the Codex CLI.
+- `secretPathPatterns` (self:read-code / read-logs) anchored to real filename boundaries instead of a raw substring, so a benign `notconfig.yaml.txt` is no longer refused while real secrets still are.
+
+### Notes
+- #7 (Codex stderr/timeout surfacing) was largely resolved by the PR #27 `runCLI` rewrite (separate stderr, distinct ctx-cancel surfacing, idle monitor).
+- Deferred to a future introspection cycle: `self:explain-decision`, `self:dashboard`, replay-from-log, active-listening primitive, per-space context scoping, Telegram reply-to capture, and a real Telegram backoff (the live polling loop uses the library's `GetUpdatesChan`).
+
 ## [0.1.2] - 2026-05-16
 
 No more nagging. The agent stops asking for manual permission on routine work.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 Built by [Sourav Singh](https://souravailabs.ai/about/) / [Sourav AI Labs](https://souravailabs.ai)
 
-[![Version](https://img.shields.io/badge/version-0.1.2-blue.svg)](https://github.com/srvsngh99/mini-krill/releases)
+[![Version](https://img.shields.io/badge/version-0.1.3-blue.svg)](https://github.com/srvsngh99/mini-krill/releases)
 [![Go](https://img.shields.io/badge/Go-1.24+-00ADD8.svg?logo=go)](https://go.dev/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Platforms](https://img.shields.io/badge/platforms-Linux%20%7C%20macOS%20%7C%20Windows-lightgrey.svg)]()

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -523,7 +523,7 @@ func (t *TelegramBot) handleCommand(chatID int64, msg *tgbotapi.Message) {
 			"/status  - Check my vital signs",
 			"/model   - Show active provider and model",
 			"/models  - List all providers and models",
-			"/switch  - Switch provider (e.g. /switch local, /switch codex gpt-5.5)",
+			"/switch  - Switch provider (e.g. /switch local, /switch codex)",
 			"/fact    - Learn something about real krill",
 			"/plan    - Start a dive plan for a task",
 			"/tasks   - List active and recent tasks",
@@ -694,7 +694,7 @@ func (t *TelegramBot) handleSwitchCommand(chatID int64, msg *tgbotapi.Message) {
 	}
 	args := strings.TrimSpace(msg.CommandArguments())
 	if args == "" {
-		t.sendMessage(chatID, "Usage: /switch <provider> [model]\nExample: /switch local\nExample: /switch codex gpt-5.5\nExample: /switch claude sonnet")
+		t.sendMessage(chatID, "Usage: /switch <provider> [model]\nExample: /switch local\nExample: /switch codex\nExample: /switch claude sonnet")
 		return
 	}
 	parts := strings.Fields(args)

--- a/internal/core/types.go
+++ b/internal/core/types.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Version is set at build time via -ldflags
-var Version = "0.1.2"
+var Version = "0.1.3"
 
 // ReservedAffinityPrefix namespaces per-task-type plan-affinity records in the
 // memory store. Only the affinity store itself (Source == AffinitySource) may

--- a/internal/llm/manager.go
+++ b/internal/llm/manager.go
@@ -153,8 +153,13 @@ func (m *ProviderManager) ListProviders() []ProviderInfo {
 			HasKey:   true,
 		},
 		{
-			Name:     "codex",
-			Models:   []string{"auto", "gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex", "gpt-5.2"},
+			Name: "codex",
+			// #23: only advertise "auto". The previous list (gpt-5.5/5.4/…)
+			// was fabricated — those Codex model IDs don't exist, so picking
+			// one produced a confusing failure ~90s later. "auto" delegates
+			// model choice to the Codex CLI, which is the honest contract
+			// (cli_provider omits --model when the model is "auto").
+			Models:   []string{"auto"},
 			IsActive: active.Provider == "codex",
 			NeedsKey: false,
 			HasKey:   codexHasKey,
@@ -279,19 +284,16 @@ func (m *ProviderManager) ResolveTarget(input string) (provider, model string, o
 		return prov, "", true
 	}
 
-	// Check if it's a model name - match to provider
+	// Check if it's a model name - match to provider.
+	// #23: no fabricated Codex model IDs (gpt-5.5 etc.) — Codex is reached
+	// via the "codex"/"chatgpt" provider aliases with model "auto".
 	modelMap := map[string]string{
-		"gpt-4o":        "openai",
-		"gpt-4o-mini":   "openai",
-		"gpt-4":         "openai",
-		"gpt-5.2":       "codex",
-		"gpt-5.3-codex": "codex",
-		"gpt-5.4":       "codex",
-		"gpt-5.4-mini":  "codex",
-		"gpt-5.5":       "codex",
-		"sonnet":        "claude",
-		"opus":          "claude",
-		"haiku":         "claude",
+		"gpt-4o":      "openai",
+		"gpt-4o-mini": "openai",
+		"gpt-4":       "openai",
+		"sonnet":      "claude",
+		"opus":        "claude",
+		"haiku":       "claude",
 	}
 
 	// Add Ollama models dynamically

--- a/internal/plugin/secret_match_test.go
+++ b/internal/plugin/secret_match_test.go
@@ -15,6 +15,10 @@ func TestSecretMatch(t *testing.T) {
 		j("/repo", "config.yaml.bak"),
 		j("/repo", ".env"),
 		j("/repo", "prod.env"),
+		j("/repo", ".env.local"),             // dotenv multi-env (regression)
+		j("/repo", ".env.production"),         // dotenv multi-env (regression)
+		j("/repo", "app", ".env.development"), // dotenv multi-env (regression)
+		j("/repo", "server.pem.bak"),          // backup of a .pem (regression)
 		j("/repo", "server.pem"),
 		j("/repo", "id_rsa.key"),
 		j("/repo", "secrets.json"),

--- a/internal/plugin/secret_match_test.go
+++ b/internal/plugin/secret_match_test.go
@@ -1,0 +1,45 @@
+package plugin
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// PR #32 nit: the secret check was a raw substring over the whole path, so a
+// benign file containing a pattern as a fragment was wrongly refused.
+// secretMatch must anchor to real filename boundaries.
+func TestSecretMatch(t *testing.T) {
+	j := filepath.Join
+	refuse := []string{
+		j("/repo", "config.yaml"),
+		j("/repo", "config.yaml.bak"),
+		j("/repo", ".env"),
+		j("/repo", "prod.env"),
+		j("/repo", "server.pem"),
+		j("/repo", "id_rsa.key"),
+		j("/repo", "secrets.json"),
+		j("/repo", "private_key"),
+		j("/repo", "service_account"),
+		j("/repo", "credentials", "db.txt"), // path component
+		j("/repo", "deploy", "credentials"), // trailing component
+	}
+	for _, p := range refuse {
+		if _, hit := secretMatch(p); !hit {
+			t.Errorf("secretMatch(%q) = false, want refused", p)
+		}
+	}
+
+	allow := []string{
+		j("/repo", "notconfig.yaml.txt"), // the regression this fixes
+		j("/repo", "internal", "agent", "agent.go"),
+		j("/repo", "envparser.go"),       // contains "env" but not a .env file
+		j("/repo", "keyboard.go"),        // contains "key" but not a .key file
+		j("/repo", "configurator.md"),    // starts like "config" but not config.yaml
+		j("/repo", "my_credentials.md"),  // "credentials" mid-name, not a component
+	}
+	for _, p := range allow {
+		if pat, hit := secretMatch(p); hit {
+			t.Errorf("secretMatch(%q) = refused on %q, want allowed", p, pat)
+		}
+	}
+}

--- a/internal/plugin/self_eyes.go
+++ b/internal/plugin/self_eyes.go
@@ -35,6 +35,42 @@ var secretPathPatterns = []string{
 	"private_key", "service_account",
 }
 
+// secretMatch reports whether abs is a secret-bearing path that must never be
+// read, returning the pattern that matched. PR #32 nit: the old check was a
+// raw substring over the whole path, so a benign file like
+// "notconfig.yaml.txt" was wrongly refused (it contains "config.yaml"). This
+// anchors each pattern to a real filename boundary instead:
+//   - extension patterns (".env", ".pem", ".key") match a true suffix;
+//   - prefix patterns ("secrets.") match the start of the basename;
+//   - name patterns ("config.yaml", "credentials", "private_key",
+//     "service_account") match the whole basename, a "<name>.bak"-style
+//     variant, or a full path component — never a mid-name substring.
+func secretMatch(abs string) (string, bool) {
+	lowerAbs := strings.ToLower(abs)
+	base := strings.ToLower(filepath.Base(abs))
+	sep := string(filepath.Separator)
+	for _, pat := range secretPathPatterns {
+		switch {
+		case strings.HasPrefix(pat, "."): // extension-like
+			if strings.HasSuffix(base, pat) {
+				return pat, true
+			}
+		case strings.HasSuffix(pat, "."): // prefix-like ("secrets.")
+			if strings.HasPrefix(base, pat) {
+				return pat, true
+			}
+		default: // whole-name / path-component token
+			if base == pat ||
+				strings.HasPrefix(base, pat+".") ||
+				strings.Contains(lowerAbs, sep+pat+sep) ||
+				strings.HasSuffix(lowerAbs, sep+pat) {
+				return pat, true
+			}
+		}
+	}
+	return "", false
+}
+
 // resolveRepoRoot finds the repo root using two strategies:
 //  1. MINIKRILL_REPO env var if set and points to a real dir
 //  2. Walk up from runtime.Caller's source file looking for go.mod
@@ -85,10 +121,8 @@ func safeRepoPath(rel string) (string, error) {
 	if !strings.HasPrefix(abs, rootAbs+string(filepath.Separator)) && abs != rootAbs {
 		return "", fmt.Errorf("path escapes the repo root")
 	}
-	for _, pat := range secretPathPatterns {
-		if strings.Contains(strings.ToLower(abs), pat) {
-			return "", fmt.Errorf("refusing to read paths matching %q (secret allowlist)", pat)
-		}
+	if pat, hit := secretMatch(abs); hit {
+		return "", fmt.Errorf("refusing to read paths matching %q (secret allowlist)", pat)
 	}
 	return abs, nil
 }

--- a/internal/plugin/self_eyes.go
+++ b/internal/plugin/self_eyes.go
@@ -40,7 +40,11 @@ var secretPathPatterns = []string{
 // raw substring over the whole path, so a benign file like
 // "notconfig.yaml.txt" was wrongly refused (it contains "config.yaml"). This
 // anchors each pattern to a real filename boundary instead:
-//   - extension patterns (".env", ".pem", ".key") match a true suffix;
+//   - extension patterns (".env", ".pem", ".key") match a true suffix
+//     OR an interior dot-segment, so the multi-environment dotenv
+//     convention (".env.local", ".env.production") and backup variants
+//     ("server.pem.bak") are still refused — but never a mid-word
+//     substring ("envparser.go" stays readable);
 //   - prefix patterns ("secrets.") match the start of the basename;
 //   - name patterns ("config.yaml", "credentials", "private_key",
 //     "service_account") match the whole basename, a "<name>.bak"-style
@@ -52,7 +56,11 @@ func secretMatch(abs string) (string, bool) {
 	for _, pat := range secretPathPatterns {
 		switch {
 		case strings.HasPrefix(pat, "."): // extension-like
-			if strings.HasSuffix(base, pat) {
+			// true extension suffix (".env", "prod.env", "server.pem")
+			// or the pattern as an interior dot-segment (".env.local",
+			// ".env.production", "server.pem.bak") — never a mid-word
+			// substring ("envparser.go" / "keyboard.go" stay readable).
+			if strings.HasSuffix(base, pat) || strings.Contains(base, pat+".") {
 				return pat, true
 			}
 		case strings.HasSuffix(pat, "."): // prefix-like ("secrets.")


### PR DESCRIPTION
Final PR of the v0.1.3 cycle — the release PR. Scoped to bounded, low-risk hardening + the version bump; the large introspection suite is explicitly deferred (see below) rather than rushed.

## #23 — honest Codex catalog
Removed the fabricated Codex model list (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, `gpt-5.2`). Those IDs don't exist, so selecting one produced a confusing failure ~90s later. Codex now advertises only `auto`, delegating model choice to the Codex CLI (`cli_provider` already omits `--model` when the model is `auto`). Pruned the matching `modelMap` entries so `/use gpt-5.5` no longer resolves to codex.

## secretPathPatterns hardening (PR #32 nit)
The secret check was a raw substring over the whole path, so `notconfig.yaml.txt` was wrongly refused (it contains `config.yaml`). New `secretMatch` anchors each pattern to a real filename boundary: extension patterns match a true suffix, `secrets.` matches a basename prefix, and name tokens match the whole basename / a `.bak`-style variant / a full path component — never a mid-name substring. Real secrets (`config.yaml`, `.env`, `*.pem/.key`, `private_key`, `service_account`, `credentials/`) are still refused.

## Release
`core.Version` 0.1.2 → **0.1.3**, README badge, and a `CHANGELOG [0.1.3]` section covering PRs A, A2, B, and C.

## Deferred (documented, not dropped)
The big introspection items — `self:explain-decision` (E4.3), `self:dashboard` (#33), replay-from-log (#35), active-listening (#31) — are each a substantial new subsystem. Cramming four of them into the release PR in a multi-session shared repo would trade quality for speed. They move to a v0.1.4 introspection cycle. Also deferred with reasons: per-space context scoping (plan Risk #2), Telegram reply-to (E3.1), and a real #9 backoff (the live loop uses the library's `GetUpdatesChan`, not a tweakable retry). #7 was already largely resolved by the PR #27 `runCLI` rewrite.

## Test
`secretMatch` (refuse set + the `notconfig.yaml.txt` regression + allow set). `go build`/`vet`/`test ./...` all green; binary reports `minikrill version 0.1.3`.