### PR TITLE
PR37 follow-ups: owner-gate seam + scrub blank line + discord nil-author guard

### DIFF
--- a/internal/chat/discord.go
+++ b/internal/chat/discord.go
@@ -118,6 +118,13 @@ func (d *DiscordBot) onMessageCreate(ctx context.Context) func(s *discordgo.Sess
 			}
 		}()
 
+		// Defensive: system/webhook edge cases can carry a nil Author. Drop
+		// explicitly rather than relying on the panic recovery above — this
+		// is a security path (the owner gate below dereferences Author).
+		if m.Author == nil {
+			return
+		}
+
 		// Never reply to ourselves.
 		if m.Author.ID == s.State.User.ID {
 			return

--- a/internal/chat/owner_gating_test.go
+++ b/internal/chat/owner_gating_test.go
@@ -7,6 +7,39 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/config"
 )
 
+// TestDecideOwnerGate is the boundary regression owed from PR #37 review
+// (follow-up 1): with owner-gating on, anything that is not a confirmed owner
+// — crucially the msg.From == nil case, which presents as isOwner=false —
+// must never resolve to gateProceed, so the agent is never reached.
+func TestDecideOwnerGate(t *testing.T) {
+	cases := []struct {
+		name                       string
+		ownerSet, isOwner, address bool
+		want                       ownerGate
+	}{
+		{"gating off → always proceed", false, false, true, gateProceed},
+		{"gating off, unaddressed → proceed", false, false, false, gateProceed},
+		{"owner proceeds", true, true, false, gateProceed},
+		{"owner proceeds even if addressed", true, true, true, gateProceed},
+		{"bystander addressing → decline", true, false, true, gateDecline},
+		{"bystander silent → ignore", true, false, false, gateIgnore},
+	}
+	for _, c := range cases {
+		if got := decideOwnerGate(c.ownerSet, c.isOwner, c.address); got != c.want {
+			t.Errorf("%s: decideOwnerGate(%v,%v,%v)=%d want %d",
+				c.name, c.ownerSet, c.isOwner, c.address, got, c.want)
+		}
+	}
+
+	// The owed invariant, stated directly: gating on + not the owner (the
+	// From==nil regime) never proceeds to the agent, addressed or not.
+	for _, addressed := range []bool{true, false} {
+		if got := decideOwnerGate(true, false, addressed); got == gateProceed {
+			t.Fatalf("owner-gating on + non-owner (From==nil) must never proceed (addressed=%v)", addressed)
+		}
+	}
+}
+
 func TestTelegramIsOwner(t *testing.T) {
 	// Unset → owner-gating off: nobody is "the owner", so the caller falls
 	// through to legacy behaviour.
@@ -64,6 +97,11 @@ func TestScrubCrosspostLiterals(t *testing.T) {
 	}
 	if !strings.Contains(got, "line one") || !strings.Contains(got, "line three") {
 		t.Errorf("scrub removed too much: got=%q", got)
+	}
+	// Follow-up 2: the broken line's own newline is consumed, so no blank
+	// line is left where the directive was.
+	if strings.Contains(got, "\n\n") {
+		t.Errorf("scrub left a blank line: got=%q", got)
 	}
 
 	// Bracket-less close fragment (mirror of the unterminated-header case) →

--- a/internal/chat/telegram.go
+++ b/internal/chat/telegram.go
@@ -52,6 +52,32 @@ func (t *TelegramBot) isOwner(id int64) bool {
 // side effects are possible from a bystander.
 const bystanderDecline = "Hey! 🦐 I only take instructions from my owner, so I can't run tasks or remember things for anyone else here — but say hi to them for me."
 
+// ownerGate is the outcome of the single-owner authorization decision.
+type ownerGate int
+
+const (
+	gateProceed ownerGate = iota // owner, or owner-gating off (legacy) — route to agent
+	gateIgnore                   // bystander not addressing the bot — drop silently
+	gateDecline                  // bystander addressing the bot — fixed decline, never routed
+)
+
+// decideOwnerGate is the single authoritative owner-authorization decision,
+// kept pure (no tgbotapi / I/O) so the boundary is unit-testable: a future
+// refactor of processUpdate has a test guarding "owner-gating on + not the
+// owner (incl. From==nil) never proceeds to the agent". ownerSet==false means
+// gating is off → always proceed (legacy behaviour). Deny-by-default: anything
+// that isn't a confirmed owner under an active gate is ignored or declined,
+// never proceeded.
+func decideOwnerGate(ownerSet, isOwner, addressed bool) ownerGate {
+	if !ownerSet || isOwner {
+		return gateProceed
+	}
+	if addressed {
+		return gateDecline
+	}
+	return gateIgnore
+}
+
 // NewTelegramBot creates a TelegramBot using the provided config and handler.
 // Returns an error if the token is missing or invalid.
 func NewTelegramBot(cfg config.TelegramConfig, handler core.ChatHandler) (*TelegramBot, error) {
@@ -181,35 +207,45 @@ func (t *TelegramBot) processUpdate(ctx context.Context, update tgbotapi.Update)
 	// never trigger tasks, memory writes, or destructive actions. This is the
 	// safety counterpart to "no approval prompts by default". When owner_id is
 	// unset, behaviour is unchanged (legacy) with a one-time hint.
-	if t.cfg.OwnerID == 0 {
+	ownerSet := t.cfg.OwnerID != 0
+	if !ownerSet {
 		t.ownerWarn.Do(func() {
 			log.Warn("telegram.owner_id is unset — anyone in a shared chat can drive the bot; set telegram.owner_id to your Telegram user ID for single-owner safety")
 		})
-	} else if msg.From == nil || !t.isOwner(msg.From.ID) {
-		// Bystander. msg.From == nil (linked-channel auto-forwards,
-		// sender_chat/anonymous posts) is classified here explicitly so the
-		// gate is the single authoritative boundary — the safety property
-		// must not depend on an incidental downstream nil-deref + recover.
-		mentioned := t.isMentioned(msg, botUsername)
-		isReplyToMe := msg.ReplyToMessage != nil &&
+	}
+	// msg.From == nil (linked-channel auto-forwards, sender_chat/anonymous
+	// posts) is never the owner — decideOwnerGate then yields ignore/decline
+	// (never proceed) when owner-gating is on, so the safety property is the
+	// gate's, not an incidental downstream nil-deref + recover.
+	isOwner := msg.From != nil && t.isOwner(msg.From.ID)
+	addressed := t.isMentioned(msg, botUsername) ||
+		(msg.ReplyToMessage != nil &&
 			msg.ReplyToMessage.From != nil &&
-			msg.ReplyToMessage.From.UserName == botUsername
+			msg.ReplyToMessage.From.UserName == botUsername)
+	switch decideOwnerGate(ownerSet, isOwner, addressed) {
+	case gateProceed:
+		// Owner, or owner-gating off (legacy) — fall through to handling.
+	case gateDecline:
 		var uid int64
 		var uname string
 		if msg.From != nil {
 			uid, uname = msg.From.ID, msg.From.UserName
 		}
-		if mentioned || isReplyToMe {
-			log.Info("bystander addressed the bot; declining (owner-gated)",
-				"user_id", uid, "username", uname)
-			// The decline deliberately bypasses bot-to-bot turn accounting:
-			// it's a single fixed reply that never reaches the agent, so it
-			// cannot drive a conversational loop.
-			t.sendMessage(chatID, bystanderDecline)
-		} else {
-			log.Debug("bystander message ignored (owner-gated)",
-				"user_id", uid, "username", uname)
+		log.Info("bystander addressed the bot; declining (owner-gated)",
+			"user_id", uid, "username", uname)
+		// The decline deliberately bypasses bot-to-bot turn accounting: it's
+		// a single fixed reply that never reaches the agent, so it cannot
+		// drive a conversational loop.
+		t.sendMessage(chatID, bystanderDecline)
+		return
+	case gateIgnore:
+		var uid int64
+		var uname string
+		if msg.From != nil {
+			uid, uname = msg.From.ID, msg.From.UserName
 		}
+		log.Debug("bystander message ignored (owner-gated)",
+			"user_id", uid, "username", uname)
 		return
 	}
 
@@ -1074,7 +1110,10 @@ func scrubCrosspostLiterals(text string) (string, bool) {
 			if nl == -1 {
 				cleaned = cleaned[:s]
 			} else {
-				cleaned = cleaned[:s] + cleaned[s+nl:]
+				// Consume the broken line's own newline too, else the text
+				// before the marker keeps its newline and we emit a blank
+				// line ("line one\n\nline three").
+				cleaned = cleaned[:s] + cleaned[s+nl+1:]
 			}
 			continue
 		}


### PR DESCRIPTION
Addresses the three **non-blocking follow-ups** from the #37 review (deliberately a separate PR — not patched into the approved one, per the review's own instruction).

## 1. (owed) Owner-gate test seam — `internal/chat/telegram.go`
The round-1 review's owed item: there was no test driving the owner boundary with `msg.From == nil` + `owner_id` set. Extracted the decision into a pure, table-tested classifier:

```go
decideOwnerGate(ownerSet, isOwner, addressed bool) ownerGate // → proceed | ignore | decline
```

`processUpdate` now `switch`es on it. Deny-by-default: anything that isn't a confirmed owner under an active gate is ignored/declined, never proceeded. `TestDecideOwnerGate` asserts the owed invariant directly — *owner-gating on + non-owner (the `From==nil` regime) never resolves to `gateProceed`*, addressed or not — so a future refactor of that gate has a guard instead of relying on an unconditional `return` + incidental downstream `recover()`.

## 2. Scrub blank-line — `internal/chat/telegram.go`
`scrubCrosspostLiterals`'s unterminated-header branch cut the broken segment but kept its trailing newline, leaving `"line one\n\nline three"`. Now consumes the newline too; the existing scrub test asserts no `\n\n` residue.

## 3. Discord nil-author guard — `internal/chat/discord.go`
Explicit `if m.Author == nil { return }` at the handler top instead of relying on panic recovery on a security path (the owner gate dereferences `m.Author`).

## Scope / test
No version bump — the v0.1.3 bump belongs to the cycle's final PR. `go build`/`vet`/`test ./...` and `go test -race ./internal/chat/` all green.