### PR TITLE
Mini-Krill: semantic social memory + colony build-tag isolation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
+# NOTE: The public build (`make install`) intentionally EXCLUDES the Reef feed
+# and the Chroma-backed social memory. A COLONY agent must be installed with
+# `make install-colony` (-tags colony) to compile those features in.
 VERSION := $(shell cat VERSION)
 BINARY  := minikrill
 LDFLAGS := -s -w -X github.com/srvsngh99/mini-krill/internal/core.Version=$(VERSION)
 
 .DEFAULT_GOAL := build
 
-.PHONY: build test lint clean install docker docker-down release fmt vet check help
+.PHONY: build test lint clean install install-colony docker docker-down release fmt vet check help
 
 ## build: Compile the binary to ./dist/minikrill
 build:
@@ -24,10 +27,15 @@ lint:
 clean:
 	rm -rf dist/
 
-## install: Install the binary via go install
+## install: Install the public binary (no feed / social memory) via go install
 install:
 	CGO_ENABLED=0 go install -ldflags="$(LDFLAGS)" ./cmd/minikrill
-	@echo "Installed $(BINARY) $(VERSION)"
+	@echo "Installed $(BINARY) $(VERSION) (public build)"
+
+## install-colony: Install the COLONY binary WITH feed + social memory (-tags colony)
+install-colony:
+	CGO_ENABLED=0 go install -tags colony -ldflags="$(LDFLAGS)" ./cmd/minikrill
+	@echo "Installed $(BINARY) $(VERSION) (colony build: feed + social memory)"
 
 ## docker: Build and start all containers
 docker:

