### PR TITLE
Add Reef client + WebBot unit tests

### DIFF
--- a/internal/chat/webbot_test.go
+++ b/internal/chat/webbot_test.go
@@ -1,0 +1,98 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+type stubHandler struct {
+	gotText atomic.Value // string
+	reply   string
+}
+
+func (h *stubHandler) HandleMessage(ctx context.Context, msg core.ChatMessage) (string, error) {
+	h.gotText.Store(msg.Text)
+	return h.reply, nil
+}
+
+// WebBot should long-poll the outbox, run the owner message through the handler,
+// post the reply, and ack the item (the at-least-once contract).
+func TestWebBotDispatchesRepliesAndAcks(t *testing.T) {
+	var polls int32
+	var posted, ackedID atomic.Value
+	ackCh := make(chan struct{}, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/outbox":
+			// First poll yields one item; later polls block briefly then return
+			// empty, so the loop does not busy-spin during the test.
+			if atomic.AddInt32(&polls, 1) == 1 {
+				json.NewEncoder(w).Encode(map[string]any{
+					"items": []map[string]string{{"id": "w1", "type": "reply", "text": "ping"}},
+				})
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+			io.WriteString(w, `{"items":[]}`)
+		case "/api/ingest":
+			var p map[string]any
+			json.NewDecoder(r.Body).Decode(&p)
+			if c, _ := p["content"].(string); c != "" && c != "Mini-Krill online on Reef." {
+				posted.Store(c)
+			}
+			io.WriteString(w, `{"ok":true,"id":"r"}`)
+		case "/api/ack":
+			var b struct {
+				IDs []string `json:"ids"`
+			}
+			json.NewDecoder(r.Body).Decode(&b)
+			if len(b.IDs) > 0 {
+				ackedID.Store(b.IDs[0])
+			}
+			io.WriteString(w, `{"ok":true,"acked":1}`)
+			select {
+			case ackCh <- struct{}{}:
+			default:
+			}
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("REEF_INGEST_URL", srv.URL)
+	t.Setenv("REEF_AGENT_TOKEN", "tok")
+	t.Setenv("REEF_AGENT_ID", "minikrill")
+
+	h := &stubHandler{reply: "pong"}
+	bot := NewWebBot(h)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { bot.Start(ctx); close(done) }()
+
+	select {
+	case <-ackCh:
+	case <-time.After(5 * time.Second):
+		cancel()
+		t.Fatal("item was never acked")
+	}
+	cancel()
+	<-done
+
+	if got, _ := h.gotText.Load().(string); got != "ping" {
+		t.Fatalf("handler received %q, want %q", got, "ping")
+	}
+	if got, _ := posted.Load().(string); got != "pong" {
+		t.Fatalf("reply posted %q, want %q", got, "pong")
+	}
+	if got, _ := ackedID.Load().(string); got != "w1" {
+		t.Fatalf("acked id %q, want %q", got, "w1")
+	}
+}

--- a/internal/reef/client_test.go
+++ b/internal/reef/client_test.go
@@ -1,0 +1,160 @@
+package reef
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// configure points the client at a mock hub for the duration of a test.
+func configure(t *testing.T, url string) {
+	t.Helper()
+	t.Setenv("REEF_INGEST_URL", url)
+	t.Setenv("REEF_AGENT_TOKEN", "test-token")
+	t.Setenv("REEF_AGENT_ID", "minikrill")
+}
+
+func TestIsConfigured(t *testing.T) {
+	t.Setenv("REEF_INGEST_URL", "")
+	t.Setenv("REEF_AGENT_TOKEN", "")
+	if IsConfigured() {
+		t.Fatal("IsConfigured should be false with no env")
+	}
+	configure(t, "http://example.test")
+	if !IsConfigured() {
+		t.Fatal("IsConfigured should be true once url+token are set")
+	}
+}
+
+func TestPollOutboxLeasesWithAck(t *testing.T) {
+	var gotPath, gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.String()
+		gotToken = r.Header.Get("X-Reef-Token")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]string{{"id": "m1", "type": "reply", "text": "hi"}},
+		})
+	}))
+	defer srv.Close()
+	configure(t, srv.URL)
+
+	items, err := PollOutbox(context.Background(), 0, true)
+	if err != nil {
+		t.Fatalf("PollOutbox: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != "m1" || items[0].Text != "hi" {
+		t.Fatalf("unexpected items: %+v", items)
+	}
+	if gotToken != "test-token" {
+		t.Fatalf("missing/incorrect token header: %q", gotToken)
+	}
+	if !contains(gotPath, "ack=1") {
+		t.Fatalf("ack=1 not sent in lease mode: %q", gotPath)
+	}
+	if !contains(gotPath, "agent=minikrill") {
+		t.Fatalf("agent not sent: %q", gotPath)
+	}
+}
+
+func TestPollOutboxLegacyHasNoAck(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.String()
+		io.WriteString(w, `{"items":[]}`)
+	}))
+	defer srv.Close()
+	configure(t, srv.URL)
+
+	if _, err := PollOutbox(context.Background(), 0, false); err != nil {
+		t.Fatalf("PollOutbox: %v", err)
+	}
+	if contains(gotPath, "ack=1") {
+		t.Fatalf("legacy poll must not send ack=1: %q", gotPath)
+	}
+}
+
+func TestPollOutboxSurfacesHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	configure(t, srv.URL)
+
+	if _, err := PollOutbox(context.Background(), 0, true); err == nil {
+		t.Fatal("expected an error on 401")
+	}
+}
+
+func TestAckPostsIDs(t *testing.T) {
+	var body struct {
+		Agent string   `json:"agent"`
+		IDs   []string `json:"ids"`
+	}
+	var gotPath, gotToken string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotToken = r.Header.Get("X-Reef-Token")
+		json.NewDecoder(r.Body).Decode(&body)
+		io.WriteString(w, `{"ok":true,"acked":1}`)
+	}))
+	defer srv.Close()
+	configure(t, srv.URL)
+
+	if err := Ack(context.Background(), []string{"m1", "m2"}); err != nil {
+		t.Fatalf("Ack: %v", err)
+	}
+	if gotPath != "/api/ack" {
+		t.Fatalf("ack hit wrong path: %q", gotPath)
+	}
+	if gotToken != "test-token" {
+		t.Fatalf("ack missing token: %q", gotToken)
+	}
+	if body.Agent != "minikrill" || len(body.IDs) != 2 || body.IDs[0] != "m1" {
+		t.Fatalf("ack body wrong: %+v", body)
+	}
+}
+
+func TestAckNoopOnEmpty(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+	defer srv.Close()
+	configure(t, srv.URL)
+
+	if err := Ack(context.Background(), nil); err != nil {
+		t.Fatalf("Ack(nil): %v", err)
+	}
+	if called {
+		t.Fatal("Ack with no ids must not hit the network")
+	}
+}
+
+func TestPostIngest(t *testing.T) {
+	var payload ingestPayload
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewDecoder(r.Body).Decode(&payload)
+		io.WriteString(w, `{"ok":true,"id":"x"}`)
+	}))
+	defer srv.Close()
+	configure(t, srv.URL)
+
+	if err := PostIngest("chat", "chat", "hello owner"); err != nil {
+		t.Fatalf("PostIngest: %v", err)
+	}
+	if payload.Agent != "minikrill" || payload.Channel != "chat" || payload.Content != "hello owner" {
+		t.Fatalf("ingest payload wrong: %+v", payload)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Why
The Reef client and Mini-Krill WebBot had no unit tests despite three rounds of at-least-once concurrency work (decision 4 in agent-reef-onboarding-feedback.md).

## What changed
- `internal/reef/client_test.go`: httptest-mocked `PollOutbox` (sends `ack=1` in lease mode, omits it in legacy, surfaces HTTP errors), `Ack` (POSTs `{agent, ids}`, no-op on empty), `PostIngest`, `IsConfigured`.
- `internal/chat/webbot_test.go`: end-to-end WebBot test against a mock hub - one queued item is long-polled, dispatched through a stub `core.ChatHandler`, its reply posted, and the item acked. Runs race-clean.

## How it was tested
- `go test -race ./internal/chat/... ./internal/reef/...` passes. Test-only change.