### PR TITLE
Fix silent identity loss on runtime rename

### DIFF
--- a/internal/agent/identity.go
+++ b/internal/agent/identity.go
@@ -297,6 +297,17 @@ func persistAgentConfig(agent config.AgentConfig) error {
 	if err != nil {
 		return err
 	}
+	// Whole-block replace would clobber identity fields the caller didn't
+	// intend to touch: a /name rename carries an in-memory AgentConfig
+	// whose Personality may be empty, which previously erased the
+	// init-chosen personality on disk. Preserve the loaded value for any
+	// identity field the incoming config leaves blank.
+	if agent.Personality == "" {
+		agent.Personality = cfg.Agent.Personality
+	}
+	if agent.AgentName == "" {
+		agent.AgentName = cfg.Agent.AgentName
+	}
 	cfg.Agent = agent
 	return config.Save(cfg)
 }

--- a/internal/agent/identity.go
+++ b/internal/agent/identity.go
@@ -302,6 +302,16 @@ func persistAgentConfig(agent config.AgentConfig) error {
 	// whose Personality may be empty, which previously erased the
 	// init-chosen personality on disk. Preserve the loaded value for any
 	// identity field the incoming config leaves blank.
+	//
+	// Design: empty means "leave whatever is on disk", NOT "clear it".
+	// Clearing identity is not a supported operation anywhere in the code
+	// (RenameAgent rejects empty input; SetPersonality always sets a
+	// concrete name), so there is no caller that legitimately wants an
+	// empty value persisted. This is the same intent as the matching
+	// non-omitempty tags in config.MarshalYAML: both refuse to let an
+	// accidental blank silently destroy user-chosen identity. If a
+	// deliberate clear is ever needed, it must be a distinct explicit
+	// path, not an empty field threaded through this helper.
 	if agent.Personality == "" {
 		agent.Personality = cfg.Agent.Personality
 	}

--- a/internal/agent/identity_persist_test.go
+++ b/internal/agent/identity_persist_test.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+)
+
+// Regression: a /name rename carries an in-memory AgentConfig whose
+// Personality is empty. persistAgentConfig must NOT let that erase the
+// init-chosen personality on disk (it previously did, after which Load
+// silently defaulted personality to "krill" — a silent identity downgrade).
+func TestPersistAgentConfig_PreservesPersonalityOnRename(t *testing.T) {
+	t.Setenv("KRILL_DATA_DIR", t.TempDir())
+
+	seed := config.DefaultConfig()
+	seed.Agent.Name = "test-krill"
+	seed.Agent.AgentName = "Jarvis"
+	seed.Agent.Personality = "jarvis"
+	if err := config.Save(seed); err != nil {
+		t.Fatalf("seed Save: %v", err)
+	}
+
+	// Simulate RenameAgent's call: only AgentName set, Personality blank.
+	if err := persistAgentConfig(config.AgentConfig{AgentName: "Friday"}); err != nil {
+		t.Fatalf("persistAgentConfig: %v", err)
+	}
+
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Agent.Personality != "jarvis" {
+		t.Errorf("personality = %q, want %q (must survive a rename)", got.Agent.Personality, "jarvis")
+	}
+	if got.Agent.AgentName != "Friday" {
+		t.Errorf("agent_name = %q, want %q (rename must still apply)", got.Agent.AgentName, "Friday")
+	}
+}
+
+// Regression: agent_name/personality must be written even when set, never
+// dropped by omitempty — a round-trip through Save/Load preserves them.
+func TestMarshalYAML_IdentityFieldsNotOmitted(t *testing.T) {
+	t.Setenv("KRILL_DATA_DIR", t.TempDir())
+
+	c := config.DefaultConfig()
+	c.Agent.AgentName = "Jarvis"
+	c.Agent.Personality = "jarvis"
+	if err := config.Save(c); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	got, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.Agent.AgentName != "Jarvis" || got.Agent.Personality != "jarvis" {
+		t.Errorf("identity not round-tripped: agent_name=%q personality=%q",
+			got.Agent.AgentName, got.Agent.Personality)
+	}
+}