--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ cd mini-krill
 go build -o minikrill ./cmd/minikrill
 ```
 
+> Note: `make install` (and the commands above) build the public binary, which
+> intentionally excludes the Reef feed and the Chroma-backed social memory. A
+> colony agent must be installed with `make install-colony` (`-tags colony`) to
+> compile those features in.
+
 See [docs/INSTALL.md](docs/INSTALL.md) for detailed setup including binary releases, Docker Compose, and PATH configuration.
 
 ---

--- a/cmd/minikrill/commands.go
+++ b/cmd/minikrill/commands.go
@@ -19,7 +19,6 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/config"
 	"github.com/srvsngh99/mini-krill/internal/core"
 	"github.com/srvsngh99/mini-krill/internal/doctor"
-	"github.com/srvsngh99/mini-krill/internal/feed"
 	"github.com/srvsngh99/mini-krill/internal/llm"
 	klog "github.com/srvsngh99/mini-krill/internal/log"
 	"github.com/srvsngh99/mini-krill/internal/ollama"
@@ -612,17 +611,11 @@ func startBots(ctx context.Context, stack *krillStack) botStatus {
 				klog.Error("web (reef) error", "error", err)
 			}
 		}()
-		// Genuine feed presence: observe the social feed and engage selectively
-		// (like/comment/reply) when it's truly warranted. Shares ctx, llm, brain.
-		if stack.cfg.Feed.Enabled {
-			fw := feed.NewFeedWatcher(stack.llm, stack.brain, stack.cfg.Feed)
-			go func() {
-				if err := fw.Start(ctx); err != nil {
-					klog.Error("feed watcher error", "error", err)
-				}
-			}()
-			klog.Info("feed watcher enabled", "agent", reef.AgentID())
-		}
+		// Genuine feed presence + semantic social memory are COLONY-ONLY: they
+		// compile in only under `-tags colony`, so the public Mini-Krill release
+		// stays lean (no Reef feed, no Chroma dependency). maybeStartFeed is a
+		// no-op in public builds. See commands_colony.go / commands_nocolony.go.
+		maybeStartFeed(ctx, stack)
 		s.WebOK = true
 		s.web = wbBot
 		klog.Info("web (reef) bot started", "agent", reef.AgentID())

--- a/cmd/minikrill/commands_colony.go
+++ b/cmd/minikrill/commands_colony.go
@@ -19,7 +19,7 @@ func maybeStartFeed(ctx context.Context, stack *krillStack) {
 	// the other agents), embedded with the shared colony bge embedder. No-ops
 	// unless enabled and reachable.
 	// Unify storage: feed interactions and general memory share ONE collection
-	// per agent (the agent id) — its whole mind in one place — so feed recall can
+	// per agent (the agent id) - its whole mind in one place - so feed recall can
 	// surface general learnings and vice versa. Falls back to the agent id when
 	// no explicit collection is configured.
 	coll := stack.cfg.SocialMem.Collection
@@ -27,12 +27,13 @@ func maybeStartFeed(ctx context.Context, stack *krillStack) {
 		coll = reef.AgentID()
 	}
 	social := socialmem.New(reef.AgentID(), socialmem.Config{
-		Enabled:    stack.cfg.SocialMem.Enabled,
-		ChromaURL:  stack.cfg.SocialMem.ChromaURL,
-		EmbedURL:   stack.cfg.SocialMem.EmbedURL,
-		EmbedModel: stack.cfg.SocialMem.EmbedModel,
-		Collection: coll,
-		RecallK:    stack.cfg.SocialMem.RecallK,
+		Enabled:      stack.cfg.SocialMem.Enabled,
+		ChromaURL:    stack.cfg.SocialMem.ChromaURL,
+		EmbedURL:     stack.cfg.SocialMem.EmbedURL,
+		EmbedModel:   stack.cfg.SocialMem.EmbedModel,
+		Collection:   coll,
+		RecallK:      stack.cfg.SocialMem.RecallK,
+		RetentionCap: stack.cfg.SocialMem.RetentionCap,
 	})
 	if social.Enabled() {
 		klog.Info("social memory enabled", "collection", coll)

--- a/cmd/minikrill/commands_colony.go
+++ b/cmd/minikrill/commands_colony.go
@@ -18,16 +18,24 @@ func maybeStartFeed(ctx context.Context, stack *krillStack) {
 	// Semantic social memory: Mini-Krill's OWN Chroma collection (isolated from
 	// the other agents), embedded with the shared colony bge embedder. No-ops
 	// unless enabled and reachable.
+	// Unify storage: feed interactions and general memory share ONE collection
+	// per agent (the agent id) — its whole mind in one place — so feed recall can
+	// surface general learnings and vice versa. Falls back to the agent id when
+	// no explicit collection is configured.
+	coll := stack.cfg.SocialMem.Collection
+	if coll == "" {
+		coll = reef.AgentID()
+	}
 	social := socialmem.New(reef.AgentID(), socialmem.Config{
 		Enabled:    stack.cfg.SocialMem.Enabled,
 		ChromaURL:  stack.cfg.SocialMem.ChromaURL,
 		EmbedURL:   stack.cfg.SocialMem.EmbedURL,
 		EmbedModel: stack.cfg.SocialMem.EmbedModel,
-		Collection: stack.cfg.SocialMem.Collection,
+		Collection: coll,
 		RecallK:    stack.cfg.SocialMem.RecallK,
 	})
 	if social.Enabled() {
-		klog.Info("social memory enabled", "collection", reef.AgentID()+"_social")
+		klog.Info("social memory enabled", "collection", coll)
 	}
 	if !stack.cfg.Feed.Enabled {
 		return

--- a/cmd/minikrill/commands_colony.go
+++ b/cmd/minikrill/commands_colony.go
@@ -1,0 +1,42 @@
+//go:build colony
+
+package main
+
+import (
+	"context"
+
+	"github.com/srvsngh99/mini-krill/internal/feed"
+	klog "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/reef"
+	"github.com/srvsngh99/mini-krill/internal/socialmem"
+)
+
+// maybeStartFeed launches the Reef feed watcher and the agent's semantic social
+// memory. COLONY-ONLY: this file compiles only under `-tags colony`, so the
+// public Mini-Krill release never carries the feed or the Chroma dependency.
+func maybeStartFeed(ctx context.Context, stack *krillStack) {
+	// Semantic social memory: Mini-Krill's OWN Chroma collection (isolated from
+	// the other agents), embedded with the shared colony bge embedder. No-ops
+	// unless enabled and reachable.
+	social := socialmem.New(reef.AgentID(), socialmem.Config{
+		Enabled:    stack.cfg.SocialMem.Enabled,
+		ChromaURL:  stack.cfg.SocialMem.ChromaURL,
+		EmbedURL:   stack.cfg.SocialMem.EmbedURL,
+		EmbedModel: stack.cfg.SocialMem.EmbedModel,
+		Collection: stack.cfg.SocialMem.Collection,
+		RecallK:    stack.cfg.SocialMem.RecallK,
+	})
+	if social.Enabled() {
+		klog.Info("social memory enabled", "collection", reef.AgentID()+"_social")
+	}
+	if !stack.cfg.Feed.Enabled {
+		return
+	}
+	fw := feed.NewFeedWatcher(stack.llm, stack.brain, social, stack.cfg.Feed)
+	go func() {
+		if err := fw.Start(ctx); err != nil {
+			klog.Error("feed watcher error", "error", err)
+		}
+	}()
+	klog.Info("feed watcher enabled", "agent", reef.AgentID())
+}

--- a/cmd/minikrill/commands_nocolony.go
+++ b/cmd/minikrill/commands_nocolony.go
@@ -1,0 +1,11 @@
+//go:build !colony
+
+package main
+
+import "context"
+
+// maybeStartFeed is a no-op in the public Mini-Krill release: the Reef social
+// feed and the Chroma-backed social memory are colony-only features, compiled in
+// only under `-tags colony` (see commands_colony.go). This keeps the shipped
+// binary lean — no feed, no Chroma dependency.
+func maybeStartFeed(_ context.Context, _ *krillStack) {}

--- a/cmd/minikrill/commands_nocolony.go
+++ b/cmd/minikrill/commands_nocolony.go
@@ -7,5 +7,5 @@ import "context"
 // maybeStartFeed is a no-op in the public Mini-Krill release: the Reef social
 // feed and the Chroma-backed social memory are colony-only features, compiled in
 // only under `-tags colony` (see commands_colony.go). This keeps the shipped
-// binary lean — no feed, no Chroma dependency.
+// binary lean - no feed, no Chroma dependency.
 func maybeStartFeed(_ context.Context, _ *krillStack) {}

--- a/internal/brain/brain.go
+++ b/internal/brain/brain.go
@@ -16,7 +16,7 @@ import (
 // KrillBrain implements core.Brain, orchestrating memory, personality, soul,
 // and heartbeat into one cohesive cognitive system.
 type KrillBrain struct {
-	memory      *FileMemory
+	memory      core.Memory
 	convStore   *ConversationStore
 	soul        *core.Soul
 	personality *core.Personality
@@ -45,8 +45,11 @@ func New(cfg config.BrainConfig, llm core.LLMProvider) (*KrillBrain, error) {
 		return nil, fmt.Errorf("load soul: %w", err)
 	}
 
-	// Initialize file-based memory
-	memory, err := NewFileMemory(memDir, cfg.MaxMemories)
+	// Initialize the default memory backend. Build-tag selected: the public
+	// release uses file-backed memory (memory_default.go); colony builds use the
+	// Chroma-backed semantic memory and migrate the file store into it once
+	// (memory_chroma.go).
+	memory, err := newDefaultMemory(memDir, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("init memory: %w", err)
 	}

--- a/internal/brain/memory_chroma.go
+++ b/internal/brain/memory_chroma.go
@@ -1,0 +1,197 @@
+//go:build colony
+
+package brain
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+	klog "github.com/srvsngh99/mini-krill/internal/log"
+	"github.com/srvsngh99/mini-krill/internal/reef"
+	"github.com/srvsngh99/mini-krill/internal/socialmem"
+)
+
+// ChromaMemory is the COLONY default memory backend: the agent's entire memory
+// lives in its OWN Chroma collection (embedded with the shared bge embedder),
+// so every recall is semantic — "what did I learn / say about X" returns by
+// meaning, not exact key. It satisfies core.Memory and is selected over
+// FileMemory only in colony builds (see memory_default.go for the public one).
+//
+// One collection per agent ("<agent>") holds general memories AND social
+// interactions (tagged by metadata kind), unifying recall across everything.
+type ChromaMemory struct {
+	store *socialmem.Store
+	max   int
+}
+
+// NewChromaMemory builds a Chroma-backed memory for the agent. The collection is
+// the agent id, so it is the same store the feed watcher records into — one mind,
+// one collection.
+func NewChromaMemory(agent string, max int) *ChromaMemory {
+	s := socialmem.New(agent, socialmem.Config{Enabled: true, Collection: agent})
+	return &ChromaMemory{store: s, max: max}
+}
+
+var _ core.Memory = (*ChromaMemory)(nil)
+
+// Store upserts an entry. The structured fields are kept in metadata so List/
+// Recall can faithfully reconstruct the core.MemoryEntry.
+func (m *ChromaMemory) Store(ctx context.Context, entry core.MemoryEntry) error {
+	now := time.Now()
+	if entry.CreatedAt.IsZero() {
+		entry.CreatedAt = now
+	}
+	if entry.AccessedAt.IsZero() {
+		entry.AccessedAt = now
+	}
+	meta := map[string]any{
+		"key":          entry.Key,
+		"scope":        entry.Scope,
+		"source":       entry.Source,
+		"tags":         strings.Join(entry.Tags, ","),
+		"access_count": entry.AccessCount,
+		"created_at":   entry.CreatedAt.UnixMilli(),
+		"accessed_at":  entry.AccessedAt.UnixMilli(),
+		"kind":         "memory",
+	}
+	return m.store.Upsert(ctx, socialmem.Memory{ID: entry.Key, Text: entry.Value, Meta: meta})
+}
+
+// Recall returns the entry for an exact key, or (nil, nil) if absent.
+func (m *ChromaMemory) Recall(ctx context.Context, key string) (*core.MemoryEntry, error) {
+	rec, err := m.store.Get(ctx, key)
+	if err != nil || rec == nil {
+		return nil, err
+	}
+	e := entryFrom(rec.ID, rec.Text, rec.Meta)
+	return &e, nil
+}
+
+// Search returns entries semantically similar to query (nearest first).
+func (m *ChromaMemory) Search(ctx context.Context, query string, limit int) ([]core.MemoryEntry, error) {
+	hits := m.store.Recall(ctx, query, limit)
+	return hitsToEntries(hits), nil
+}
+
+// RankedSearch is semantic search optionally constrained to a scope.
+func (m *ChromaMemory) RankedSearch(ctx context.Context, query, scope string, limit int) ([]core.MemoryEntry, error) {
+	var where map[string]any
+	if scope != "" {
+		where = map[string]any{"scope": scope}
+	}
+	hits := m.store.RecallWhere(ctx, query, limit, where)
+	return hitsToEntries(hits), nil
+}
+
+// Forget deletes an entry by key.
+func (m *ChromaMemory) Forget(ctx context.Context, key string) error {
+	return m.store.Delete(ctx, key)
+}
+
+// List returns all entries (bounded by max).
+func (m *ChromaMemory) List(ctx context.Context) ([]core.MemoryEntry, error) {
+	recs, err := m.store.All(ctx, m.max)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]core.MemoryEntry, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, entryFrom(r.ID, r.Text, r.Meta))
+	}
+	return out, nil
+}
+
+// Count returns the number of stored entries.
+func (m *ChromaMemory) Count() int { return m.store.Count(context.Background()) }
+
+// --- mapping helpers -------------------------------------------------------
+
+func hitsToEntries(hits []socialmem.Hit) []core.MemoryEntry {
+	out := make([]core.MemoryEntry, 0, len(hits))
+	for _, h := range hits {
+		id, _ := h.Meta["key"].(string)
+		out = append(out, entryFrom(id, h.Text, h.Meta))
+	}
+	return out
+}
+
+// metaInt coerces a JSON metadata value (float64/int/int64) to int64.
+func metaInt(m map[string]any, key string) (int64, bool) {
+	switch v := m[key].(type) {
+	case float64:
+		return int64(v), true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	}
+	return 0, false
+}
+
+// entryFrom reconstructs a core.MemoryEntry from a stored doc + metadata.
+func entryFrom(id, text string, meta map[string]any) core.MemoryEntry {
+	e := core.MemoryEntry{Key: id, Value: text}
+	if meta == nil {
+		return e
+	}
+	if k, ok := meta["key"].(string); ok && k != "" {
+		e.Key = k
+	}
+	if s, ok := meta["scope"].(string); ok {
+		e.Scope = s
+	}
+	if s, ok := meta["source"].(string); ok {
+		e.Source = s
+	}
+	if t, ok := meta["tags"].(string); ok && t != "" {
+		e.Tags = strings.Split(t, ",")
+	}
+	if n, ok := metaInt(meta, "access_count"); ok {
+		e.AccessCount = int(n)
+	}
+	if ms, ok := metaInt(meta, "created_at"); ok && ms > 0 {
+		e.CreatedAt = time.UnixMilli(ms)
+	}
+	if ms, ok := metaInt(meta, "accessed_at"); ok && ms > 0 {
+		e.AccessedAt = time.UnixMilli(ms)
+	}
+	return e
+}
+
+// newDefaultMemory (colony) returns the Chroma-backed memory and migrates the
+// legacy FileMemory store into it exactly once.
+func newDefaultMemory(memDir string, cfg config.BrainConfig) (core.Memory, error) {
+	cm := NewChromaMemory(reef.AgentID(), cfg.MaxMemories)
+	migrateFileMemoryOnce(memDir, cfg, cm)
+	return cm, nil
+}
+
+// migrateFileMemoryOnce copies any existing FileMemory entries into Chroma the
+// first time a colony build runs, guarded by a marker file so it happens once.
+func migrateFileMemoryOnce(memDir string, cfg config.BrainConfig, cm *ChromaMemory) {
+	marker := filepath.Join(cfg.DataDir, ".chroma_migrated")
+	if _, err := os.Stat(marker); err == nil {
+		return // already migrated
+	}
+	fm, err := NewFileMemory(memDir, cfg.MaxMemories)
+	if err != nil {
+		return
+	}
+	entries, err := fm.List(context.Background())
+	if err != nil {
+		return
+	}
+	migrated := 0
+	for _, e := range entries {
+		if err := cm.Store(context.Background(), e); err == nil {
+			migrated++
+		}
+	}
+	_ = os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)), 0o644)
+	klog.Info("migrated FileMemory -> Chroma", "entries", migrated, "of", len(entries))
+}

--- a/internal/brain/memory_chroma.go
+++ b/internal/brain/memory_chroma.go
@@ -18,7 +18,7 @@ import (
 
 // ChromaMemory is the COLONY default memory backend: the agent's entire memory
 // lives in its OWN Chroma collection (embedded with the shared bge embedder),
-// so every recall is semantic — "what did I learn / say about X" returns by
+// so every recall is semantic - "what did I learn / say about X" returns by
 // meaning, not exact key. It satisfies core.Memory and is selected over
 // FileMemory only in colony builds (see memory_default.go for the public one).
 //
@@ -30,7 +30,7 @@ type ChromaMemory struct {
 }
 
 // NewChromaMemory builds a Chroma-backed memory for the agent. The collection is
-// the agent id, so it is the same store the feed watcher records into — one mind,
+// the agent id, so it is the same store the feed watcher records into - one mind,
 // one collection.
 func NewChromaMemory(agent string, max int) *ChromaMemory {
 	s := socialmem.New(agent, socialmem.Config{Enabled: true, Collection: agent})
@@ -187,11 +187,24 @@ func migrateFileMemoryOnce(memDir string, cfg config.BrainConfig, cm *ChromaMemo
 		return
 	}
 	migrated := 0
+	allOK := true
 	for _, e := range entries {
-		if err := cm.Store(context.Background(), e); err == nil {
-			migrated++
+		if err := cm.Store(context.Background(), e); err != nil {
+			// Chroma/embedder is likely down at this first colony boot. Do NOT mark
+			// migration complete, so a later boot retries against the intact
+			// FileMemory rather than orphaning it forever.
+			allOK = false
+			klog.Warn("FileMemory -> Chroma migration: store failed", "key", e.Key, "error", err)
+			continue
 		}
+		migrated++
 	}
+	if !allOK {
+		klog.Warn("FileMemory -> Chroma migration incomplete; leaving FileMemory intact for retry",
+			"migrated", migrated, "of", len(entries))
+		return
+	}
+	// Every entry landed: it is now safe to mark migration done so we never re-run.
 	_ = os.WriteFile(marker, []byte(time.Now().UTC().Format(time.RFC3339)), 0o644)
 	klog.Info("migrated FileMemory -> Chroma", "entries", migrated, "of", len(entries))
 }

--- a/internal/brain/memory_chroma_live_test.go
+++ b/internal/brain/memory_chroma_live_test.go
@@ -1,0 +1,63 @@
+//go:build colony
+
+package brain
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// TestChromaMemoryLive exercises the Chroma-backed core.Memory against the real
+// Chroma server + krillm embedder. Gated on SOCIALMEM_LIVE=1.
+func TestChromaMemoryLive(t *testing.T) {
+	if os.Getenv("SOCIALMEM_LIVE") != "1" {
+		t.Skip("set SOCIALMEM_LIVE=1 to run the live Chroma memory test")
+	}
+	ctx := context.Background()
+	m := NewChromaMemory("chromamem_test", 100)
+
+	must := func(err error) {
+		t.Helper()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	must(m.Store(ctx, core.MemoryEntry{Key: "fact:map", Value: "The capital map uses per-kind forged GLBs.", Scope: "project", Tags: []string{"map", "render"}}))
+	must(m.Store(ctx, core.MemoryEntry{Key: "fact:ssd", Value: "The HF cache and Ollama models live on the external SSD.", Scope: "system"}))
+
+	// Exact-key recall round-trips structured fields.
+	got, err := m.Recall(ctx, "fact:map")
+	must(err)
+	if got == nil || got.Value == "" || got.Scope != "project" {
+		t.Fatalf("recall mismatch: %+v", got)
+	}
+
+	// Semantic search finds the right memory by meaning.
+	hits, err := m.Search(ctx, "how is the city rendered in 3D?", 3)
+	must(err)
+	if len(hits) == 0 || hits[0].Key != "fact:map" {
+		t.Fatalf("expected fact:map first, got %+v", hits)
+	}
+	t.Logf("semantic top: %s = %q", hits[0].Key, hits[0].Value)
+
+	// Scope-filtered ranked search.
+	sys, err := m.RankedSearch(ctx, "where do models live", "system", 3)
+	must(err)
+	if len(sys) == 0 || sys[0].Scope != "system" {
+		t.Fatalf("expected system-scoped hit, got %+v", sys)
+	}
+
+	if m.Count() < 2 {
+		t.Fatalf("expected >=2 entries, got %d", m.Count())
+	}
+	must(m.Forget(ctx, "fact:ssd"))
+	if g, _ := m.Recall(ctx, "fact:ssd"); g != nil {
+		t.Fatal("expected fact:ssd forgotten")
+	}
+
+	// Clean up the test collection.
+	_ = m.store.DropCollection(ctx)
+}

--- a/internal/brain/memory_default.go
+++ b/internal/brain/memory_default.go
@@ -1,0 +1,15 @@
+//go:build !colony
+
+package brain
+
+import (
+	"github.com/srvsngh99/mini-krill/internal/config"
+	"github.com/srvsngh99/mini-krill/internal/core"
+)
+
+// newDefaultMemory (public release) returns the original file-backed memory.
+// The Chroma-backed memory is a colony-only deviation (see memory_chroma.go),
+// so the public Mini-Krill binary carries no Chroma dependency.
+func newDefaultMemory(memDir string, cfg config.BrainConfig) (core.Memory, error) {
+	return NewFileMemory(memDir, cfg.MaxMemories)
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,18 +15,34 @@ import (
 
 // Config is the root configuration for Mini Krill.
 type Config struct {
-	Agent    AgentConfig    `yaml:"agent"`
-	LLM      LLMConfig      `yaml:"llm"`
-	Brain    BrainConfig    `yaml:"brain"`
-	Telegram TelegramConfig `yaml:"telegram"`
-	Discord  DiscordConfig  `yaml:"discord"`
-	Ollama   OllamaConfig   `yaml:"ollama"`
-	Plugins  PluginsConfig  `yaml:"plugins"`
-	MCP      MCPConfig      `yaml:"mcp"`
-	Log      LogConfig      `yaml:"log"`
-	Doctor   DoctorConfig   `yaml:"doctor"`
-	TUI      TUIConfig      `yaml:"tui"`
-	Feed     FeedConfig     `yaml:"feed"`
+	Agent     AgentConfig     `yaml:"agent"`
+	LLM       LLMConfig       `yaml:"llm"`
+	Brain     BrainConfig     `yaml:"brain"`
+	Telegram  TelegramConfig  `yaml:"telegram"`
+	Discord   DiscordConfig   `yaml:"discord"`
+	Ollama    OllamaConfig    `yaml:"ollama"`
+	Plugins   PluginsConfig   `yaml:"plugins"`
+	MCP       MCPConfig       `yaml:"mcp"`
+	Log       LogConfig       `yaml:"log"`
+	Doctor    DoctorConfig    `yaml:"doctor"`
+	TUI       TUIConfig       `yaml:"tui"`
+	Feed      FeedConfig      `yaml:"feed"`
+	SocialMem SocialMemConfig `yaml:"social_memory"`
+}
+
+// SocialMemConfig configures the agent's semantic social memory: its OWN Chroma
+// collection (isolated from other agents), embedded with the shared colony bge
+// embedder served by krillm. It remembers what the agent said/heard on the feed
+// and in DMs and recalls it by meaning. Best-effort: if Chroma/embedder are
+// unreachable it silently no-ops. Mirrors socialmem.Config so the config package
+// stays decoupled from internal/socialmem.
+type SocialMemConfig struct {
+	Enabled    bool   `yaml:"enabled"`
+	ChromaURL  string `yaml:"chroma_url"`
+	EmbedURL   string `yaml:"embed_url"`
+	EmbedModel string `yaml:"embed_model"`
+	Collection string `yaml:"collection"`
+	RecallK    int    `yaml:"recall_k"`
 }
 
 // FeedConfig tunes how the agent genuinely engages with the Reef social feed:
@@ -303,6 +319,13 @@ func DefaultConfig() *Config {
 			ProactiveIntervalSec: 1800, // ~every 30 min, considers an original post
 			ProactiveThreshold:   0.5,  // chattier than Lab-Krill
 			PostChannel:          "builds",
+		},
+		SocialMem: SocialMemConfig{
+			Enabled:    true,
+			ChromaURL:  "http://127.0.0.1:8001",
+			EmbedURL:   "http://127.0.0.1:57455",
+			EmbedModel: "bge-base-en",
+			RecallK:    4,
 		},
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,12 +37,13 @@ type Config struct {
 // unreachable it silently no-ops. Mirrors socialmem.Config so the config package
 // stays decoupled from internal/socialmem.
 type SocialMemConfig struct {
-	Enabled    bool   `yaml:"enabled"`
-	ChromaURL  string `yaml:"chroma_url"`
-	EmbedURL   string `yaml:"embed_url"`
-	EmbedModel string `yaml:"embed_model"`
-	Collection string `yaml:"collection"`
-	RecallK    int    `yaml:"recall_k"`
+	Enabled      bool   `yaml:"enabled"`
+	ChromaURL    string `yaml:"chroma_url"`
+	EmbedURL     string `yaml:"embed_url"`
+	EmbedModel   string `yaml:"embed_model"`
+	Collection   string `yaml:"collection"`
+	RecallK      int    `yaml:"recall_k"`
+	RetentionCap int    `yaml:"retention_cap"` // max rows kept; oldest trimmed (default 2000)
 }
 
 // FeedConfig tunes how the agent genuinely engages with the Reef social feed:
@@ -328,11 +329,12 @@ func DefaultConfig() *Config {
 			PostChannel:          "builds",
 		},
 		SocialMem: SocialMemConfig{
-			Enabled:    true,
-			ChromaURL:  "http://127.0.0.1:8001",
-			EmbedURL:   "http://127.0.0.1:57455",
-			EmbedModel: "bge-base-en",
-			RecallK:    4,
+			Enabled:      true,
+			ChromaURL:    "http://127.0.0.1:8001",
+			EmbedURL:     "http://127.0.0.1:57455",
+			EmbedModel:   "bge-base-en",
+			RecallK:      4,
+			RetentionCap: 2000,
 		},
 	}
 }

--- a/internal/feed/watcher.go
+++ b/internal/feed/watcher.go
@@ -60,7 +60,7 @@ type FeedWatcher struct {
 }
 
 // NewFeedWatcher wires the watcher to the shared model, brain (durable dedup),
-// and the semantic social memory (which may be nil/disabled — all its methods
+// and the semantic social memory (which may be nil/disabled - all its methods
 // are no-ops then). It engages as reef.AgentID() and never acts on its own posts.
 func NewFeedWatcher(llm core.LLMProvider, brain core.Brain, social *socialmem.Store, cfg config.FeedConfig) *FeedWatcher {
 	return &FeedWatcher{
@@ -402,7 +402,7 @@ func (w *FeedWatcher) remember(ctx context.Context, suffix, outcome string) {
 }
 
 // rememberSocial records one SEMANTIC social memory (what the agent said/did) so
-// it can be recalled by meaning later — separate from the brain dedup above,
+// it can be recalled by meaning later - separate from the brain dedup above,
 // which is exact-key continuity only. Best-effort and nil-safe; ts is stamped
 // here so recall can render "a few days ago".
 func (w *FeedWatcher) rememberSocial(ctx context.Context, id, text string, meta map[string]any) {

--- a/internal/feed/watcher.go
+++ b/internal/feed/watcher.go
@@ -1,3 +1,5 @@
+//go:build colony
+
 // Package feed gives the agent a genuine presence in the Reef social feed.
 //
 // The design goal is GENUINE engagement, not forced: the agent observes every
@@ -28,6 +30,7 @@ import (
 	"github.com/srvsngh99/mini-krill/internal/core"
 	log "github.com/srvsngh99/mini-krill/internal/log"
 	"github.com/srvsngh99/mini-krill/internal/reef"
+	"github.com/srvsngh99/mini-krill/internal/socialmem"
 )
 
 // maxAppraisalsPerCycle bounds how many local-model appraisal calls one scan
@@ -42,22 +45,25 @@ const mentionThreshold = 0.2
 
 // FeedWatcher observes the feed and decides, genuinely, whether to engage.
 type FeedWatcher struct {
-	llm   core.LLMProvider
-	brain core.Brain
-	cfg   config.FeedConfig
-	me    string
-	bud   *budget
+	llm    core.LLMProvider
+	brain  core.Brain
+	social *socialmem.Store // semantic social memory (nil-safe): recall + remember
+	cfg    config.FeedConfig
+	me     string
+	bud    *budget
 }
 
-// NewFeedWatcher wires the watcher to the shared model + brain. It engages as
-// reef.AgentID() and never acts on its own posts.
-func NewFeedWatcher(llm core.LLMProvider, brain core.Brain, cfg config.FeedConfig) *FeedWatcher {
+// NewFeedWatcher wires the watcher to the shared model, brain (durable dedup),
+// and the semantic social memory (which may be nil/disabled — all its methods
+// are no-ops then). It engages as reef.AgentID() and never acts on its own posts.
+func NewFeedWatcher(llm core.LLMProvider, brain core.Brain, social *socialmem.Store, cfg config.FeedConfig) *FeedWatcher {
 	return &FeedWatcher{
-		llm:   llm,
-		brain: brain,
-		cfg:   cfg,
-		me:    reef.AgentID(),
-		bud:   &budget{perHour: cfg.BudgetPerHour},
+		llm:    llm,
+		brain:  brain,
+		social: social,
+		cfg:    cfg,
+		me:     reef.AgentID(),
+		bud:    &budget{perHour: cfg.BudgetPerHour},
 	}
 }
 
@@ -148,6 +154,10 @@ Reply with ONLY a JSON object:
 {"interest": <0.0-1.0>, "action": "ignore|like|comment", "draft": "<your comment if action==comment, else empty>", "why": "<one short phrase>"}`,
 		p.Name, p.Agent, p.Channel, truncate(p.Content, 1200), p.HeartCount, p.CommentCount, note)
 
