### PR TITLE
Reef WebBot: at-least-once delivery (lease, ack, dedup)

### DIFF
--- a/internal/chat/seenset_test.go
+++ b/internal/chat/seenset_test.go
@@ -1,0 +1,34 @@
+package chat
+
+import "testing"
+
+func TestSeenSetDedup(t *testing.T) {
+	s := newSeenSet(3)
+	if !s.take("a") {
+		t.Fatal("first take of a should be new")
+	}
+	if s.take("a") {
+		t.Fatal("second take of a should be a duplicate")
+	}
+}
+
+func TestSeenSetEmptyIDNeverDedups(t *testing.T) {
+	s := newSeenSet(3)
+	if !s.take("") || !s.take("") {
+		t.Fatal("empty id must always be treated as new (never deduped)")
+	}
+}
+
+func TestSeenSetEviction(t *testing.T) {
+	s := newSeenSet(3)
+	s.take("a")
+	s.take("b")
+	s.take("c")
+	s.take("d") // exceeds max 3 -> oldest ("a") evicted
+	if s.take("b") {
+		t.Fatal("b should still be remembered (within window)")
+	}
+	if !s.take("a") {
+		t.Fatal("a should have been evicted and read as new again")
+	}
+}

--- a/internal/chat/web.go
+++ b/internal/chat/web.go
@@ -41,19 +41,23 @@ func NewWebBot(handler core.ChatHandler) *WebBot {
 func (w *WebBot) Platform() string { return "web" }
 
 // Start posts a presence ping then long-polls the Reef outbox until ctx is
-// cancelled, dispatching each owner message to the handler. On shutdown it
-// waits for in-flight dispatches to finish so replies the hub already marked
-// delivered are not silently dropped (the hub does not redeliver).
+// cancelled, dispatching each owner message to the handler. Delivery is
+// at-least-once: it polls with ack=1 (the hub leases items rather than consuming
+// them), acks each item once its turn finishes, and dedupes redeliveries by id.
+// A crash between pulling an item and acking leaves it leased, so the hub
+// redelivers it rather than dropping the owner message. On shutdown it waits for
+// in-flight dispatches to finish so their replies still post and ack.
 func (w *WebBot) Start(ctx context.Context) error {
 	if err := reef.PostIngest("chat", "status", "Mini-Krill online on Reef."); err != nil {
 		log.Warn("reef startup ping failed", "error", err)
 	}
 	log.Info("web (reef) bot started", "agent", reef.AgentID())
+	seen := newSeenSet(1000)
 	for {
 		if ctx.Err() != nil {
 			return nil
 		}
-		items, err := reef.PollOutbox(ctx, 25)
+		items, err := reef.PollOutbox(ctx, 25, true)
 		if err != nil {
 			if ctx.Err() != nil {
 				return nil
@@ -65,21 +69,27 @@ func (w *WebBot) Start(ctx context.Context) error {
 			continue
 		}
 		for _, it := range items {
+			// A redelivery of an item we already took: re-ack it, in case our
+			// earlier ack was lost (otherwise it redelivers-and-skips forever).
+			if !seen.take(it.ID) {
+				_ = reef.Ack(ctx, []string{it.ID})
+				continue
+			}
 			text := strings.TrimSpace(it.Text)
 			if text == "" {
+				_ = reef.Ack(ctx, []string{it.ID}) // consume empty items
 				continue
 			}
 			// Acquire a slot before spawning so a burst of queued owner
 			// messages cannot spawn unbounded goroutines. Block (respecting
-			// ctx) until a slot frees, since the hub has already drained and
-			// marked these items delivered; dropping them would lose them.
+			// ctx) until a slot frees.
 			select {
 			case w.sem <- struct{}{}:
 			case <-ctx.Done():
 				return nil
 			}
 			w.wg.Add(1)
-			go func(text string) {
+			go func(id, text string) {
 				defer w.wg.Done()
 				defer func() { <-w.sem }()
 				// Detach from ctx for the turn body so an in-flight reply still
@@ -88,9 +98,46 @@ func (w *WebBot) Start(ctx context.Context) error {
 				turnCtx, cancel := context.WithTimeout(context.Background(), turnDeadline)
 				defer cancel()
 				w.dispatch(turnCtx, text)
-			}(text)
+				// Ack once handled so the hub stops redelivering. Detached +
+				// short timeout so it still completes during shutdown drain.
+				ackCtx, ackCancel := context.WithTimeout(context.Background(), 15*time.Second)
+				defer ackCancel()
+				if err := reef.Ack(ackCtx, []string{id}); err != nil {
+					log.Warn("reef ack failed", "error", err)
+				}
+			}(it.ID, text)
 		}
 	}
+}
+
+// seenSet is a bounded FIFO set of ids for at-least-once dedup. It is touched
+// only by the single Start goroutine, so it needs no locking.
+type seenSet struct {
+	max   int
+	ids   map[string]bool
+	order []string
+}
+
+func newSeenSet(max int) *seenSet {
+	return &seenSet{max: max, ids: make(map[string]bool)}
+}
+
+// take records id and returns true if it had not been seen before. An empty id
+// is always treated as new (never deduped).
+func (s *seenSet) take(id string) bool {
+	if id == "" {
+		return true
+	}
+	if s.ids[id] {
+		return false
+	}
+	s.ids[id] = true
+	s.order = append(s.order, id)
+	if len(s.order) > s.max {
+		delete(s.ids, s.order[0])
+		s.order = s.order[1:]
+	}
+	return true
 }
 
 // dispatch runs one owner message through the handler and posts the reply.

--- a/internal/reef/client.go
+++ b/internal/reef/client.go
@@ -76,11 +76,19 @@ type OutboxItem struct {
 // ctx aborts the in-flight request on shutdown so the caller does not block for
 // the full long-poll window. The hub blocks server-side up to waitSeconds when
 // the queue is empty (it does not return early), so callers do not spin.
-func PollOutbox(ctx context.Context, waitSeconds int) ([]OutboxItem, error) {
+//
+// When ack is true the hub LEASES items instead of consuming them: the caller
+// must Ack each item id once handled, and an unacked item is redelivered after
+// the lease expires (at-least-once). When false the hub consumes items on pull
+// (legacy at-most-once).
+func PollOutbox(ctx context.Context, waitSeconds int, ack bool) ([]OutboxItem, error) {
 	if !IsConfigured() {
 		return nil, nil
 	}
 	url := fmt.Sprintf("%s/api/outbox?agent=%s&wait=%d", baseURL(), AgentID(), waitSeconds)
+	if ack {
+		url += "&ack=1"
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
@@ -102,4 +110,34 @@ func PollOutbox(ctx context.Context, waitSeconds int) ([]OutboxItem, error) {
 		return nil, err
 	}
 	return out.Items, nil
+}
+
+// Ack acknowledges handled outbox items so the hub stops redelivering them.
+// Pair with PollOutbox(ctx, wait, true). Best-effort from the caller's view: a
+// failed ack just means the item's lease expires and it is redelivered, which
+// the caller dedupes.
+func Ack(ctx context.Context, ids []string) error {
+	if !IsConfigured() || len(ids) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(map[string]any{"agent": AgentID(), "ids": ids})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL()+"/api/ack", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("reef ack: status %d", resp.StatusCode)
+	}
+	return nil
 }


### PR DESCRIPTION
## Why
The Reef hub now supports at-least-once delivery (lease + ack), but Mini-Krill's WebBot still consumed outbox items on pull (at-most-once), so a crash between pulling an owner message and posting the reply silently dropped it.

## What changed
- `internal/reef/client.go`: `PollOutbox(ctx, wait, ack)` adds `&ack=1`; new `Ack(ctx, ids)` POSTs `/api/ack`.
- `internal/chat/web.go`: the WebBot polls with `ack=true`, acks each item inside its dispatch goroutine once the turn finishes (detached + 15s timeout so it still completes during shutdown drain), consumes empty items, and dedupes redeliveries via a bounded `seenSet` (touched only by the single Start goroutine). An already-seen redelivery is re-acked so a lost ack self-heals.
- `seenset_test.go`: unit tests for dedup, empty-id, FIFO eviction.

## How it was tested
- `go build ./...`, `go vet`, `go test ./internal/chat -run TestSeenSet` all pass. Hub side already merged + deployed; legacy and ack pollers coexist, so this rolls out independently.