### PR TITLE
Fix broken build: restore brand terminal-mark constants

### DIFF
--- a/internal/brand/brand.go
+++ b/internal/brand/brand.go
@@ -10,6 +10,15 @@ const (
 	Attribution = "by Sourav Singh / Sourav AI Labs"
 	Tagline     = "Local-first AI agent with a crustaceous soul"
 	Credits     = "Inspired by Jarvis and OpenClaw"
+
+	// Terminal-prompt lockup marks used by the CLI banner (cmd/minikrill).
+	// They render as:
+	//   >_ mini-krill   v0.1.4
+	//   > SAI_  Sourav AI Labs  ·  souravailabs.ai
+	Wordmark = ">_ mini-krill"   // bold product wordmark
+	LabMark  = "> SAI_"          // Sourav AI Labs terminal monogram
+	Lab      = Studio            // "Sourav AI Labs"
+	Site     = "souravailabs.ai" // public site
 )
 
 // Mark is an ASCII krill/shrimp silhouette inspired by the circular logo.


### PR DESCRIPTION
## Why
`cmd/minikrill/main.go` references `brand.Wordmark`, `brand.LabMark`, `brand.Lab`, and `brand.Site` for its banner lockup, but those constants are not defined in the `brand` package, so `go build ./cmd/minikrill` fails with `undefined: brand.Wordmark` (etc.). main does not build, which also blocks deploying the merged Reef WebBot at-least-once change (#43).

## What changed
- Add the four missing constants to `internal/brand/brand.go` with the exact values the banner already renders (confirmed from the running binary's output and the `printBanner` doc comment):
  - `Wordmark = ">_ mini-krill"`
  - `LabMark  = "> SAI_"`
  - `Lab      = Studio` ("Sourav AI Labs")
  - `Site     = "souravailabs.ai"`

## How it was tested
- `go build ./...` and `go vet ./...` pass (previously failed). The CLI banner renders identically: `>_ mini-krill ...` and `> SAI_  Sourav AI Labs  ·  souravailabs.ai`. No behaviour change beyond making the package compile.