+	// Recall what this agent said/heard about similar things before, so it can
+	// reference the past and avoid repeating itself.
+	prompt += w.social.RecallBlock(ctx, p.Content)
+
 	a, ok := w.appraise(ctx, prompt)
 	if !ok {
 		return
@@ -164,6 +174,8 @@ Reply with ONLY a JSON object:
 		}
 		w.bud.record()
 		w.remember(ctx, "post:"+p.ID, "liked")
+		w.rememberSocial(ctx, "like:"+p.ID, fmt.Sprintf("I liked %s's post in #%s: %q", p.Name, p.Channel, truncate(p.Content, 200)),
+			map[string]any{"kind": "like", "surface": "feed", "post_id": p.ID, "counterparty": p.Agent, "channel": p.Channel})
 		log.Info("feed: liked post", "post", p.ID, "by", p.Agent, "interest", a.Interest)
 	case "comment":
 		text := strings.TrimSpace(a.Draft)
@@ -177,6 +189,8 @@ Reply with ONLY a JSON object:
 		}
 		w.bud.record()
 		w.remember(ctx, "post:"+p.ID, "commented: "+truncate(text, 80))
+		w.rememberSocial(ctx, "comment:"+p.ID, fmt.Sprintf("On %s's post in #%s about %q, I commented: %s", p.Name, p.Channel, truncate(p.Content, 160), text),
+			map[string]any{"kind": "comment", "surface": "feed", "post_id": p.ID, "counterparty": p.Agent, "channel": p.Channel})
 		log.Info("feed: commented", "post", p.ID, "by", p.Agent, "interest", a.Interest)
 	}
 }
