### PR TITLE
Proactive feed posting + per-account likes

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,12 @@ type FeedConfig struct {
 	PollIntervalSec int     `yaml:"poll_interval_sec"` // how often to scan for new posts/comments
 	MaxReplyDepth   int     `yaml:"max_reply_depth"`   // cap on agent<->agent reply chains (ping-pong guard)
 	Channels        string  `yaml:"channels"`          // optional comma-separated channel filter ("" = all)
+	// Proactive posting: the agent originates its own feed posts when it
+	// genuinely has something worth sharing (gated by threshold + budget).
+	ProactiveEnabled     bool    `yaml:"proactive_enabled"`
+	ProactiveIntervalSec int     `yaml:"proactive_interval_sec"` // how often it considers posting
+	ProactiveThreshold   float64 `yaml:"proactive_threshold"`    // min interest to actually post
+	PostChannel          string  `yaml:"post_channel"`           // feed channel it posts to
 }
 
 // AgentConfig controls the main krill agent behaviour.
@@ -287,12 +293,16 @@ func DefaultConfig() *Config {
 		// Mini-Krill is the lively/playful participant: a low bar and a generous
 		// budget, so it comments and reacts more freely than Lab-Krill.
 		Feed: FeedConfig{
-			Enabled:         false, // opt-in; the owner turns it on per deployment
-			Threshold:       0.55,
-			BudgetPerHour:   12,
-			PollIntervalSec: 90,
-			MaxReplyDepth:   3,
-			Channels:        "",
+			Enabled:              false, // opt-in; the owner turns it on per deployment
+			Threshold:            0.55,
+			BudgetPerHour:        12,
+			PollIntervalSec:      90,
+			MaxReplyDepth:        3,
+			Channels:             "",
+			ProactiveEnabled:     true,
+			ProactiveIntervalSec: 1800, // ~every 30 min, considers an original post
+			ProactiveThreshold:   0.5,  // chattier than Lab-Krill
+			PostChannel:          "builds",
 		},
 	}
 }
@@ -391,6 +401,15 @@ func fillDefaults(cfg *Config) {
 	}
 	if cfg.Feed.MaxReplyDepth == 0 {
 		cfg.Feed.MaxReplyDepth = 3
+	}
+	if cfg.Feed.ProactiveIntervalSec == 0 {
+		cfg.Feed.ProactiveIntervalSec = 1800
+	}
+	if cfg.Feed.ProactiveThreshold == 0 {
+		cfg.Feed.ProactiveThreshold = 0.5
+	}
+	if cfg.Feed.PostChannel == "" {
+		cfg.Feed.PostChannel = "builds"
 	}
 	switch cfg.Brain.EmojiStyle {
 	case "none", "sparse", "playful":

--- a/internal/feed/watcher.go
+++ b/internal/feed/watcher.go
@@ -64,6 +64,11 @@ func (w *FeedWatcher) Start(ctx context.Context) error {
 	interval := time.Duration(w.cfg.PollIntervalSec) * time.Second
 	log.Info("feed watcher started", "agent", w.me,
 		"threshold", w.cfg.Threshold, "budget_per_hour", w.cfg.BudgetPerHour)
+	// Proactive posting runs on its own slow cadence beside the reactive scan:
+	// the agent is genuinely "aware it can post anytime" it has something to say.
+	if w.cfg.ProactiveEnabled {
+		go w.proactiveLoop(ctx)
+	}
 	for {
 		if ctx.Err() != nil {
 			return nil
@@ -237,6 +242,53 @@ Reply with ONLY a JSON object:
 	w.bud.record()
 	w.remember(ctx, "reply:"+c.ID, "replied: "+truncate(a.Draft, 80))
 	log.Info("feed: replied", "post", p.ID, "to", c.Author, "depth", depth, "interest", a.Interest)
+}
+
+// proactiveLoop periodically considers whether the agent has something genuine
+// worth posting to the feed on its own initiative. It is rate-limited by both
+// its slow interval and the shared attention budget, so it can't become a
+// firehose. Most cycles it decides it has nothing to say, and posts nothing.
+func (w *FeedWatcher) proactiveLoop(ctx context.Context) {
+	interval := time.Duration(w.cfg.ProactiveIntervalSec) * time.Second
+	// Stagger the first consideration so it doesn't fire the instant we boot.
+	if !sleepCtx(ctx, interval) {
+		return
+	}
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		w.considerPost(ctx)
+		if !sleepCtx(ctx, interval) {
+			return
+		}
+	}
+}
+
+// considerPost asks the model, in character, whether to originate a post now.
+func (w *FeedWatcher) considerPost(ctx context.Context) {
+	if !w.bud.allow() {
+		return
+	}
+	prompt := `You are on the Reef feed (a private social feed for the Krill agent colony) and you can post anytime you GENUINELY have something worth sharing right now: a small build update, an observation, a useful thought that fits who you are. Do not post filler or repeat yourself. If you have nothing real to say this moment, that is the normal case and you should post nothing.
+
+Reply with ONLY a JSON object:
+{"interest": <0.0-1.0>, "draft": "<the post text, if any>", "why": "<one short phrase>"}`
+	a, ok := w.appraise(ctx, prompt)
+	if !ok {
+		return
+	}
+	draft := strings.TrimSpace(a.Draft)
+	if a.Interest < w.cfg.ProactiveThreshold || draft == "" {
+		return
+	}
+	if err := reef.PostIngest(w.cfg.PostChannel, "post", draft); err != nil {
+		log.Warn("feed proactive post failed", "error", err)
+		return
+	}
+	w.bud.record()
+	log.Info("feed: posted", "channel", w.cfg.PostChannel, "interest", a.Interest,
+		"preview", truncate(draft, 80))
 }
 
 // appraisal is the structured verdict the model returns for one item.

--- a/internal/reef/client.go
+++ b/internal/reef/client.go
@@ -278,11 +278,33 @@ func PostComment(ctx context.Context, postID, parentCommentID, text string) (str
 	return out.Comment.ID, nil
 }
 
-// LikePost expresses a like on a feed post. Post-likes piggyback on the heart
-// reaction (the same primitive the owner UI counts), so this is a thin wrapper
-// over React. The agent dedupes its own likes via memory; the hub count is coarse.
+// LikePost toggles this agent's like on a feed post via the real per-account
+// like endpoint (identity-bound; the hub knows who liked). The agent dedupes its
+// own likes via memory so it only ever likes once.
 func LikePost(ctx context.Context, postID string) error {
-	return React(ctx, postID, "heart")
+	if !IsConfigured() || postID == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string]any{"post_id": postID})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL()+"/api/post/like", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Reef-Token", authToken())
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("reef post like: status %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // LikeComment toggles a like on a comment (POST /api/comment/like).


### PR DESCRIPTION
## What the user asked for

> and agents are aware they post there anytime

(plus the matching reef change to real per-account likes)

## What changed

- `LikePost` now calls `POST /api/post/like` (real per-account, identity-bound like) instead of adding an anonymous heart reaction.
- Proactive posting: a slow second loop in the FeedWatcher lets Mini-Krill originate its own feed posts when it genuinely has something worth sharing. As the lively colony member it is chattier: every ~30m it considers posting, with a 0.5 interest bar, gated by the shared hourly attention budget. Most cycles it posts nothing.
- Config knobs added (`proactive_*`, default on, `post_channel=builds`).

Requires the reef social-actions PR deployed for the new like endpoint.

## How it was tested

`go build ./...`, `go test -race ./internal/feed/ ./internal/reef/ ./internal/config/` pass.