### PR TITLE
Add Reef web channel (WebBot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ docs/promo/
 credentials.*
 *.key
 *.pem
+com.deepkrill.minikrill.plist

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -458,6 +458,11 @@ var diveCmd = &cobra.Command{
 		fmt.Println()
 		fmt.Println(cCyan + "  Mini Krill is surfacing..." + cReset)
 		cancel()
+		if bs.web != nil {
+			// Stop the poll loop (via cancel above) then drain in-flight turns
+			// so a reply the hub already marked delivered still posts.
+			_ = bs.web.Stop()
+		}
 		_ = stack.hb.Stop()
 		_ = stack.mcp.Close()
 		return nil
@@ -584,6 +589,7 @@ type botStatus struct {
 	DiscordErr  error
 	WebOK       bool
 	WebErr      error
+	web         *chat.WebBot // set in reef mode; drained on shutdown
 }
 
 // startBots launches Telegram and Discord bots in the background when enabled.
@@ -606,6 +612,7 @@ func startBots(ctx context.Context, stack *krillStack) botStatus {
 			}
 		}()
 		s.WebOK = true
+		s.web = wbBot
 		klog.Info("web (reef) bot started", "agent", reef.AgentID())
 		return s
 	}
@@ -688,13 +695,18 @@ var chatCmd = &cobra.Command{
 		_ = stack.hb.Start(ctx)
 		defer func() { _ = stack.hb.Stop() }()
 
+		var bs botStatus
 		if daemonPID() == 0 {
-			bs := startBots(ctx, stack)
+			bs = startBots(ctx, stack)
 			if stack.cfg.Telegram.Enabled && bs.TelegramErr != nil {
 				klog.Warn("telegram bot failed to start", "error", bs.TelegramErr)
 			}
 		} else {
 			klog.Debug("skipping bot startup, dive daemon is running")
+		}
+		if bs.web != nil {
+			// On TUI exit, cancel the poll loop then drain in-flight turns.
+			defer func() { cancel(); _ = bs.web.Stop() }()
 		}
 
 		app := tui.NewApp(stack.agent, stack.brain, stack.hb, stack.skills, stack.mcp, core.Version, stack.cfg.Log.File)

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -23,6 +23,7 @@ import (
 	klog "github.com/srvsngh99/mini-krill/internal/log"
 	"github.com/srvsngh99/mini-krill/internal/ollama"
 	"github.com/srvsngh99/mini-krill/internal/plugin"
+	"github.com/srvsngh99/mini-krill/internal/reef"
 	"github.com/srvsngh99/mini-krill/internal/reminder"
 	"github.com/srvsngh99/mini-krill/internal/tui"
 )
@@ -415,14 +416,17 @@ var diveCmd = &cobra.Command{
 		fmt.Printf("  "+cDim+"Skills:"+cReset+"   %d registered\n", len(stack.skills.List()))
 
 		bs := startBots(ctx, stack)
-		if stack.cfg.Telegram.Enabled {
+		if bs.WebOK {
+			fmt.Println("  " + cGreen + "Reef:     swimming" + cReset)
+		}
+		if stack.cfg.Telegram.Enabled && !reef.IsConfigured() {
 			if bs.TelegramOK {
 				fmt.Println("  " + cGreen + "Telegram: swimming" + cReset)
 			} else {
 				fmt.Printf("  "+cRed+"Telegram: %s\n"+cReset, friendlyError(bs.TelegramErr))
 			}
 		}
-		if stack.cfg.Discord.Enabled {
+		if stack.cfg.Discord.Enabled && !reef.IsConfigured() {
 			if bs.DiscordOK {
 				fmt.Println("  " + cGreen + "Discord:  swimming" + cReset)
 			} else {
@@ -578,12 +582,33 @@ type botStatus struct {
 	TelegramErr error
 	DiscordOK   bool
 	DiscordErr  error
+	WebOK       bool
+	WebErr      error
 }
 
 // startBots launches Telegram and Discord bots in the background when enabled.
 // Bots are tied to ctx and will shut down when the context is cancelled.
 func startBots(ctx context.Context, stack *krillStack) botStatus {
 	var s botStatus
+	// One adapter at a time: when Reef is configured, run only the web bot.
+	if reef.IsConfigured() {
+		wbBot := chat.NewWebBot(stack.handler)
+		if runner := stack.agent.TaskRunnerRef(); runner != nil {
+			runner.RegisterNotifier("web", func(chatID, message string) {
+				if err := reef.PostIngest("chat", "chat", message); err != nil {
+					klog.Warn("reef notify failed", "error", err)
+				}
+			})
+		}
+		go func() {
+			if err := wbBot.Start(ctx); err != nil {
+				klog.Error("web (reef) error", "error", err)
+			}
+		}()
+		s.WebOK = true
+		klog.Info("web (reef) bot started", "agent", reef.AgentID())
+		return s
+	}
 	if stack.cfg.Telegram.Enabled {
 		tgBot, err := chat.NewTelegramBot(stack.cfg.Telegram, stack.handler)
 		if err != nil {

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -53,31 +53,29 @@ func main() {
 
 var rootCmd = &cobra.Command{
 	Use:     "minikrill",
-	Short:   "Mini Krill - Your crustaceous AI buddy",
+	Short:   "mini-krill — a lightweight, local-first AI agent",
 	Version: core.Version,
-	Long: cBCyan + `
-   .-''''-.
-  /  >o  /)    Mini Krill
- |  /___/ |    by Sourav Singh / Sourav AI Labs
-  \__\_\_/` + cReset + `
+	Long: "  " + cBold + brand.Wordmark + cReset + "   " + cDim + brand.Tagline + cReset + `
 
   A lightweight, open-source AI agent that runs locally via
   Ollama or through subscription-backed Codex/Claude CLIs.
 
   ` + cDim + `Get started:` + cReset + `
-    ` + cCyan + `minikrill init` + cReset + `       Setup wizard
-    ` + cCyan + `minikrill chat` + cReset + `       Interactive chat
-    ` + cCyan + `minikrill dive` + cReset + `       Start background services
-    ` + cCyan + `minikrill tui` + cReset + `        Terminal dashboard
-    ` + cCyan + `minikrill doctor` + cReset + `     Health diagnostics
+    ` + cBold + `minikrill init` + cReset + `       Setup wizard
+    ` + cBold + `minikrill chat` + cReset + `       Interactive chat
+    ` + cBold + `minikrill dive` + cReset + `       Start background services
+    ` + cBold + `minikrill tui` + cReset + `        Terminal dashboard
+    ` + cBold + `minikrill doctor` + cReset + `     Health diagnostics
 
   ` + cDim + `Documentation:` + cReset + `
-    ` + cCyan + `README.md` + cReset + `            Overview and usage
-    ` + cCyan + `docs/INSTALL.md` + cReset + `     Install and setup
-    ` + cCyan + `docs/PROVIDERS.md` + cReset + `   Ollama, Codex, Claude
-    ` + cCyan + `docs/MEMORY.md` + cReset + `      Memory and preferences
-    ` + cCyan + `docs/INTERFACES.md` + cReset + `  CLI, Telegram, Discord
-    ` + cCyan + `docs/TESTING.md` + cReset + `     Feature test checklist`,
+    ` + cBold + `README.md` + cReset + `            Overview and usage
+    ` + cBold + `docs/INSTALL.md` + cReset + `     Install and setup
+    ` + cBold + `docs/PROVIDERS.md` + cReset + `   Ollama, Codex, Claude
+    ` + cBold + `docs/MEMORY.md` + cReset + `      Memory and preferences
+    ` + cBold + `docs/INTERFACES.md` + cReset + `  CLI, Telegram, Discord
+    ` + cBold + `docs/TESTING.md` + cReset + `     Feature test checklist
+
+  ` + cDim + brand.LabMark + "  " + brand.Lab + "  ·  " + brand.Site + cReset,
 }
 
 func init() {
@@ -217,18 +215,13 @@ func newOllamaManager() (*ollama.OllamaManager, *config.Config) {
 	return ollama.NewManager(cfg.Ollama), cfg
 }
 
+// printBanner prints the monochrome mini-krill lockup: the `>_ mini-krill`
+// wordmark in bold, the tagline and Sourav AI Labs lockup dimmed beneath.
 func printBanner() {
 	fmt.Println()
-	for i, line := range brand.BannerLines(core.Version, true) {
-		switch {
-		case i < len(brand.MarkCompact):
-			fmt.Println(cBCyan + line + cReset)
-		case i == len(brand.MarkCompact):
-			fmt.Println(cBold + line + cReset)
-		default:
-			fmt.Println(cDim + line + cReset)
-		}
-	}
+	fmt.Printf("  %s%s%s   %sv%s%s\n", cBold, brand.Wordmark, cReset, cDim, core.Version, cReset)
+	fmt.Printf("  %s%s%s\n", cDim, brand.Tagline, cReset)
+	fmt.Printf("  %s%s  %s  ·  %s%s\n", cDim, brand.LabMark, brand.Lab, brand.Site, cReset)
 	fmt.Println()
 }
 
@@ -255,6 +248,9 @@ func capitalizeFirstASCII(s string) string {
 
 // friendlyError strips raw API error dumps into a short, helpful message.
 func friendlyError(err error) string {
+	if err == nil {
+		return "not started"
+	}
 	msg := err.Error()
 	if idx := strings.Index(msg, `{"error"`); idx > 0 {
 		msg = msg[:idx]

--- a/cmd/minikrill/main.go
+++ b/cmd/minikrill/main.go
@@ -53,7 +53,7 @@ func main() {
 
 var rootCmd = &cobra.Command{
 	Use:     "minikrill",
-	Short:   "mini-krill — a lightweight, local-first AI agent",
+	Short:   "mini-krill - a lightweight, local-first AI agent",
 	Version: core.Version,
 	Long: "  " + cBold + brand.Wordmark + cReset + "   " + cDim + brand.Tagline + cReset + `
 

--- a/com.deepkrill.minikrill.plist.template
+++ b/com.deepkrill.minikrill.plist.template
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Template. Copy to com.deepkrill.minikrill.plist (gitignored), fill the
+     REEF_AGENT_TOKEN with the contents of ~/reef/.agent_token, then install:
+       cp com.deepkrill.minikrill.plist ~/Library/LaunchAgents/
+       chmod 600 ~/Library/LaunchAgents/com.deepkrill.minikrill.plist
+       launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.deepkrill.minikrill.plist
+     Never commit the filled-in plist - it holds the token in plaintext. -->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.deepkrill.minikrill</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/sourav/go/bin/minikrill</string>
+    <string>dive</string>
+    <string>--foreground</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>/Users/sourav/Desktop/playground/mini-krill</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>REEF_INGEST_URL</key>
+    <string>http://127.0.0.1:8770</string>
+    <key>REEF_AGENT_TOKEN</key>
+    <string>__REEF_AGENT_TOKEN__</string>
+    <key>REEF_AGENT_ID</key>
+    <string>minikrill</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>/Users/sourav/Library/Logs/deepkrill/minikrill.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/sourav/Library/Logs/deepkrill/minikrill.err</string>
+</dict>
+</plist>

--- a/internal/chat/web.go
+++ b/internal/chat/web.go
@@ -49,22 +49,29 @@ func (w *WebBot) Start(ctx context.Context) error {
 			if text == "" {
 				continue
 			}
-			msg := core.ChatMessage{
-				Platform: "web", ChatID: "reef", UserID: "owner",
-				Username: "owner", Text: text,
-			}
-			resp, herr := w.handler.HandleMessage(ctx, msg)
-			if herr != nil {
-				log.Error("web handler error", "error", herr)
-				resp = "I hit an error processing that."
-			}
-			if strings.TrimSpace(resp) == "" {
-				continue
-			}
-			if err := reef.PostIngest("chat", "chat", resp); err != nil {
-				log.Error("reef reply post failed", "error", err)
-			}
+			// Dispatch in a goroutine so a slow agent turn never stalls the
+			// poll loop (HandleMessage can run a full plan/execute cycle).
+			go w.dispatch(ctx, text)
 		}
+	}
+}
+
+// dispatch runs one owner message through the handler and posts the reply.
+func (w *WebBot) dispatch(ctx context.Context, text string) {
+	msg := core.ChatMessage{
+		Platform: "web", ChatID: "reef", UserID: "owner",
+		Username: "owner", Text: text,
+	}
+	resp, err := w.handler.HandleMessage(ctx, msg)
+	if err != nil {
+		log.Error("web handler error", "error", err)
+		resp = "I hit an error processing that."
+	}
+	if strings.TrimSpace(resp) == "" {
+		return
+	}
+	if err := reef.PostIngest("chat", "chat", resp); err != nil {
+		log.Error("reef reply post failed", "error", err)
 	}
 }
 

--- a/internal/chat/web.go
+++ b/internal/chat/web.go
@@ -16,6 +16,12 @@ import (
 // a flood of queued messages would spawn unbounded goroutines; this caps it.
 const maxConcurrentTurns = 4
 
+// drainGrace bounds how long Stop waits for in-flight dispatches to finish
+// posting their replies. It is short so shutdown (and launchd's SIGTERM window)
+// is never held hostage by a slow turn; turns past the grace are abandoned at
+// process exit. The hub does not redeliver, so this is a best-effort flush.
+const drainGrace = 5 * time.Second
+
 // WebBot is the Reef hub ChatBot: it long-polls the Reef outbox for the owner's
 // messages, runs each through the shared core.ChatHandler, and posts replies
 // back to the Reef chat channel. It is the headless, web-app equivalent of the
@@ -43,7 +49,6 @@ func (w *WebBot) Start(ctx context.Context) error {
 		log.Warn("reef startup ping failed", "error", err)
 	}
 	log.Info("web (reef) bot started", "agent", reef.AgentID())
-	defer w.wg.Wait()
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -107,9 +112,20 @@ func (w *WebBot) dispatch(ctx context.Context, text string) {
 	}
 }
 
-// Stop waits for in-flight dispatches; the poll loop stops via its Start
-// context. Start also drains on its own, so this is safe to call independently.
-func (w *WebBot) Stop() error { w.wg.Wait(); return nil }
+// Stop waits up to drainGrace for in-flight dispatches to finish posting their
+// replies, then returns. The poll loop itself stops via the Start context, so
+// callers should cancel that context before calling Stop. Bounding the wait
+// keeps shutdown responsive even if a turn is mid-flight.
+func (w *WebBot) Stop() error {
+	done := make(chan struct{})
+	go func() { w.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(drainGrace):
+		log.Warn("reef web bot: drain timed out, some replies may still be in flight")
+	}
+	return nil
+}
 
 // sleepCtx sleeps for d or until ctx is cancelled, returning false if ctx ended.
 func sleepCtx(ctx context.Context, d time.Duration) bool {

--- a/internal/chat/web.go
+++ b/internal/chat/web.go
@@ -1,0 +1,72 @@
+package chat
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/reef"
+)
+
+// WebBot is the Reef hub ChatBot: it long-polls the Reef outbox for the owner's
+// messages, runs each through the shared core.ChatHandler, and posts replies
+// back to the Reef chat channel. It is the headless, web-app equivalent of the
+// Telegram and Discord bots and satisfies core.ChatBot.
+type WebBot struct {
+	handler core.ChatHandler
+}
+
+// NewWebBot creates a WebBot bound to the shared chat handler.
+func NewWebBot(handler core.ChatHandler) *WebBot {
+	return &WebBot{handler: handler}
+}
+
+// Platform identifies this bot for owner-gating and notifier routing.
+func (w *WebBot) Platform() string { return "web" }
+
+// Start posts a presence ping then long-polls the Reef outbox until ctx is
+// cancelled, dispatching each owner message to the handler.
+func (w *WebBot) Start(ctx context.Context) error {
+	if err := reef.PostIngest("chat", "status", "Mini-Krill online on Reef."); err != nil {
+		log.Warn("reef startup ping failed", "error", err)
+	}
+	log.Info("web (reef) bot started", "agent", reef.AgentID())
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+		items, err := reef.PollOutbox(25)
+		if err != nil {
+			time.Sleep(5 * time.Second)
+			continue
+		}
+		for _, it := range items {
+			text := strings.TrimSpace(it.Text)
+			if text == "" {
+				continue
+			}
+			msg := core.ChatMessage{
+				Platform: "web", ChatID: "reef", UserID: "owner",
+				Username: "owner", Text: text,
+			}
+			resp, herr := w.handler.HandleMessage(ctx, msg)
+			if herr != nil {
+				log.Error("web handler error", "error", herr)
+				resp = "I hit an error processing that."
+			}
+			if strings.TrimSpace(resp) == "" {
+				continue
+			}
+			if err := reef.PostIngest("chat", "chat", resp); err != nil {
+				log.Error("reef reply post failed", "error", err)
+			}
+		}
+	}
+}
+
+// Stop is a no-op; the bot stops when its Start context is cancelled.
+func (w *WebBot) Stop() error { return nil }

--- a/internal/chat/web.go
+++ b/internal/chat/web.go
@@ -3,6 +3,7 @@ package chat
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/srvsngh99/mini-krill/internal/core"
@@ -10,38 +11,52 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/reef"
 )
 
+// maxConcurrentTurns bounds how many owner messages WebBot processes at once.
+// The owner is a single human, so concurrency above a small number only means
+// a flood of queued messages would spawn unbounded goroutines; this caps it.
+const maxConcurrentTurns = 4
+
 // WebBot is the Reef hub ChatBot: it long-polls the Reef outbox for the owner's
 // messages, runs each through the shared core.ChatHandler, and posts replies
 // back to the Reef chat channel. It is the headless, web-app equivalent of the
 // Telegram and Discord bots and satisfies core.ChatBot.
 type WebBot struct {
 	handler core.ChatHandler
+	sem     chan struct{}  // bounds concurrent dispatches
+	wg      sync.WaitGroup // tracks in-flight dispatches for graceful drain
 }
 
 // NewWebBot creates a WebBot bound to the shared chat handler.
 func NewWebBot(handler core.ChatHandler) *WebBot {
-	return &WebBot{handler: handler}
+	return &WebBot{handler: handler, sem: make(chan struct{}, maxConcurrentTurns)}
 }
 
 // Platform identifies this bot for owner-gating and notifier routing.
 func (w *WebBot) Platform() string { return "web" }
 
 // Start posts a presence ping then long-polls the Reef outbox until ctx is
-// cancelled, dispatching each owner message to the handler.
+// cancelled, dispatching each owner message to the handler. On shutdown it
+// waits for in-flight dispatches to finish so replies the hub already marked
+// delivered are not silently dropped (the hub does not redeliver).
 func (w *WebBot) Start(ctx context.Context) error {
 	if err := reef.PostIngest("chat", "status", "Mini-Krill online on Reef."); err != nil {
 		log.Warn("reef startup ping failed", "error", err)
 	}
 	log.Info("web (reef) bot started", "agent", reef.AgentID())
+	defer w.wg.Wait()
 	for {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return nil
-		default:
 		}
-		items, err := reef.PollOutbox(25)
+		items, err := reef.PollOutbox(ctx, 25)
 		if err != nil {
-			time.Sleep(5 * time.Second)
+			if ctx.Err() != nil {
+				return nil
+			}
+			log.Warn("reef outbox poll failed", "error", err)
+			if !sleepCtx(ctx, 5*time.Second) {
+				return nil
+			}
 			continue
 		}
 		for _, it := range items {
@@ -49,9 +64,26 @@ func (w *WebBot) Start(ctx context.Context) error {
 			if text == "" {
 				continue
 			}
-			// Dispatch in a goroutine so a slow agent turn never stalls the
-			// poll loop (HandleMessage can run a full plan/execute cycle).
-			go w.dispatch(ctx, text)
+			// Acquire a slot before spawning so a burst of queued owner
+			// messages cannot spawn unbounded goroutines. Block (respecting
+			// ctx) until a slot frees, since the hub has already drained and
+			// marked these items delivered; dropping them would lose them.
+			select {
+			case w.sem <- struct{}{}:
+			case <-ctx.Done():
+				return nil
+			}
+			w.wg.Add(1)
+			go func(text string) {
+				defer w.wg.Done()
+				defer func() { <-w.sem }()
+				// Detach from ctx for the turn body so an in-flight reply still
+				// posts during shutdown drain, but cap it with turnDeadline so a
+				// hung turn cannot leak forever (parity with telegram/discord).
+				turnCtx, cancel := context.WithTimeout(context.Background(), turnDeadline)
+				defer cancel()
+				w.dispatch(turnCtx, text)
+			}(text)
 		}
 	}
 }
@@ -75,5 +107,18 @@ func (w *WebBot) dispatch(ctx context.Context, text string) {
 	}
 }
 
-// Stop is a no-op; the bot stops when its Start context is cancelled.
-func (w *WebBot) Stop() error { return nil }
+// Stop waits for in-flight dispatches; the poll loop stops via its Start
+// context. Start also drains on its own, so this is safe to call independently.
+func (w *WebBot) Stop() error { w.wg.Wait(); return nil }
+
+// sleepCtx sleeps for d or until ctx is cancelled, returning false if ctx ended.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/internal/reef/client.go
+++ b/internal/reef/client.go
@@ -6,6 +6,7 @@ package reef
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -71,13 +72,16 @@ type OutboxItem struct {
 	Text string `json:"text"`
 }
 
-// PollOutbox long-polls the hub for owner messages (waitSeconds <= 50).
-func PollOutbox(waitSeconds int) ([]OutboxItem, error) {
+// PollOutbox long-polls the hub for owner messages (waitSeconds <= 50). The
+// ctx aborts the in-flight request on shutdown so the caller does not block for
+// the full long-poll window. The hub blocks server-side up to waitSeconds when
+// the queue is empty (it does not return early), so callers do not spin.
+func PollOutbox(ctx context.Context, waitSeconds int) ([]OutboxItem, error) {
 	if !IsConfigured() {
 		return nil, nil
 	}
 	url := fmt.Sprintf("%s/api/outbox?agent=%s&wait=%d", baseURL(), AgentID(), waitSeconds)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -87,6 +91,10 @@ func PollOutbox(waitSeconds int) ([]OutboxItem, error) {
 		return nil, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("reef outbox: status %d", resp.StatusCode)
+	}
 	var out struct {
 		Items []OutboxItem `json:"items"`
 	}

--- a/internal/reef/client.go
+++ b/internal/reef/client.go
@@ -1,0 +1,97 @@
+// Package reef connects Mini-Krill to the Reef messaging hub: it posts the
+// agent's messages and long-polls for the owner's replies. When
+// REEF_INGEST_URL / REEF_AGENT_TOKEN are unset the client is inert
+// (IsConfigured returns false) and Mini-Krill uses its other channels.
+package reef
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+func baseURL() string   { return strings.TrimRight(os.Getenv("REEF_INGEST_URL"), "/") }
+func authToken() string { return os.Getenv("REEF_AGENT_TOKEN") }
+
+// AgentID is this agent's id in Reef (default "minikrill").
+func AgentID() string {
+	if v := os.Getenv("REEF_AGENT_ID"); v != "" {
+		return v
+	}
+	return "minikrill"
+}
+
+// IsConfigured reports whether the Reef hub URL and token are both set.
+func IsConfigured() bool { return baseURL() != "" && authToken() != "" }
+
+type ingestPayload struct {
+	Agent   string `json:"agent"`
+	Channel string `json:"channel"`
+	Kind    string `json:"kind"`
+	Format  string `json:"format"`
+	Content string `json:"content"`
+}
+
+// PostIngest delivers one message to the Reef hub.
+func PostIngest(channel, kind, content string) error {
+	if !IsConfigured() {
+		return nil
+	}
+	body, err := json.Marshal(ingestPayload{AgentID(), channel, kind, "md", content})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequest(http.MethodPost, baseURL()+"/api/ingest", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("reef ingest: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
+// OutboxItem is one owner->agent message returned by the long-poll.
+type OutboxItem struct {
+	ID   string `json:"id"`
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+// PollOutbox long-polls the hub for owner messages (waitSeconds <= 50).
+func PollOutbox(waitSeconds int) ([]OutboxItem, error) {
+	if !IsConfigured() {
+		return nil, nil
+	}
+	url := fmt.Sprintf("%s/api/outbox?agent=%s&wait=%d", baseURL(), AgentID(), waitSeconds)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: time.Duration(waitSeconds+10) * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Items []OutboxItem `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Items, nil
+}


### PR DESCRIPTION
## Why

Part of moving the Krill colony off Telegram and onto the Reef hub (the agent-centric messaging app). This PR makes Mini-Krill run headless on Reef as a `core.ChatBot`.

## What changed

- `internal/reef/client.go` (new) - dependency-free Reef client. `PostIngest` posts messages; `PollOutbox` long-polls the owner outbox (ctx-aware, checks HTTP status). Inert unless `REEF_INGEST_URL` + `REEF_AGENT_TOKEN` are set.
- `internal/chat/web.go` (new) - `WebBot` (`Platform()` = `web`): long-polls the outbox and runs each owner message through the shared `ChatHandler`. Dispatches are bounded by a semaphore and each turn runs under `turnDeadline`, so a burst cannot spawn unbounded goroutines and a hung turn cannot leak. On shutdown a bounded `Stop()` drains in-flight turns (the hub marks outbox items delivered on drain and does not redeliver).
- `cmd/minikrill/commands.go` - `startBots` runs web-only when Reef is configured (one adapter at a time), registers a `web` task notifier, and drains the WebBot after `cancel()` in both the dive daemon and TUI shutdown paths.
- `cmd/minikrill/main.go` - fixes a latent `friendlyError(nil)` panic; drops the em-dash from the root command summary.

## How it was tested

- `go build ./...`, `go vet ./...`, `gofmt -l` clean; `go test ./internal/chat/...` and `go test -race ./internal/chat/...` pass.
- Ran `minikrill dive` live against the Reef hub: posts status and answers owner DMs.
- Three adversarial review rounds; round 3 verified the shutdown drain is actually wired in, bounded by `drainGrace`, and free of deadlock or goroutine leak.