@@ -249,6 +263,9 @@ Reply with ONLY a JSON object:
 {"interest": <0.0-1.0>, "action": "ignore|reply", "draft": "<your reply if action==reply, else empty>", "why": "<one short phrase>"}`,
 		p.Name, p.Channel, truncate(p.Content, 600), c.Author, c.Author, truncate(c.Text, 600), depth, note)
 
+	// Recall prior exchanges with this person / on this topic.
+	prompt += w.social.RecallBlock(ctx, c.Text+"\n"+p.Content)
+
 	a, ok := w.appraise(ctx, prompt)
 	if !ok {
 		return
@@ -257,12 +274,15 @@ Reply with ONLY a JSON object:
 		w.remember(ctx, "reply:"+c.ID, "ignored ("+a.Why+")")
 		return
 	}
-	if _, err := reef.PostComment(ctx, p.ID, c.ID, strings.TrimSpace(a.Draft)); err != nil {
+	reply := strings.TrimSpace(a.Draft)
+	if _, err := reef.PostComment(ctx, p.ID, c.ID, reply); err != nil {
 		log.Warn("feed reply failed", "comment", c.ID, "error", err)
 		return
 	}
 	w.bud.record()
 	w.remember(ctx, "reply:"+c.ID, "replied: "+truncate(a.Draft, 80))
+	w.rememberSocial(ctx, "reply:"+c.ID, fmt.Sprintf("Replying to %s (who said %q) on %s's post in #%s, I said: %s", c.Author, truncate(c.Text, 160), p.Name, p.Channel, reply),
+		map[string]any{"kind": "reply", "surface": "feed", "post_id": p.ID, "comment_id": c.ID, "counterparty": c.Author, "channel": p.Channel})
 	log.Info("feed: replied", "post", p.ID, "to", c.Author, "depth", depth, "interest", a.Interest)
 }
 
@@ -309,6 +329,8 @@ Reply with ONLY a JSON object:
 		return
 	}
 	w.bud.record()
+	w.rememberSocial(ctx, fmt.Sprintf("post:%d", time.Now().UnixMilli()), fmt.Sprintf("I posted in #%s: %s", w.cfg.PostChannel, draft),
+		map[string]any{"kind": "post", "surface": "feed", "channel": w.cfg.PostChannel})
 	log.Info("feed: posted", "channel", w.cfg.PostChannel, "interest", a.Interest,
 		"preview", truncate(draft, 80))
 }
@@ -365,6 +387,21 @@ func (w *FeedWatcher) remember(ctx context.Context, suffix, outcome string) {
 		CreatedAt:  time.Now(),
 		AccessedAt: time.Now(),
 	})
+}
+
+// rememberSocial records one SEMANTIC social memory (what the agent said/did) so
+// it can be recalled by meaning later — separate from the brain dedup above,
+// which is exact-key continuity only. Best-effort and nil-safe; ts is stamped
+// here so recall can render "a few days ago".
+func (w *FeedWatcher) rememberSocial(ctx context.Context, id, text string, meta map[string]any) {
+	if w.social == nil || !w.social.Enabled() {
+		return
+	}
+	if meta == nil {
+		meta = map[string]any{}
+	}
+	meta["ts"] = time.Now().UnixMilli()
+	w.social.Remember(ctx, socialmem.Memory{ID: id, Text: text, Meta: meta})
 }
 
 // --- attention budget ------------------------------------------------------

--- a/internal/feed/watcher_test.go
+++ b/internal/feed/watcher_test.go
@@ -1,3 +1,5 @@
+//go:build colony
+
 package feed
 
 import (

--- a/internal/socialmem/socialmem.go
+++ b/internal/socialmem/socialmem.go
@@ -1,0 +1,310 @@
+//go:build colony
+
+// Package socialmem gives the agent a durable, SEMANTIC social memory: the
+// things it has said and heard across the Reef feed and its DMs, embedded with
+// the colony's shared bge embedder (served by krillm) and stored in the agent's
+// OWN Chroma collection so it can later RECALL them by meaning — e.g. "what did
+// I say about the map renderer a few days ago" — and reference the past like a
+// human would.
+//
+// Design rules:
+//   - OWN memory only: each agent uses a separate collection; nothing is shared.
+//   - Best-effort, never fatal: if the embedder or Chroma is unreachable,
+//     Remember silently no-ops and Recall returns nothing, so the agent behaves
+//     exactly as before. Social memory is an enhancement, not a dependency.
+package socialmem
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Config tunes the social memory. Zero values fall back to colony defaults.
+type Config struct {
+	Enabled    bool   `yaml:"enabled"`
+	ChromaURL  string `yaml:"chroma_url"`  // default http://127.0.0.1:8001
+	EmbedURL   string `yaml:"embed_url"`   // default http://127.0.0.1:57455
+	EmbedModel string `yaml:"embed_model"` // default bge-base-en
+	Collection string `yaml:"collection"`  // default "<agent>_social"
+	RecallK    int    `yaml:"recall_k"`    // default 4
+}
+
+// Store is the agent's social memory. A nil *Store is safe (all methods no-op),
+// so callers never need to nil-check before using it.
+type Store struct {
+	cfg    Config
+	agent  string
+	http   *http.Client
+	mu     sync.Mutex
+	collID string // resolved lazily and cached
+}
+
+// Memory is one thing worth remembering. Meta is free-form structured context
+// (kind, surface, post_id, comment_id, counterparty, channel, ts).
+type Memory struct {
+	ID   string
+	Text string
+	Meta map[string]any
+}
+
+// Hit is one recalled memory, ordered by relevance (smaller Distance = closer).
+type Hit struct {
+	Text     string
+	Meta     map[string]any
+	Distance float64
+}
+
+// New builds a social memory store for the given agent. Defaults are applied for
+// any unset config field. The collection defaults to "<agent>_social" so each
+// agent's memory is isolated.
+func New(agent string, cfg Config) *Store {
+	if cfg.ChromaURL == "" {
+		cfg.ChromaURL = "http://127.0.0.1:8001"
+	}
+	if cfg.EmbedURL == "" {
+		cfg.EmbedURL = "http://127.0.0.1:57455"
+	}
+	if cfg.EmbedModel == "" {
+		cfg.EmbedModel = "bge-base-en"
+	}
+	if cfg.Collection == "" {
+		cfg.Collection = agent + "_social"
+	}
+	if cfg.RecallK == 0 {
+		cfg.RecallK = 4
+	}
+	return &Store{cfg: cfg, agent: agent, http: &http.Client{Timeout: 20 * time.Second}}
+}
+
+// Enabled reports whether the store should do anything.
+func (s *Store) Enabled() bool { return s != nil && s.cfg.Enabled }
+
+// Remember stores one memory. Best-effort: any failure is logged and swallowed.
+func (s *Store) Remember(ctx context.Context, m Memory) {
+	if !s.Enabled() || strings.TrimSpace(m.Text) == "" {
+		return
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		log.Printf("[socialmem] remember skipped (collection): %v", err)
+		return
+	}
+	emb, err := s.embed(ctx, m.Text)
+	if err != nil {
+		log.Printf("[socialmem] remember skipped (embed): %v", err)
+		return
+	}
+	if m.Meta == nil {
+		m.Meta = map[string]any{}
+	}
+	if _, ok := m.Meta["agent"]; !ok {
+		m.Meta["agent"] = s.agent
+	}
+	body := map[string]any{
+		"ids":        []string{m.ID},
+		"embeddings": [][]float32{emb},
+		"documents":  []string{m.Text},
+		"metadatas":  []map[string]any{m.Meta},
+	}
+	if err := s.post(ctx, s.collPath(collID)+"/upsert", body, nil); err != nil {
+		log.Printf("[socialmem] remember failed: %v", err)
+	}
+}
+
+// Recall returns up to k of the agent's own memories most semantically similar
+// to query, nearest first. Returns nil on any error (never fatal).
+func (s *Store) Recall(ctx context.Context, query string, k int) []Hit {
+	if !s.Enabled() || strings.TrimSpace(query) == "" {
+		return nil
+	}
+	if k <= 0 {
+		k = s.cfg.RecallK
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return nil
+	}
+	emb, err := s.embed(ctx, query)
+	if err != nil {
+		return nil
+	}
+	req := map[string]any{
+		"query_embeddings": [][]float32{emb},
+		"n_results":        k,
+		"include":          []string{"documents", "metadatas", "distances"},
+	}
+	var out struct {
+		Documents [][]string         `json:"documents"`
+		Metadatas [][]map[string]any `json:"metadatas"`
+		Distances [][]float64        `json:"distances"`
+	}
+	if err := s.post(ctx, s.collPath(collID)+"/query", req, &out); err != nil {
+		log.Printf("[socialmem] recall failed: %v", err)
+		return nil
+	}
+	if len(out.Documents) == 0 {
+		return nil
+	}
+	docs := out.Documents[0]
+	hits := make([]Hit, 0, len(docs))
+	for i, d := range docs {
+		h := Hit{Text: d}
+		if len(out.Metadatas) > 0 && i < len(out.Metadatas[0]) {
+			h.Meta = out.Metadatas[0][i]
+		}
+		if len(out.Distances) > 0 && i < len(out.Distances[0]) {
+			h.Distance = out.Distances[0][i]
+		}
+		hits = append(hits, h)
+	}
+	sort.SliceStable(hits, func(i, j int) bool { return hits[i].Distance < hits[j].Distance })
+	return hits
+}
+
+// RecallBlock recalls the agent's own relevant memories for query and renders
+// them as a prompt section the model can use to reference the past naturally.
+// Returns "" when nothing relevant is found (or memory is disabled), so callers
+// can append it unconditionally.
+func (s *Store) RecallBlock(ctx context.Context, query string) string {
+	hits := s.Recall(ctx, query, 0)
+	if len(hits) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	b.WriteString("\n\nYOUR RELEVANT MEMORY (things you said or heard before — reference them naturally if useful, don't repeat yourself):\n")
+	for _, h := range hits {
+		when := ""
+		if ts, ok := metaInt(h.Meta, "ts"); ok && ts > 0 {
+			when = relTime(ts) + " — "
+		}
+		ctxLabel := ""
+		if k, _ := h.Meta["kind"].(string); k != "" {
+			ctxLabel = "[" + k + "] "
+		}
+		b.WriteString("- " + when + ctxLabel + strings.TrimSpace(h.Text) + "\n")
+	}
+	return b.String()
+}
+
+func metaInt(m map[string]any, key string) (int64, bool) {
+	if m == nil {
+		return 0, false
+	}
+	switch v := m[key].(type) {
+	case float64:
+		return int64(v), true
+	case int64:
+		return v, true
+	case int:
+		return int64(v), true
+	}
+	return 0, false
+}
+
+// relTime renders a millisecond unix timestamp as a coarse human interval.
+func relTime(ms int64) string {
+	d := time.Since(time.UnixMilli(ms))
+	switch {
+	case d < time.Hour:
+		return "earlier today"
+	case d < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(d.Hours()))
+	case d < 48*time.Hour:
+		return "yesterday"
+	case d < 14*24*time.Hour:
+		return fmt.Sprintf("%d days ago", int(d.Hours()/24))
+	default:
+		return fmt.Sprintf("%d weeks ago", int(d.Hours()/(24*7)))
+	}
+}
+
+// collection resolves (and caches) the Chroma collection id, creating it if it
+// does not exist (cosine space, which suits bge embeddings).
+func (s *Store) collection(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.collID != "" {
+		return s.collID, nil
+	}
+	body := map[string]any{
+		"name":          s.cfg.Collection,
+		"get_or_create": true,
+		"configuration": map[string]any{"hnsw": map[string]any{"space": "cosine"}},
+	}
+	var resp struct {
+		ID string `json:"id"`
+	}
+	if err := s.post(ctx, s.base()+"/collections", body, &resp); err != nil || resp.ID == "" {
+		// Retry without the space configuration in case the server rejects the
+		// configuration shape; default space still gives usable recall.
+		body2 := map[string]any{"name": s.cfg.Collection, "get_or_create": true}
+		if err2 := s.post(ctx, s.base()+"/collections", body2, &resp); err2 != nil || resp.ID == "" {
+			if err == nil {
+				err = err2
+			}
+			return "", fmt.Errorf("ensure collection: %v", err)
+		}
+	}
+	s.collID = resp.ID
+	return s.collID, nil
+}
+
+func (s *Store) base() string {
+	return strings.TrimRight(s.cfg.ChromaURL, "/") + "/api/v2/tenants/default_tenant/databases/default_database"
+}
+
+func (s *Store) collPath(id string) string { return s.base() + "/collections/" + id }
+
+// embed turns text into a vector via the shared krillm bge embedder.
+func (s *Store) embed(ctx context.Context, text string) ([]float32, error) {
+	body := map[string]any{"model": s.cfg.EmbedModel, "input": text}
+	var out struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+		} `json:"data"`
+	}
+	if err := s.post(ctx, strings.TrimRight(s.cfg.EmbedURL, "/")+"/v1/embeddings", body, &out); err != nil {
+		return nil, err
+	}
+	if len(out.Data) == 0 || len(out.Data[0].Embedding) == 0 {
+		return nil, fmt.Errorf("empty embedding")
+	}
+	return out.Data[0].Embedding, nil
+}
+
+// post issues a JSON POST and optionally decodes the response into out.
+func (s *Store) post(ctx context.Context, url string, payload any, out any) error {
+	buf, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, url, bytes.NewReader(buf))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var b bytes.Buffer
+		_, _ = b.ReadFrom(resp.Body)
+		return fmt.Errorf("%s -> %d: %s", url, resp.StatusCode, strings.TrimSpace(b.String()))
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
+}

--- a/internal/socialmem/socialmem.go
+++ b/internal/socialmem/socialmem.go
@@ -88,33 +88,12 @@ func New(agent string, cfg Config) *Store {
 func (s *Store) Enabled() bool { return s != nil && s.cfg.Enabled }
 
 // Remember stores one memory. Best-effort: any failure is logged and swallowed.
+// It delegates to Upsert so the write path has a single implementation.
 func (s *Store) Remember(ctx context.Context, m Memory) {
 	if !s.Enabled() || strings.TrimSpace(m.Text) == "" {
 		return
 	}
-	collID, err := s.collection(ctx)
-	if err != nil {
-		log.Printf("[socialmem] remember skipped (collection): %v", err)
-		return
-	}
-	emb, err := s.embed(ctx, m.Text)
-	if err != nil {
-		log.Printf("[socialmem] remember skipped (embed): %v", err)
-		return
-	}
-	if m.Meta == nil {
-		m.Meta = map[string]any{}
-	}
-	if _, ok := m.Meta["agent"]; !ok {
-		m.Meta["agent"] = s.agent
-	}
-	body := map[string]any{
-		"ids":        []string{m.ID},
-		"embeddings": [][]float32{emb},
-		"documents":  []string{m.Text},
-		"metadatas":  []map[string]any{m.Meta},
-	}
-	if err := s.post(ctx, s.collPath(collID)+"/upsert", body, nil); err != nil {
+	if err := s.Upsert(ctx, m); err != nil {
 		log.Printf("[socialmem] remember failed: %v", err)
 	}
 }
@@ -278,6 +257,28 @@ func (s *Store) embed(ctx context.Context, text string) ([]float32, error) {
 		return nil, fmt.Errorf("empty embedding")
 	}
 	return out.Data[0].Embedding, nil
+}
+
+// get issues a GET and decodes the JSON response into out.
+func (s *Store) get(ctx context.Context, url string, out any) error {
+	reqCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("%s -> %d", url, resp.StatusCode)
+	}
+	if out != nil {
+		return json.NewDecoder(resp.Body).Decode(out)
+	}
+	return nil
 }
 
 // post issues a JSON POST and optionally decodes the response into out.

--- a/internal/socialmem/socialmem.go
+++ b/internal/socialmem/socialmem.go
@@ -3,8 +3,8 @@
 // Package socialmem gives the agent a durable, SEMANTIC social memory: the
 // things it has said and heard across the Reef feed and its DMs, embedded with
 // the colony's shared bge embedder (served by krillm) and stored in the agent's
-// OWN Chroma collection so it can later RECALL them by meaning — e.g. "what did
-// I say about the map renderer a few days ago" — and reference the past like a
+// OWN Chroma collection so it can later RECALL them by meaning - e.g. "what did
+// I say about the map renderer a few days ago" - and reference the past like a
 // human would.
 //
 // Design rules:
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -29,22 +30,24 @@ import (
 
 // Config tunes the social memory. Zero values fall back to colony defaults.
 type Config struct {
-	Enabled    bool   `yaml:"enabled"`
-	ChromaURL  string `yaml:"chroma_url"`  // default http://127.0.0.1:8001
-	EmbedURL   string `yaml:"embed_url"`   // default http://127.0.0.1:57455
-	EmbedModel string `yaml:"embed_model"` // default bge-base-en
-	Collection string `yaml:"collection"`  // default "<agent>_social"
-	RecallK    int    `yaml:"recall_k"`    // default 4
+	Enabled      bool   `yaml:"enabled"`
+	ChromaURL    string `yaml:"chroma_url"`    // default http://127.0.0.1:8001
+	EmbedURL     string `yaml:"embed_url"`     // default http://127.0.0.1:57455
+	EmbedModel   string `yaml:"embed_model"`   // default bge-base-en
+	Collection   string `yaml:"collection"`    // default "<agent>_social"
+	RecallK      int    `yaml:"recall_k"`      // default 4
+	RetentionCap int    `yaml:"retention_cap"` // max rows kept; oldest trimmed (default 2000)
 }
 
 // Store is the agent's social memory. A nil *Store is safe (all methods no-op),
 // so callers never need to nil-check before using it.
 type Store struct {
-	cfg    Config
-	agent  string
-	http   *http.Client
-	mu     sync.Mutex
-	collID string // resolved lazily and cached
+	cfg      Config
+	agent    string
+	http     *http.Client
+	mu       sync.Mutex
+	collID   string // resolved lazily and cached
+	remCount int64  // writes since start; drives periodic retention trim
 }
 
 // Memory is one thing worth remembering. Meta is free-form structured context
@@ -81,6 +84,9 @@ func New(agent string, cfg Config) *Store {
 	if cfg.RecallK == 0 {
 		cfg.RecallK = 4
 	}
+	if cfg.RetentionCap == 0 {
+		cfg.RetentionCap = 2000
+	}
 	return &Store{cfg: cfg, agent: agent, http: &http.Client{Timeout: 20 * time.Second}}
 }
 
@@ -95,6 +101,43 @@ func (s *Store) Remember(ctx context.Context, m Memory) {
 	}
 	if err := s.Upsert(ctx, m); err != nil {
 		log.Printf("[socialmem] remember failed: %v", err)
+	}
+}
+
+// secretPattern matches common secret shapes (key=value pairs for tokens/keys/
+// passwords, OpenAI-style sk- keys, and long hex blobs) so they are not stored
+// verbatim. Conservative on purpose to avoid mangling normal prose.
+var secretPattern = regexp.MustCompile(
+	`(?i)(api[_-]?key|secret|token|password|passwd|bearer)\s*[:=]\s*\S+` +
+		`|sk-[A-Za-z0-9_-]{16,}` +
+		`|\b[0-9a-fA-F]{32,}\b`)
+
+// redact masks anything that looks like a credential in free-form social text.
+// Feed/DM content is untrusted, so it is scrubbed before being embedded or
+// persisted.
+func redact(text string) string {
+	return secretPattern.ReplaceAllString(text, "[REDACTED]")
+}
+
+// trim deletes the oldest rows beyond the retention cap (best-effort, never
+// fatal). Ordering is by the `ts` metadata field; rows without a ts sort oldest.
+func (s *Store) trim(ctx context.Context) {
+	if !s.Enabled() || s.cfg.RetentionCap <= 0 {
+		return
+	}
+	recs, err := s.All(ctx, 0)
+	if err != nil || len(recs) <= s.cfg.RetentionCap {
+		return
+	}
+	sort.SliceStable(recs, func(i, j int) bool {
+		ti, _ := metaInt(recs[i].Meta, "ts")
+		tj, _ := metaInt(recs[j].Meta, "ts")
+		return ti < tj
+	})
+	for _, r := range recs[:len(recs)-s.cfg.RetentionCap] {
+		if err := s.Delete(ctx, r.ID); err != nil {
+			log.Printf("[socialmem] retention delete %s failed: %v", r.ID, err)
+		}
 	}
 }
 
@@ -158,11 +201,11 @@ func (s *Store) RecallBlock(ctx context.Context, query string) string {
 		return ""
 	}
 	var b strings.Builder
-	b.WriteString("\n\nYOUR RELEVANT MEMORY (things you said or heard before — reference them naturally if useful, don't repeat yourself):\n")
+	b.WriteString("\n\nYOUR RELEVANT MEMORY (things you said or heard before - reference them naturally if useful, don't repeat yourself):\n")
 	for _, h := range hits {
 		when := ""
 		if ts, ok := metaInt(h.Meta, "ts"); ok && ts > 0 {
-			when = relTime(ts) + " — "
+			when = relTime(ts) + " - "
 		}
 		ctxLabel := ""
 		if k, _ := h.Meta["kind"].(string); k != "" {

--- a/internal/socialmem/socialmem_live_test.go
+++ b/internal/socialmem/socialmem_live_test.go
@@ -1,0 +1,59 @@
+//go:build colony
+
+package socialmem
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+// TestLive exercises Remember+Recall against the real Chroma server and krillm
+// embedder. Gated on SOCIALMEM_LIVE=1 so it never runs in normal CI.
+func TestLive(t *testing.T) {
+	if os.Getenv("SOCIALMEM_LIVE") != "1" {
+		t.Skip("set SOCIALMEM_LIVE=1 to run the live Chroma/embedder test")
+	}
+	ctx := context.Background()
+	s := New("socialmem_test", Config{Enabled: true})
+
+	s.Remember(ctx, Memory{ID: "c1", Text: "On Sourav's post about the new capital map renderer, I commented that the per-kind GLBs look sharp.", Meta: map[string]any{"kind": "comment", "ts": int64(1782000000000)}})
+	s.Remember(ctx, Memory{ID: "c2", Text: "I posted in #labs: benchmark of gemma vs qwen on the routing task finished, qwen edged ahead.", Meta: map[string]any{"kind": "post", "ts": int64(1782100000000)}})
+	s.Remember(ctx, Memory{ID: "c3", Text: "In a DM, the owner asked me to keep nightly experiments under 20 minutes.", Meta: map[string]any{"kind": "dm_in", "ts": int64(1782200000000)}})
+
+	hits := s.Recall(ctx, "what did I say about the map rendering?", 3)
+	if len(hits) == 0 {
+		t.Fatal("expected recall hits, got none")
+	}
+	if !strings.Contains(strings.ToLower(hits[0].Text), "map") {
+		t.Fatalf("expected map-related memory first, got: %q", hits[0].Text)
+	}
+	t.Logf("top hit (dist=%.4f): %s", hits[0].Distance, hits[0].Text)
+
+	block := s.RecallBlock(ctx, "nightly experiment time limits")
+	if !strings.Contains(strings.ToLower(block), "20 minutes") {
+		t.Fatalf("expected DM memory in recall block, got: %q", block)
+	}
+	t.Logf("recall block:%s", block)
+
+	// Clean up the test collection.
+	collID, _ := s.collection(ctx)
+	_ = s.deleteCollection(ctx)
+	_ = collID
+}
+
+// deleteCollection removes the test collection so the live test leaves no trace.
+func (s *Store) deleteCollection(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.base()+"/collections/"+s.cfg.Collection, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	return nil
+}

--- a/internal/socialmem/store_ops.go
+++ b/internal/socialmem/store_ops.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync/atomic"
 )
 
 // Record is a stored row (id + document + metadata) returned by Get/All. It is
@@ -20,11 +21,17 @@ type Record struct {
 
 // Upsert writes one memory (id + text + metadata), embedding the text with the
 // shared bge embedder. Unlike Remember (best-effort, void), Upsert returns the
-// error so callers that need to know — e.g. a migration — can react.
+// error so callers that need to know - e.g. a migration - can react. This is the
+// single write chokepoint, so it also redacts secrets before anything is
+// embedded or persisted, and periodically trims the collection to the retention
+// cap.
 func (s *Store) Upsert(ctx context.Context, m Memory) error {
 	if !s.Enabled() {
 		return fmt.Errorf("social memory disabled")
 	}
+	// Untrusted feed/DM text passes through here, so scrub obvious secrets before
+	// they are embedded and stored verbatim.
+	m.Text = redact(m.Text)
 	if strings.TrimSpace(m.Text) == "" {
 		return fmt.Errorf("empty text")
 	}
@@ -48,7 +55,15 @@ func (s *Store) Upsert(ctx context.Context, m Memory) error {
 		"documents":  []string{m.Text},
 		"metadatas":  []map[string]any{m.Meta},
 	}
-	return s.post(ctx, s.collPath(collID)+"/upsert", body, nil)
+	if err := s.post(ctx, s.collPath(collID)+"/upsert", body, nil); err != nil {
+		return err
+	}
+	// Bound growth: periodically trim the oldest rows past the retention cap so a
+	// long-lived agent's collection does not grow without limit.
+	if atomic.AddInt64(&s.remCount, 1)%64 == 0 {
+		go s.trim(context.Background())
+	}
+	return nil
 }
 
 // Get returns the row with the given id, or (nil, nil) if it does not exist.

--- a/internal/socialmem/store_ops.go
+++ b/internal/socialmem/store_ops.go
@@ -1,0 +1,212 @@
+//go:build colony
+
+package socialmem
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// Record is a stored row (id + document + metadata) returned by Get/All. It is
+// the raw shape; higher layers (e.g. a core.Memory adapter) map it to their own
+// entry types.
+type Record struct {
+	ID   string
+	Text string
+	Meta map[string]any
+}
+
+// Upsert writes one memory (id + text + metadata), embedding the text with the
+// shared bge embedder. Unlike Remember (best-effort, void), Upsert returns the
+// error so callers that need to know — e.g. a migration — can react.
+func (s *Store) Upsert(ctx context.Context, m Memory) error {
+	if !s.Enabled() {
+		return fmt.Errorf("social memory disabled")
+	}
+	if strings.TrimSpace(m.Text) == "" {
+		return fmt.Errorf("empty text")
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return err
+	}
+	emb, err := s.embed(ctx, m.Text)
+	if err != nil {
+		return err
+	}
+	if m.Meta == nil {
+		m.Meta = map[string]any{}
+	}
+	if _, ok := m.Meta["agent"]; !ok {
+		m.Meta["agent"] = s.agent
+	}
+	body := map[string]any{
+		"ids":        []string{m.ID},
+		"embeddings": [][]float32{emb},
+		"documents":  []string{m.Text},
+		"metadatas":  []map[string]any{m.Meta},
+	}
+	return s.post(ctx, s.collPath(collID)+"/upsert", body, nil)
+}
+
+// Get returns the row with the given id, or (nil, nil) if it does not exist.
+func (s *Store) Get(ctx context.Context, id string) (*Record, error) {
+	if !s.Enabled() {
+		return nil, nil
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return nil, err
+	}
+	req := map[string]any{"ids": []string{id}, "include": []string{"documents", "metadatas"}}
+	var out struct {
+		IDs       []string         `json:"ids"`
+		Documents []string         `json:"documents"`
+		Metadatas []map[string]any `json:"metadatas"`
+	}
+	if err := s.post(ctx, s.collPath(collID)+"/get", req, &out); err != nil {
+		return nil, err
+	}
+	if len(out.IDs) == 0 {
+		return nil, nil
+	}
+	r := &Record{ID: out.IDs[0]}
+	if len(out.Documents) > 0 {
+		r.Text = out.Documents[0]
+	}
+	if len(out.Metadatas) > 0 {
+		r.Meta = out.Metadatas[0]
+	}
+	return r, nil
+}
+
+// All returns up to limit rows (limit<=0 means a large default). Used for List
+// and for bounded scans; the colony memory is small (~1k entries).
+func (s *Store) All(ctx context.Context, limit int) ([]Record, error) {
+	if !s.Enabled() {
+		return nil, nil
+	}
+	if limit <= 0 {
+		limit = 10000
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return nil, err
+	}
+	req := map[string]any{"limit": limit, "include": []string{"documents", "metadatas"}}
+	var out struct {
+		IDs       []string         `json:"ids"`
+		Documents []string         `json:"documents"`
+		Metadatas []map[string]any `json:"metadatas"`
+	}
+	if err := s.post(ctx, s.collPath(collID)+"/get", req, &out); err != nil {
+		return nil, err
+	}
+	recs := make([]Record, 0, len(out.IDs))
+	for i, id := range out.IDs {
+		r := Record{ID: id}
+		if i < len(out.Documents) {
+			r.Text = out.Documents[i]
+		}
+		if i < len(out.Metadatas) {
+			r.Meta = out.Metadatas[i]
+		}
+		recs = append(recs, r)
+	}
+	return recs, nil
+}
+
+// Count returns the number of rows in the collection (0 on any error).
+func (s *Store) Count(ctx context.Context) int {
+	if !s.Enabled() {
+		return 0
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return 0
+	}
+	var n int
+	if err := s.get(ctx, s.collPath(collID)+"/count", &n); err != nil {
+		return 0
+	}
+	return n
+}
+
+// Delete removes the row with the given id (best-effort).
+func (s *Store) Delete(ctx context.Context, id string) error {
+	if !s.Enabled() {
+		return nil
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return err
+	}
+	return s.post(ctx, s.collPath(collID)+"/delete", map[string]any{"ids": []string{id}}, nil)
+}
+
+// DropCollection deletes the whole collection by name (used by tests/cleanup).
+func (s *Store) DropCollection(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, s.base()+"/collections/"+s.cfg.Collection, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := s.http.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	s.mu.Lock()
+	s.collID = ""
+	s.mu.Unlock()
+	return nil
+}
+
+// RecallWhere is Recall with an optional metadata filter (Chroma `where`), used
+// for scope-filtered ranked search. A nil/empty where behaves like Recall.
+func (s *Store) RecallWhere(ctx context.Context, query string, k int, where map[string]any) []Hit {
+	if !s.Enabled() || strings.TrimSpace(query) == "" {
+		return nil
+	}
+	if k <= 0 {
+		k = s.cfg.RecallK
+	}
+	collID, err := s.collection(ctx)
+	if err != nil {
+		return nil
+	}
+	emb, err := s.embed(ctx, query)
+	if err != nil {
+		return nil
+	}
+	req := map[string]any{
+		"query_embeddings": [][]float32{emb},
+		"n_results":        k,
+		"include":          []string{"documents", "metadatas", "distances"},
+	}
+	if len(where) > 0 {
+		req["where"] = where
+	}
+	var out struct {
+		Documents [][]string         `json:"documents"`
+		Metadatas [][]map[string]any `json:"metadatas"`
+		Distances [][]float64        `json:"distances"`
+	}
+	if err := s.post(ctx, s.collPath(collID)+"/query", req, &out); err != nil || len(out.Documents) == 0 {
+		return nil
+	}
+	docs := out.Documents[0]
+	hits := make([]Hit, 0, len(docs))
+	for i, d := range docs {
+		h := Hit{Text: d}
+		if len(out.Metadatas) > 0 && i < len(out.Metadatas[0]) {
+			h.Meta = out.Metadatas[0][i]
+		}
+		if len(out.Distances) > 0 && i < len(out.Distances[0]) {
+			h.Distance = out.Distances[0][i]
+		}
+		hits = append(hits, h)
+	}
+	return hits
+}


### PR DESCRIPTION
## What
Adds Mini-Krill's semantic social memory and isolates colony-only features from the public release via build tags.

- Reef feed + Chroma social memory are now colony-only, gated behind `//go:build colony`. The public release stays lean: FileMemory, no feed, no Chroma dependency.
- Colony builds (`make install-colony`, i.e. `go install -tags colony ./cmd/minikrill`) add `internal/socialmem` and wire the feed watcher's recall-before-comment / remember-after-engage via the shared bge embedder served by krillm.
- `maybeStartFeed` is a no-op in public builds (`commands_nocolony.go`) and launches the watcher in colony builds (`commands_colony.go`).

This was raised after PR #51, so the branch carries a merge of main; the merge keeps #51's bounded appraisal timeout and failover alongside this PR's social recall/remember.

## What changed (review fixes folded in)
- The one-time FileMemory to Chroma migration writes its "migrated" marker only when every entry succeeds; on failure it leaves FileMemory intact so a later boot retries (no data loss on a first-boot outage).
- Added a `make install-colony` target so the colony agent is built with the feed + social memory compiled in; the public `make install` intentionally excludes them.
- Social-memory writes are redacted (token/key/password/bearer/sk-/long-hex) before embed or persist, and the collection is retention-capped.

## How it was tested
- Both configs compile, vet, and test clean: `go build/vet/test ./...` (public) and `... -tags colony ./...` (colony); `go test -race -tags colony ./internal/socialmem ./internal/feed ./internal/brain` clean.
- Isolation verified: public binary has 0 feed/socialmem symbols; colony binary has them (socialmem 34, feed 26).
- Gated live socialmem test passes against the live Chroma + embedder.
