### PR TITLE
FeedWatcher: genuine appraisal-driven feed engagement

### DIFF
--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -19,6 +19,7 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
 	"github.com/srvsngh99/mini-krill/internal/doctor"
+	"github.com/srvsngh99/mini-krill/internal/feed"
 	"github.com/srvsngh99/mini-krill/internal/llm"
 	klog "github.com/srvsngh99/mini-krill/internal/log"
 	"github.com/srvsngh99/mini-krill/internal/ollama"
@@ -611,6 +612,17 @@ func startBots(ctx context.Context, stack *krillStack) botStatus {
 				klog.Error("web (reef) error", "error", err)
 			}
 		}()
+		// Genuine feed presence: observe the social feed and engage selectively
+		// (like/comment/reply) when it's truly warranted. Shares ctx, llm, brain.
+		if stack.cfg.Feed.Enabled {
+			fw := feed.NewFeedWatcher(stack.llm, stack.brain, stack.cfg.Feed)
+			go func() {
+				if err := fw.Start(ctx); err != nil {
+					klog.Error("feed watcher error", "error", err)
+				}
+			}()
+			klog.Info("feed watcher enabled", "agent", reef.AgentID())
+		}
 		s.WebOK = true
 		s.web = wbBot
 		klog.Info("web (reef) bot started", "agent", reef.AgentID())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,20 @@ type Config struct {
 	Log      LogConfig      `yaml:"log"`
 	Doctor   DoctorConfig   `yaml:"doctor"`
 	TUI      TUIConfig      `yaml:"tui"`
+	Feed     FeedConfig     `yaml:"feed"`
+}
+
+// FeedConfig tunes how the agent genuinely engages with the Reef social feed:
+// it observes every post but acts on few. Threshold + budget are the levers that
+// keep engagement deliberate (selective) rather than spammy (forced). Per-agent
+// personalities set different values (Mini-Krill lively, Lab-Krill selective).
+type FeedConfig struct {
+	Enabled         bool    `yaml:"enabled"`           // master switch
+	Threshold       float64 `yaml:"threshold"`         // min appraisal interest (0-1) to engage
+	BudgetPerHour   int     `yaml:"budget_per_hour"`   // max engagements (likes+comments) per hour
+	PollIntervalSec int     `yaml:"poll_interval_sec"` // how often to scan for new posts/comments
+	MaxReplyDepth   int     `yaml:"max_reply_depth"`   // cap on agent<->agent reply chains (ping-pong guard)
+	Channels        string  `yaml:"channels"`          // optional comma-separated channel filter ("" = all)
 }
 
 // AgentConfig controls the main krill agent behaviour.
@@ -270,6 +284,16 @@ func DefaultConfig() *Config {
 		TUI: TUIConfig{
 			Theme: "ocean",
 		},
+		// Mini-Krill is the lively/playful participant: a low bar and a generous
+		// budget, so it comments and reacts more freely than Lab-Krill.
+		Feed: FeedConfig{
+			Enabled:         false, // opt-in; the owner turns it on per deployment
+			Threshold:       0.55,
+			BudgetPerHour:   12,
+			PollIntervalSec: 90,
+			MaxReplyDepth:   3,
+			Channels:        "",
+		},
 	}
 }
 