--- a/internal/agent/identity_persist_test.go
+++ b/internal/agent/identity_persist_test.go
@@ -1,6 +1,9 @@
 package agent
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/srvsngh99/mini-krill/internal/config"
@@ -9,7 +12,7 @@ import (
 // Regression: a /name rename carries an in-memory AgentConfig whose
 // Personality is empty. persistAgentConfig must NOT let that erase the
 // init-chosen personality on disk (it previously did, after which Load
-// silently defaulted personality to "krill" — a silent identity downgrade).
+// silently defaulted personality to "krill" (a silent identity downgrade).
 func TestPersistAgentConfig_PreservesPersonalityOnRename(t *testing.T) {
 	t.Setenv("KRILL_DATA_DIR", t.TempDir())
 
@@ -38,23 +41,36 @@ func TestPersistAgentConfig_PreservesPersonalityOnRename(t *testing.T) {
 	}
 }
 
-// Regression: agent_name/personality must be written even when set, never
-// dropped by omitempty — a round-trip through Save/Load preserves them.
+// Regression: the agent_name/personality keys must be emitted even when the
+// values are empty. This is the assertion that actually pins the omitempty
+// removal: with `,omitempty` restored these keys vanish from the file for an
+// empty struct, so this test fails. (A non-empty round-trip would pass either
+// way and would not guard the regression.)
 func TestMarshalYAML_IdentityFieldsNotOmitted(t *testing.T) {
-	t.Setenv("KRILL_DATA_DIR", t.TempDir())
+	dir := t.TempDir()
+	t.Setenv("KRILL_DATA_DIR", dir)
 
 	c := config.DefaultConfig()
-	c.Agent.AgentName = "Jarvis"
-	c.Agent.Personality = "jarvis"
+	c.Agent.AgentName = "" // the exact condition omitempty would have dropped
+	c.Agent.Personality = ""
 	if err := config.Save(c); err != nil {
 		t.Fatalf("Save: %v", err)
 	}
-	got, err := config.Load()
+
+	raw, err := os.ReadFile(filepath.Join(dir, "config.yaml"))
 	if err != nil {
-		t.Fatalf("Load: %v", err)
+		t.Fatalf("read config.yaml: %v", err)
 	}
-	if got.Agent.AgentName != "Jarvis" || got.Agent.Personality != "jarvis" {
-		t.Errorf("identity not round-tripped: agent_name=%q personality=%q",
-			got.Agent.AgentName, got.Agent.Personality)
+	text := string(raw)
+	// agent_name is unique to the agent block, so presence is sufficient.
+	if !strings.Contains(text, "agent_name:") {
+		t.Error("agent_name: key missing from config.yaml on empty value (omitempty regression)")
+	}
+	// personality: appears in BOTH the agent and brain blocks; the brain
+	// one is never omitempty, so it is always present. With the agent
+	// field's omitempty removed there must be two occurrences; with it
+	// restored and the value empty there is only the brain one.
+	if n := strings.Count(text, "personality:"); n < 2 {
+		t.Errorf("agent personality: key missing (found %d personality: lines, want >=2; omitempty regression)", n)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,9 +87,15 @@ func (a *AgentConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // into AutonomyFloor on first load.
 func (a AgentConfig) MarshalYAML() (interface{}, error) {
 	return &struct {
-		Name          string `yaml:"name"`
-		AgentName     string `yaml:"agent_name,omitempty"`
-		Personality   string `yaml:"personality,omitempty"`
+		Name string `yaml:"name"`
+		// agent_name and personality are deliberately NOT omitempty: they
+		// are user-chosen identity set at `minikrill init`. Omitting an
+		// empty value here let a runtime save with an empty in-memory field
+		// silently erase the line, after which the next load defaulted
+		// personality to "krill" — a silent identity downgrade. Always
+		// writing them makes the loss visible and round-trip-safe.
+		AgentName     string `yaml:"agent_name"`
+		Personality   string `yaml:"personality"`
 		MaxSubKrills  int    `yaml:"max_sub_krills"`
 		AutonomyFloor string `yaml:"autonomy_floor"`
 		RecoveryTurns int    `yaml:"recovery_turns,omitempty"`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,7 +92,7 @@ func (a AgentConfig) MarshalYAML() (interface{}, error) {
 		// are user-chosen identity set at `minikrill init`. Omitting an
 		// empty value here let a runtime save with an empty in-memory field
 		// silently erase the line, after which the next load defaulted
-		// personality to "krill" — a silent identity downgrade. Always
+		// personality to "krill" (a silent identity downgrade). Always
 		// writing them makes the loss visible and round-trip-safe.
 		AgentName     string `yaml:"agent_name"`
 		Personality   string `yaml:"personality"`


### PR DESCRIPTION
## Problem

The user-chosen `agent_name` and `personality` (set at `minikrill init`) could be **silently erased** by any runtime config save — observed in the wild as a config that drifted to `agent_name: aaaa…` with the personality reset to `krill`.

Two independent causes:

1. **`MarshalYAML` tagged `agent_name`/`personality` `omitempty`** — a save where the in-memory field was empty dropped the line from `config.yaml` entirely. The next `Load` then defaulted personality to `"krill"` (`fillDefaults`), a silent identity downgrade with no error logged.
2. **`persistAgentConfig` did a whole-block `cfg.Agent = agent` replace** — a `/name` rename carries an `AgentConfig` whose `Personality` is unset, so persisting a rename clobbered the on-disk personality.

`init` itself was never at fault; it writes both fields correctly. The loss happened post-init via the runtime rename path.

## Fix

- Drop `omitempty` on the two identity fields so a set identity always round-trips and can never be silently dropped.
- `persistAgentConfig` now preserves the loaded `personality`/`agent_name` when the incoming config leaves them blank, instead of whole-block clobbering.

## Tests

Adds `identity_persist_test.go`:
- rename with blank personality must preserve the on-disk personality (and still apply the new name)
- `agent_name`/`personality` round-trip through `Save`/`Load`

`go build ./...`, `go test ./internal/agent ./internal/config`, `go vet` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)