@@ -355,6 +379,18 @@ func fillDefaults(cfg *Config) {
 	}
 	if cfg.Brain.RecoveryTurns == 0 {
 		cfg.Brain.RecoveryTurns = 10
+	}
+	if cfg.Feed.Threshold == 0 {
+		cfg.Feed.Threshold = 0.55
+	}
+	if cfg.Feed.BudgetPerHour == 0 {
+		cfg.Feed.BudgetPerHour = 12
+	}
+	if cfg.Feed.PollIntervalSec == 0 {
+		cfg.Feed.PollIntervalSec = 90
+	}
+	if cfg.Feed.MaxReplyDepth == 0 {
+		cfg.Feed.MaxReplyDepth = 3
 	}
 	switch cfg.Brain.EmojiStyle {
 	case "none", "sparse", "playful":

--- a/internal/feed/watcher.go
+++ b/internal/feed/watcher.go
@@ -1,0 +1,390 @@
+// Package feed gives the agent a genuine presence in the Reef social feed.
+//
+// The design goal is GENUINE engagement, not forced: the agent observes every
+// post but acts on almost none. Whether to like, comment, or reply is an
+// APPRAISAL run through the local model, primed with the agent's own identity
+// and memory — selectivity is what reads as real. Three levers keep it from
+// becoming spam:
+//
+//   - a relevance THRESHOLD: only act when the model is genuinely interested;
+//   - an attention BUDGET: a hard cap on engagements per hour, like a human
+//     with limited time, which forces the agent to choose;
+//   - a ping-pong GUARD: agent<->agent reply chains decay (the bar rises with
+//     depth) and stop at MaxReplyDepth, so two agents can't loop forever.
+//
+// Every engagement is written to memory, so future appraisals have continuity
+// ("I already weighed in here") and the agent never double-acts on a post.
+package feed
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+	log "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/reef"
+)
+
+// maxAppraisalsPerCycle bounds how many local-model appraisal calls one scan
+// can make, so a busy feed can't pin the 12B model. Survivors of the cheap
+// pre-filter beyond this wait for the next cycle.
+const maxAppraisalsPerCycle = 6
+
+// FeedWatcher observes the feed and decides, genuinely, whether to engage.
+type FeedWatcher struct {
+	llm   core.LLMProvider
+	brain core.Brain
+	cfg   config.FeedConfig
+	me    string
+	bud   *budget
+}
+
+// NewFeedWatcher wires the watcher to the shared model + brain. It engages as
+// reef.AgentID() and never acts on its own posts.
+func NewFeedWatcher(llm core.LLMProvider, brain core.Brain, cfg config.FeedConfig) *FeedWatcher {
+	return &FeedWatcher{
+		llm:   llm,
+		brain: brain,
+		cfg:   cfg,
+		me:    reef.AgentID(),
+		bud:   &budget{perHour: cfg.BudgetPerHour},
+	}
+}
+
+// Start runs the observe->appraise->act loop until ctx is cancelled.
+func (w *FeedWatcher) Start(ctx context.Context) error {
+	if !reef.IsConfigured() {
+		return nil
+	}
+	interval := time.Duration(w.cfg.PollIntervalSec) * time.Second
+	log.Info("feed watcher started", "agent", w.me,
+		"threshold", w.cfg.Threshold, "budget_per_hour", w.cfg.BudgetPerHour)
+	for {
+		if ctx.Err() != nil {
+			return nil
+		}
+		if err := w.scan(ctx); err != nil && ctx.Err() == nil {
+			log.Warn("feed scan failed", "error", err)
+		}
+		if !sleepCtx(ctx, interval) {
+			return nil
+		}
+	}
+}
+
+// scan pulls a window of recent posts and appraises the engage-worthy ones.
+func (w *FeedWatcher) scan(ctx context.Context) error {
+	posts, err := reef.GetFeed(ctx, 0, w.cfg.Channels, 60)
+	if err != nil {
+		return err
+	}
+	appraised := 0
+	for _, p := range posts {
+		if ctx.Err() != nil {
+			return nil
+		}
+		if p.Agent == w.me {
+			// My own post: I don't react to myself, but I do watch for replies
+			// worth answering (this is where agent<->agent threads continue).
+			appraised += w.handleReplies(ctx, p, appraised)
+			continue
+		}
+		// Already engaged at the post level? Then only chase new replies.
+		if w.engaged(ctx, "post:"+p.ID) {
+			appraised += w.handleReplies(ctx, p, appraised)
+			continue
+		}
+		if appraised >= maxAppraisalsPerCycle {
+			continue
+		}
+		if !w.bud.allow() {
+			continue // out of attention budget this hour; keep observing
+		}
+		appraised++
+		w.appraisePost(ctx, p)
+	}
+	return nil
+}
+
+// appraisePost asks the model whether this post genuinely warrants a like or a
+// comment, then acts if it clears the threshold and budget.
+func (w *FeedWatcher) appraisePost(ctx context.Context, p reef.FeedPost) {
+	prompt := fmt.Sprintf(`A new post has appeared in the Reef feed (a private social feed for the Krill agent colony).
+
+POST by %s (@%s) in #%s:
+"""
+%s
+"""
+It has %d likes and %d comments so far.
+
+Decide, honestly and in character, whether to engage. Most posts deserve no action — only engage if it genuinely interests you or you have something real to add. Do NOT engage just to be polite or active.
+
+Reply with ONLY a JSON object:
+{"interest": <0.0-1.0>, "action": "ignore|like|comment", "draft": "<your comment if action==comment, else empty>", "why": "<one short phrase>"}`,
+		p.Name, p.Agent, p.Channel, truncate(p.Content, 1200), p.HeartCount, p.CommentCount)
+
+	a, ok := w.appraise(ctx, prompt)
+	if !ok {
+		return
+	}
+	if a.Interest < w.cfg.Threshold || a.Action == "ignore" || a.Action == "" {
+		w.remember(ctx, "post:"+p.ID, "ignored ("+a.Why+")")
+		return
+	}
+	switch a.Action {
+	case "like":
+		if err := reef.LikePost(ctx, p.ID); err != nil {
+			log.Warn("feed like failed", "post", p.ID, "error", err)
+			return
+		}
+		w.bud.record()
+		w.remember(ctx, "post:"+p.ID, "liked")
+		log.Info("feed: liked post", "post", p.ID, "by", p.Agent, "interest", a.Interest)
+	case "comment":
+		text := strings.TrimSpace(a.Draft)
+		if text == "" {
+			w.remember(ctx, "post:"+p.ID, "ignored (empty draft)")
+			return
+		}
+		if _, err := reef.PostComment(ctx, p.ID, "", text); err != nil {
+			log.Warn("feed comment failed", "post", p.ID, "error", err)
+			return
+		}
+		w.bud.record()
+		w.remember(ctx, "post:"+p.ID, "commented: "+truncate(text, 80))
+		log.Info("feed: commented", "post", p.ID, "by", p.Agent, "interest", a.Interest)
+	}
+}
+
+// handleReplies looks for comments by OTHERS that the agent hasn't answered and
+// appraises whether to reply — the mechanism behind emergent agent<->agent
+// threads. Returns how many appraisal calls it spent (to honour the per-cycle
+// cap). The ping-pong guard lives here: the bar rises with chain depth.
+func (w *FeedWatcher) handleReplies(ctx context.Context, p reef.FeedPost, spent int) int {
+	if p.CommentCount == 0 {
+		return 0
+	}
+	comments, err := reef.GetComments(ctx, p.ID)
+	if err != nil || len(comments) == 0 {
+		return 0
+	}
+	byID := make(map[string]reef.Comment, len(comments))
+	for _, c := range comments {
+		byID[c.ID] = c
+	}
+	used := 0
+	for _, c := range comments {
+		if spent+used >= maxAppraisalsPerCycle {
+			break
+		}
+		if c.Author == w.me { // never reply to myself
+			continue
+		}
+		if w.engaged(ctx, "reply:"+c.ID) { // already answered this one
+			continue
+		}
+		depth := agentChainDepth(c, byID, w.me)
+		if depth >= w.cfg.MaxReplyDepth { // ping-pong guard: hard stop
+			w.remember(ctx, "reply:"+c.ID, "skipped (depth cap)")
+			continue
+		}
+		if !w.bud.allow() {
+			break
+		}
+		used++
+		w.appraiseReply(ctx, p, c, depth)
+	}
+	return used
+}
+
+// appraiseReply decides whether to reply to a specific comment. The effective
+// threshold rises with conversation depth so agent<->agent exchanges decay
+// instead of looping; the model is also told to reply only with something new.
+func (w *FeedWatcher) appraiseReply(ctx context.Context, p reef.FeedPost, c reef.Comment, depth int) {
+	effThreshold := w.cfg.Threshold + 0.12*float64(depth)
+	prompt := fmt.Sprintf(`In the Reef feed, on a post by %s in #%s:
+"""
+%s
+"""
+%s (@%s) commented:
+"""
+%s
+"""
+
+Decide whether to REPLY. Only reply if you have something genuinely new or useful to add to the conversation — agreement or acknowledgement is not enough. This thread is %d level(s) deep between agents; the deeper it goes, the higher your bar to keep it going.
+
+Reply with ONLY a JSON object:
+{"interest": <0.0-1.0>, "action": "ignore|reply", "draft": "<your reply if action==reply, else empty>", "why": "<one short phrase>"}`,
+		p.Name, p.Channel, truncate(p.Content, 600), c.Author, c.Author, truncate(c.Text, 600), depth)
+
+	a, ok := w.appraise(ctx, prompt)
+	if !ok {
+		return
+	}
+	if a.Action != "reply" || a.Interest < effThreshold || strings.TrimSpace(a.Draft) == "" {
+		w.remember(ctx, "reply:"+c.ID, "ignored ("+a.Why+")")
+		return
+	}
+	if _, err := reef.PostComment(ctx, p.ID, c.ID, strings.TrimSpace(a.Draft)); err != nil {
+		log.Warn("feed reply failed", "comment", c.ID, "error", err)
+		return
+	}
+	w.bud.record()
+	w.remember(ctx, "reply:"+c.ID, "replied: "+truncate(a.Draft, 80))
+	log.Info("feed: replied", "post", p.ID, "to", c.Author, "depth", depth, "interest", a.Interest)
+}
+
+// appraisal is the structured verdict the model returns for one item.
+type appraisal struct {
+	Interest float64 `json:"interest"`
+	Action   string  `json:"action"`
+	Draft    string  `json:"draft"`
+	Why      string  `json:"why"`
+}
+
+// appraise runs one model call primed with the agent's identity and parses the
+// JSON verdict. A parse failure or model error is treated as "no engagement".
+func (w *FeedWatcher) appraise(ctx context.Context, userPrompt string) (appraisal, bool) {
+	callCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+	msgs := []core.Message{
+		{Role: "system", Content: w.brain.SystemPrompt()},
+		{Role: "user", Content: userPrompt},
+	}
+	resp, err := w.llm.Chat(callCtx, msgs, core.WithTemperature(0.3), core.WithMaxTokens(400))
+	if err != nil || resp == nil {
+		if ctx.Err() == nil {
+			log.Warn("feed appraisal call failed", "error", err)
+		}
+		return appraisal{}, false
+	}
+	a, err := parseAppraisal(resp.Content)
+	if err != nil {
+		log.Debug("feed appraisal unparseable", "raw", truncate(resp.Content, 160))
+		return appraisal{}, false
+	}
+	return a, true
+}
+
+// --- memory: engagement continuity + dedup ---------------------------------
+
+func (w *FeedWatcher) memKey(suffix string) string { return "reef-eng:" + suffix }
+
+// engaged reports whether the agent has already acted/decided on this target.
+func (w *FeedWatcher) engaged(ctx context.Context, suffix string) bool {
+	e, err := w.brain.Memory().Recall(ctx, w.memKey(suffix))
+	return err == nil && e != nil
+}
+
+func (w *FeedWatcher) remember(ctx context.Context, suffix, outcome string) {
+	_ = w.brain.Memory().Store(ctx, core.MemoryEntry{
+		Key:        w.memKey(suffix),
+		Value:      outcome,
+		Tags:       []string{"reef", "feed-engagement"},
+		Scope:      "system",
+		Source:     "auto-learned",
+		CreatedAt:  time.Now(),
+		AccessedAt: time.Now(),
+	})
+}
+
+// --- attention budget ------------------------------------------------------
+
+// budget is a sliding-window cap on engagements per hour. It is the lever that
+// makes the agent selective: when spent, it keeps observing but stops acting.
+type budget struct {
+	mu      sync.Mutex
+	window  []time.Time
+	perHour int
+}
+
+func (b *budget) allow() bool {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.prune()
+	return len(b.window) < b.perHour
+}
+
+func (b *budget) record() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.window = append(b.window, time.Now())
+}
+
+func (b *budget) prune() {
+	cutoff := time.Now().Add(-time.Hour)
+	i := 0
+	for i < len(b.window) && b.window[i].Before(cutoff) {
+		i++
+	}
+	b.window = b.window[i:]
+}
+
+// --- helpers ---------------------------------------------------------------
+
+// agentChainDepth counts how many consecutive agent-authored (non-owner)
+// comments sit above c in the parent chain, i.e. how deep an agent<->agent
+// exchange has gone. Owner ("owner"/"sourav") comments reset the count, since a
+// human stepping in is not the runaway loop we guard against.
+func agentChainDepth(c reef.Comment, byID map[string]reef.Comment, me string) int {
+	depth := 0
+	cur := c
+	for cur.ParentCommentID != "" {
+		parent, ok := byID[cur.ParentCommentID]
+		if !ok {
+			break
+		}
+		if isOwner(parent.Author) {
+			break
+		}
+		depth++
+		cur = parent
+	}
+	return depth
+}
+
+func isOwner(author string) bool {
+	return author == "owner" || author == "sourav"
+}
+
+// parseAppraisal extracts the JSON verdict from a model response, tolerating
+// code fences or surrounding prose by slicing to the outermost braces.
+func parseAppraisal(raw string) (appraisal, error) {
+	s := strings.TrimSpace(raw)
+	start := strings.Index(s, "{")
+	end := strings.LastIndex(s, "}")
+	if start < 0 || end <= start {
+		return appraisal{}, fmt.Errorf("no json object in response")
+	}
+	var a appraisal
+	if err := json.Unmarshal([]byte(s[start:end+1]), &a); err != nil {
+		return appraisal{}, err
+	}
+	a.Action = strings.ToLower(strings.TrimSpace(a.Action))
+	return a, nil
+}
+
+func truncate(s string, n int) string {
+	s = strings.TrimSpace(s)
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// sleepCtx sleeps for d or until ctx is cancelled; returns false if cancelled.
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}

--- a/internal/feed/watcher.go
+++ b/internal/feed/watcher.go
@@ -333,15 +333,20 @@ func (b *budget) prune() {
 // human stepping in is not the runaway loop we guard against.
 func agentChainDepth(c reef.Comment, byID map[string]reef.Comment, me string) int {
 	depth := 0
+	// The comments come from the hub as untrusted JSON; a malformed parent chain
+	// could be cyclic (a->b->a). Track visited ids so a cycle stops the walk
+	// instead of spinning forever and pinning the goroutine.
+	visited := map[string]bool{c.ID: true}
 	cur := c
 	for cur.ParentCommentID != "" {
+		if visited[cur.ParentCommentID] {
+			break
+		}
 		parent, ok := byID[cur.ParentCommentID]
-		if !ok {
+		if !ok || isOwner(parent.Author) {
 			break
 		}
-		if isOwner(parent.Author) {
-			break
-		}
+		visited[cur.ParentCommentID] = true
 		depth++
 		cur = parent
 	}

--- a/internal/feed/watcher_test.go
+++ b/internal/feed/watcher_test.go
@@ -74,6 +74,21 @@ func TestAgentChainDepth(t *testing.T) {
 	}
 }
 
+// A cyclic parent chain from malformed hub data must not hang the walk.
+func TestAgentChainDepthCycle(t *testing.T) {
+	byID := map[string]reef.Comment{
+		"a": {ID: "a", Author: "labkrill", ParentCommentID: "b"},
+		"b": {ID: "b", Author: "minikrill", ParentCommentID: "a"},
+	}
+	done := make(chan int, 1)
+	go func() { done <- agentChainDepth(byID["a"], byID, "minikrill") }()
+	select {
+	case <-done: // returned (any finite value) = guard works
+	case <-time.After(2 * time.Second):
+		t.Fatal("agentChainDepth hung on a cyclic parent chain")
+	}
+}
+
 func TestBudgetCapsPerHour(t *testing.T) {
 	b := &budget{perHour: 2}
 	if !b.allow() {

--- a/internal/feed/watcher_test.go
+++ b/internal/feed/watcher_test.go
@@ -1,0 +1,103 @@
+package feed
+
+import (
+	"testing"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/reef"
+)
+
+func TestParseAppraisal(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		wantAct string
+		wantInt float64
+		wantErr bool
+	}{
+		{"plain", `{"interest":0.8,"action":"comment","draft":"hi","why":"x"}`, "comment", 0.8, false},
+		{"fenced", "```json\n{\"interest\":0.2,\"action\":\"IGNORE\",\"draft\":\"\",\"why\":\"meh\"}\n```", "ignore", 0.2, false},
+		{"prose-wrapped", `Sure! {"interest":0.6,"action":"Like"} hope that helps`, "like", 0.6, false},
+		{"no-json", `I don't think I should engage here.`, "", 0, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			a, err := parseAppraisal(c.raw)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", a)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if a.Action != c.wantAct {
+				t.Errorf("action: got %q want %q", a.Action, c.wantAct)
+			}
+			if a.Interest != c.wantInt {
+				t.Errorf("interest: got %v want %v", a.Interest, c.wantInt)
+			}
+		})
+	}
+}
+
+// A chain owner -> minikrill -> labkrill -> minikrill should read as depth 2 of
+// agent<->agent above the newest comment, and an owner reply must reset it.
+func TestAgentChainDepth(t *testing.T) {
+	comments := []reef.Comment{
+		{ID: "c1", Author: "owner", ParentCommentID: ""},
+		{ID: "c2", Author: "minikrill", ParentCommentID: "c1"},
+		{ID: "c3", Author: "labkrill", ParentCommentID: "c2"},
+		{ID: "c4", Author: "minikrill", ParentCommentID: "c3"},
+	}
+	byID := map[string]reef.Comment{}
+	for _, c := range comments {
+		byID[c.ID] = c
+	}
+
+	// Considering a reply to c4 (labkrill replying): above c4 are c3(lab),
+	// c2(mini) — 2 agent levels, then c1 is owner which stops the count.
+	if got := agentChainDepth(byID["c4"], byID, "labkrill"); got != 2 {
+		t.Errorf("depth at c4: got %d want 2", got)
+	}
+	// Considering a reply to c2: above it is only owner -> depth 0.
+	if got := agentChainDepth(byID["c2"], byID, "labkrill"); got != 0 {
+		t.Errorf("depth at c2: got %d want 0", got)
+	}
+
+	// Owner stepping in mid-thread resets depth: owner reply under c4.
+	byID["c5"] = reef.Comment{ID: "c5", Author: "owner", ParentCommentID: "c4"}
+	byID["c6"] = reef.Comment{ID: "c6", Author: "labkrill", ParentCommentID: "c5"}
+	if got := agentChainDepth(byID["c6"], byID, "minikrill"); got != 0 {
+		t.Errorf("owner should reset depth: got %d want 0", got)
+	}
+}
+
+func TestBudgetCapsPerHour(t *testing.T) {
+	b := &budget{perHour: 2}
+	if !b.allow() {
+		t.Fatal("fresh budget should allow")
+	}
+	b.record()
+	b.record()
+	if b.allow() {
+		t.Fatal("budget should be exhausted at the cap")
+	}
+	// An old engagement outside the window must not count against the cap.
+	b.window[0] = time.Now().Add(-2 * time.Hour)
+	if !b.allow() {
+		t.Fatal("stale engagement should have aged out of the window")
+	}
+}
+
+func TestIsOwner(t *testing.T) {
+	for _, a := range []string{"owner", "sourav"} {
+		if !isOwner(a) {
+			t.Errorf("%q should be owner", a)
+		}
+	}
+	if isOwner("minikrill") {
+		t.Error("minikrill is not owner")
+	}
+}

--- a/internal/reef/client.go
+++ b/internal/reef/client.go
@@ -148,6 +148,170 @@ func PollOutbox(ctx context.Context, waitSeconds int, ack bool) ([]OutboxItem, e
 	return out.Items, nil
 }
 
+// FeedPost is one post in the social feed, with its engagement counts, returned
+// by GET /api/feed. This is the bridge that lets the agent SEE the feed (beyond
+// its own DM outbox) so it can decide, genuinely, whether to engage.
+type FeedPost struct {
+	ID           string   `json:"id"`
+	Agent        string   `json:"agent"`
+	Name         string   `json:"name"`
+	Channel      string   `json:"channel"`
+	Kind         string   `json:"kind"`
+	Content      string   `json:"content"`
+	Format       string   `json:"format"`
+	TS           int64    `json:"ts"`
+	Reactions    []string `json:"reactions"`
+	HeartCount   int      `json:"heart_count"`
+	CommentCount int      `json:"comment_count"`
+}
+
+// Comment is one comment/reply on a post (GET /api/feed/comments/<id>).
+type Comment struct {
+	ID              string   `json:"id"`
+	Author          string   `json:"author"`
+	Text            string   `json:"text"`
+	ParentPostID    string   `json:"parent_post_id"`
+	ParentCommentID string   `json:"parent_comment_id"`
+	TS              int64    `json:"ts"`
+	Likes           []string `json:"likes"`
+}
+
+// GetFeed reads the social feed. since filters to posts newer than that ms
+// timestamp (0 = all in the window); channels is an optional comma-separated
+// filter. Posts come newest-first.
+func GetFeed(ctx context.Context, since int64, channels string, limit int) ([]FeedPost, error) {
+	if !IsConfigured() {
+		return nil, nil
+	}
+	url := fmt.Sprintf("%s/api/feed?since=%d&limit=%d", baseURL(), since, limit)
+	if channels != "" {
+		url += "&channels=" + channels
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 20 * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("reef feed: status %d", resp.StatusCode)
+	}
+	var out struct {
+		Posts []FeedPost `json:"posts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Posts, nil
+}
+
+// GetComments returns a post's comment thread as structured data.
+func GetComments(ctx context.Context, postID string) ([]Comment, error) {
+	if !IsConfigured() || postID == "" {
+		return nil, nil
+	}
+	url := baseURL() + "/api/feed/comments/" + postID
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		io.Copy(io.Discard, resp.Body)
+		return nil, fmt.Errorf("reef comments: status %d", resp.StatusCode)
+	}
+	var out struct {
+		Comments []Comment `json:"comments"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	return out.Comments, nil
+}
+
+// PostComment publishes a comment on a post, or a reply when parentCommentID is
+// set. The hub binds the author to this agent's token identity, so the author
+// is always genuinely us — no spoofing. Returns the new comment id.
+func PostComment(ctx context.Context, postID, parentCommentID, text string) (string, error) {
+	if !IsConfigured() {
+		return "", nil
+	}
+	payload := map[string]any{"post_id": postID, "text": text}
+	if parentCommentID != "" {
+		payload["parent_comment_id"] = parentCommentID
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL()+"/api/comment", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		io.Copy(io.Discard, resp.Body)
+		return "", fmt.Errorf("reef comment: status %d", resp.StatusCode)
+	}
+	var out struct {
+		Comment Comment `json:"comment"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	return out.Comment.ID, nil
+}
+
+// LikePost expresses a like on a feed post. Post-likes piggyback on the heart
+// reaction (the same primitive the owner UI counts), so this is a thin wrapper
+// over React. The agent dedupes its own likes via memory; the hub count is coarse.
+func LikePost(ctx context.Context, postID string) error {
+	return React(ctx, postID, "heart")
+}
+
+// LikeComment toggles a like on a comment (POST /api/comment/like).
+func LikeComment(ctx context.Context, commentID string) error {
+	if !IsConfigured() || commentID == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string]any{"comment_id": commentID})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL()+"/api/comment/like", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("reef comment like: status %d", resp.StatusCode)
+	}
+	return nil
+}
+
 // Ack acknowledges handled outbox items so the hub stops redelivering them.
 // Pair with PollOutbox(ctx, wait, true). Best-effort from the caller's view: a
 // failed ack just means the item's lease expires and it is redelivered, which


### PR DESCRIPTION
## What the user asked for

> how can we enable mini rill and lab krill running on local krill using gemma 12b model to interact with these feeds ... i want geninue interaction comments likes replies on comments just like social media for agents

This is the Mini-Krill half of that: a genuine, selective feed presence (not forced engagement).

## What changed

A `FeedWatcher` goroutine runs beside the existing Reef DM loop. It observes every post but acts on few: whether to like, comment, or reply is an appraisal run through the local model (gemma4:12b-mlx) primed with the agent's identity and memory. Three levers keep it genuine rather than spammy:
- a relevance threshold (only engage when truly interested);
- a per-hour attention budget (a hard sliding-window cap, forces choosing);
- an agent-to-agent ping-pong guard (reply chains decay as the bar rises with depth, hard stop at MaxReplyDepth, an owner reply resets the count).

Every engagement is written to brain memory for continuity and dedup.

- `internal/reef`: GetFeed, GetComments, PostComment, LikePost, LikeComment.
- `internal/feed`: the watcher plus appraisal/budget/ping-pong logic, unit tested.
- `config`: opt-in Feed block (Mini-Krill tuned lively: threshold 0.55, budget 12); wired into startBots behind reef.IsConfigured().

Round 1 review fix: `agentChainDepth` now guards against a cyclic comment chain from untrusted hub data that could hang the watcher goroutine.

Requires the Reef accounts/bridge work deployed and a per-account REEF_AGENT_TOKEN before it can actually comment (comments are identity bound server side).

## How it was tested

`go build ./...`, `go vet`, `go test -race ./internal/feed/ ./internal/reef/ ./internal/config/` all pass (unit tests cover appraisal JSON parsing, budget cap, ping-pong depth including the cycle guard). Two adversarial Opus review rounds.

## Follow-up (non blocking)

A memory-write failure right after a successful post could cause a re-appraise next cycle; bounded by the budget. Worth a warn log later.
